### PR TITLE
Assets refreshing mechanism

### DIFF
--- a/modules/beam/src/main/scala/com.snowplowanalytics.snowplow.enrich.beam/AssetsManagement.scala
+++ b/modules/beam/src/main/scala/com.snowplowanalytics.snowplow.enrich.beam/AssetsManagement.scala
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2012-2020 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and
+ * limitations there under.
+ */
+package com.snowplowanalytics.snowplow.enrich.beam
+
+import java.io.File
+import java.net.URI
+import java.nio.file.NoSuchFileException
+import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.{Files, Paths}
+
+import cats.syntax.either._
+
+import org.joda.time.Duration
+
+import org.slf4j.LoggerFactory
+
+import org.apache.beam.sdk.extensions.gcp.options.GcsOptions
+import org.apache.beam.sdk.io.GenerateSequence
+import org.apache.beam.sdk.values.WindowingStrategy.AccumulationMode
+import org.apache.beam.sdk.transforms.windowing.{AfterPane, Repeatedly}
+import org.apache.beam.sdk.transforms.windowing.Window.ClosingBehavior
+
+import com.spotify.scio.ScioContext
+import com.spotify.scio.coders.Coder
+import com.spotify.scio.util.RemoteFileUtil
+import com.spotify.scio.values.{DistCache, SCollection, SideInput, WindowOptions}
+
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf
+import com.snowplowanalytics.snowplow.enrich.beam.utils.createSymLink
+
+/**
+ * Module responsible for assets (such as MaxMind and referer-parser DBs)
+ * management: downloading, distributing per workers, updating when necessary
+ */
+object AssetsManagement {
+
+  val SideInputName = "assets-refresh-tick"
+
+  /** List of linked files or error messages */
+  type DbList = List[Either[String, FileLink]]
+
+  /**
+   * A downloaded asset. `Path` not used because its not serializable
+   * @param uri an original GCS URI
+   * @param original real file path on a worker
+   * @param link link path to `original`. Its used because enrichments
+   *             refer to static/hardcoded filepath, whereas `original`
+   *             is dynamic
+   */
+  case class FileLink(
+    uri: String,
+    original: String,
+    link: String
+  )
+
+  private val logger = LoggerFactory.getLogger(this.getClass)
+
+  /**
+   * Create a transformation sole purpose of which is to periodially refresh
+   * worker assets. If no `refreshRate` given - it's an empty transformation
+   * @param sc Scio context
+   * @param refreshRate an interval with which assets should be updated
+   * @param enrichmentConfs enrichment configurations to provide links
+   * @tparam A type of data flowing through original stream
+   * @return no-op or refresh transformation
+   */
+  def mkTransformation[A: Coder](
+    sc: ScioContext,
+    refreshRate: Option[Duration],
+    enrichmentConfs: List[EnrichmentConf]
+  ): SCollection[A] => SCollection[A] =
+    refreshRate match {
+      case Some(rate) =>
+        val rfu = RemoteFileUtil.create(sc.optionsAs[GcsOptions])
+        val refreshInput = getSideInput(sc, rate).asSingletonSideInput(false)
+        val distCache = buildDistCache(sc, enrichmentConfs)
+        withAssetsUpdate[A](distCache, refreshInput, rfu)
+      case None =>
+        val distCache = buildDistCache(sc, enrichmentConfs)
+        // identity function analog for scio
+        (collection: SCollection[A]) =>
+          collection
+            .withName("assets-refresh-noop")
+            .map { a =>
+              val _ = distCache()
+              a
+            }
+    }
+
+  /** `SCollection` ticking with `true` for a minute, after specified period of time */
+  def getSideInput(sc: ScioContext, period: Duration): SCollection[Boolean] =
+    sc
+      .customInput(
+        SideInputName,
+        GenerateSequence
+          .from(0L)
+          .withRate(1L, Duration.standardMinutes(1))
+      )
+      .map(x => x % period.getStandardMinutes == 0)
+      .withName("assets-refresh-window")
+      .withGlobalWindow(
+        options = WindowOptions(
+          trigger = Repeatedly.forever(AfterPane.elementCountAtLeast(1)),
+          accumulationMode = AccumulationMode.DISCARDING_FIRED_PANES,
+          closingBehavior = ClosingBehavior.FIRE_IF_NON_EMPTY,
+          allowedLateness = Duration.standardSeconds(0)
+        )
+      )
+      .withName("assets-refresh-noupdate")
+
+  /** Transformation that only updates DBs and returns data as is */
+  def withAssetsUpdate[A: Coder](
+    cachedFiles: DistCache[DbList],
+    refreshInput: SideInput[Boolean],
+    rfu: RemoteFileUtil
+  )(
+    raw: SCollection[A]
+  ): SCollection[A] =
+    raw
+      .withGlobalWindow()
+      .withSideInputs(refreshInput)
+      .withName("assets-refresh") // aggregate somehow, if there's true in acc - return false
+      .map { (raw, side) =>
+        val update = side(refreshInput)
+        if (update) {
+          val existing = cachedFiles() // Get already downloaded
+          // Traverse all existing files and find out if at least one had to be deleted
+          val atLeastOne = existing.foldLeft(false)((acc, cur) => shouldUpdate(cur) || acc)
+          if (atLeastOne) {
+            logger.info(s"Deleting all assets: ${}")
+            existing.foreach(deleteFile(rfu))
+            logger.info("Re-downloading expired assets")
+            val _ = cachedFiles()
+          }
+        } else {
+          val _ = cachedFiles() // In case side-input's first value wasn't true somehow, should be no-op
+        }
+
+        raw
+      }
+      .toSCollection
+
+  /**
+   * Builds a Scio's [[DistCache]] which downloads the needed files and create the necessary
+   * symlinks.
+   * @param sc Scio context
+   * @param enrichmentConfs list of enrichment configurations
+   * @return a properly build [[DistCache]]
+   */
+  def buildDistCache(sc: ScioContext, enrichmentConfs: List[EnrichmentConf]): DistCache[DbList] = {
+    val filesToCache: List[(URI, String)] = enrichmentConfs
+      .flatMap(_.filesToCache)
+    val filesToDownload = filesToCache.map(_._1.toString)
+    val filesDestinations = filesToCache.map(_._2)
+
+    sc.distCache(filesToDownload)(linkFiles(filesToDownload, filesDestinations))
+  }
+
+  /**
+   * Check if link is older than 2 minutes and try to delete it and its original file
+   * Checking that it's old allows to not re-trigger downloading
+   * multiple times because refreshing side input will be true for one minute
+   * @param fileLink data structure containing all information about a file
+   *                 that potentially has to be deleted and re-downloaded
+   * @return true if thread managed to delete a link and RFU
+   *         false if there was any error or it wasn't necessary to delete it
+   */
+  private def shouldUpdate(fileLink: Either[String, FileLink]): Boolean =
+    fileLink match {
+      case Right(FileLink(_, originalPath, _)) =>
+        val path = Paths.get(originalPath)
+        try {
+          val lastModified = Files
+            .readAttributes(path, classOf[BasicFileAttributes])
+            .lastModifiedTime()
+            .toMillis
+          val now = System.currentTimeMillis()
+          val should = now - lastModified > 120000L
+          if (should) logger.info(s"File $originalPath is timestamped with $lastModified at $now")
+          should
+        } catch {
+          case _: NoSuchFileException =>
+            logger.warn(
+              s"File $path does not exist for lastModifiedTime, possibly another thread deleted it. Blocking the worker to avoid futher racing"
+            )
+            Thread.sleep(2000)
+            false
+        }
+      case Left(_) =>
+        // Threads ran into race condition and cannot overwrite each other's link - not a failure
+        false
+    }
+
+  private def deleteFile(rfu: RemoteFileUtil)(fileLink: Either[String, FileLink]): Unit =
+    fileLink match {
+      case Right(FileLink(originalUri, originalPath, linkPath)) =>
+        val deleted = deleteFilePhysically(originalPath) || deleteFilePhysically(linkPath)
+        if (deleted) {
+          rfu.delete(URI.create(originalUri))
+          logger.info(s"Deleted $fileLink")
+        }
+      case Left(_) =>
+        ()
+    }
+
+  private def deleteFilePhysically(path: String): Boolean =
+    Either.catchOnly[NoSuchFileException](Files.delete(Paths.get(path))) match {
+      case Left(_) =>
+        logger.warn(s"Tried to delete nonexisting $path")
+        false
+      case Right(_) =>
+        true
+    }
+
+  /**
+   * Link every `downloaded` file to a destination from `links`
+   * Both `downloaded` and `links` must have same amount of elements
+   */
+  private def linkFiles(uris: List[String], links: List[String])(downloaded: Seq[File]): DbList = {
+    val mapped = downloaded.toList
+      .zip(links)
+      .map { case (file, symLink) => createSymLink(file, symLink) }
+
+    uris.zip(mapped).zip(downloaded).map {
+      case ((uri, Right(p)), file) =>
+        logger.info(s"File $file cached at $p")
+        FileLink(uri, file.toString, p.toString).asRight
+      case ((uri, Left(e)), file) =>
+        logger.warn(s"File $file (downloaded from $uri) could not be cached: $e")
+        e.asLeft
+    }
+  }
+}

--- a/modules/beam/src/main/scala/com.snowplowanalytics.snowplow.enrich.beam/config.scala
+++ b/modules/beam/src/main/scala/com.snowplowanalytics.snowplow.enrich.beam/config.scala
@@ -24,13 +24,19 @@ import scala.io.Source
 import cats.Id
 import cats.data.ValidatedNel
 import cats.implicits._
+
+import org.joda.time.Duration
+
+import com.spotify.scio.Args
+
 import com.snowplowanalytics.iglu.client.Client
 import com.snowplowanalytics.iglu.core._
 import com.snowplowanalytics.iglu.core.circe.CirceIgluCodecs._
+
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.EnrichmentRegistry
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf
 import com.snowplowanalytics.snowplow.enrich.common.utils.JsonUtils
-import com.spotify.scio.Args
+
 import io.circe.Json
 import io.circe.parser.decode
 import io.circe.syntax._
@@ -52,12 +58,13 @@ object config {
     enrichments: Option[String],
     labels: Option[String],
     sentryDSN: Option[String],
-    metrics: Boolean
+    metrics: Boolean,
+    assetsRefreshDuration: Int
   )
   object EnrichConfig {
 
     /** Smart constructor taking SCIO's [[Args]] */
-    def apply(args: Args): Either[String, EnrichConfig] =
+    def from(args: Args): Either[String, EnrichConfig] =
       for {
         _ <- if (args.optional("help").isDefined) helpString(configurations).asLeft else "".asRight
         l <- configurations
@@ -79,7 +86,8 @@ object config {
         args.optional("enrichments"),
         args.optional("labels"),
         args.optional("sentry-dsn"),
-        args.boolean("metrics", true)
+        args.boolean("metrics", default = true),
+        args.int("assets-refresh-rate", default = 0)
       )
 
     private val configurations = List(
@@ -98,10 +106,11 @@ object config {
       Configuration.Optional("enrichments", "Path to the directory containing the enrichment files"),
       Configuration.Optional("labels", "Dataflow labels to be set ie. env=qa1;region=eu"),
       Configuration.Optional("sentry-dsn", "Sentry DSN"),
-      Configuration.Optional("metrics", "Enable ScioMetrics (default: true)")
+      Configuration.Optional("metrics", "Enable ScioMetrics (default: true)"),
+      Configuration.Optional("assets-refresh-rate", "How often (in minutes) enrich should try to update worker assets (e.g. MaxMind DB)")
     )
 
-    /** Generates an help string from a list of conifugration */
+    /** Generates an help string from a list of configuration */
     private def helpString(configs: List[Configuration]): String =
       "Possible configuration are:\n" +
         configs
@@ -135,7 +144,8 @@ object config {
     enrichmentConfs: List[EnrichmentConf],
     labels: Map[String, String],
     sentryDSN: Option[String],
-    metrics: Boolean
+    metrics: Boolean,
+    assetsRefreshRate: Option[Duration]
   )
 
   /**
@@ -150,11 +160,15 @@ object config {
       _ <- Client.parseDefault[Id](json).leftMap(_.message).value
     } yield json
 
-  /** Reads a resolver file at the specfied path. */
+  /** Reads a resolver file at the specified path. */
   private def readResolverFile(path: String): Either[String, String] = {
     val file = new File(path)
-    if (file.exists) Source.fromFile(file).mkString.asRight
-    else s"Iglu resolver configuration file `$path` does not exist".asLeft
+    if (file.exists) {
+      val source = Source.fromFile(file)
+      val config = source.mkString
+      source.close()
+      config.asRight
+    } else s"Iglu resolver configuration file `$path` does not exist".asLeft
   }
 
   /**
@@ -165,7 +179,7 @@ object config {
   def parseEnrichmentRegistry(enrichmentsPath: Option[String], client: Client[Id, Json]): Either[String, Json] =
     for {
       fileContents <- readEnrichmentFiles(enrichmentsPath)
-      jsons <- fileContents.map(JsonUtils.extractJson(_)).sequence[EitherS, Json]
+      jsons <- fileContents.map(JsonUtils.extractJson).sequence[EitherS, Json]
       schemaKey = SchemaKey(
                     "com.snowplowanalytics.snowplow",
                     "enrichments",

--- a/modules/beam/src/main/scala/com.snowplowanalytics.snowplow.enrich.beam/utils.scala
+++ b/modules/beam/src/main/scala/com.snowplowanalytics.snowplow.enrich.beam/utils.scala
@@ -25,14 +25,18 @@ import scala.util.Try
 
 import cats.Id
 import cats.effect.Clock
+
 import io.circe.Json
 import io.circe.syntax._
-import com.snowplowanalytics.snowplow.badrows._
-import com.snowplowanalytics.snowplow.enrich.common.outputs.EnrichedEvent
+
 import org.joda.time.{DateTime, DateTimeZone}
 import org.joda.time.format.DateTimeFormat
+
+import com.snowplowanalytics.snowplow.badrows._
+
+import com.snowplowanalytics.snowplow.enrich.common.outputs.EnrichedEvent
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf
-import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.PiiPseudonymizerConf
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf.PiiPseudonymizerConf
 
 object utils {
 
@@ -88,10 +92,8 @@ object utils {
   /** Determine if we have to emit pii transformation events. */
   def emitPii(confs: List[EnrichmentConf]): Boolean =
     confs
-      .collect { case c: PiiPseudonymizerConf => c }
-      .headOption
-      .map(_.emitIdentificationEvent)
-      .getOrElse(false)
+      .collectFirst { case c: PiiPseudonymizerConf => c }
+      .exists(_.emitIdentificationEvent)
 
   // We want to take one-tenth of the payload characters (not taking into account multi-bytes char)
   private val ReductionFactor = 10

--- a/modules/beam/src/test/scala/com.snowplowanalytics.snowplow.enrich.beam/SingletonSpec.scala
+++ b/modules/beam/src/test/scala/com.snowplowanalytics.snowplow.enrich.beam/SingletonSpec.scala
@@ -14,13 +14,15 @@
  */
 package com.snowplowanalytics.snowplow.enrich.beam
 
-import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry._
 import io.circe.literal._
-import org.scalatest._
-import matchers.should.Matchers._
 
-import singleton._
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry._
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf.AnonIpConf
+
+import org.scalatest.matchers.should.Matchers._
 import org.scalatest.freespec.AnyFreeSpec
+
+import com.snowplowanalytics.snowplow.enrich.beam.singleton._
 
 class SingletonSpec extends AnyFreeSpec {
   "the singleton object should" - {

--- a/modules/beam/src/test/scala/com.snowplowanalytics.snowplow.enrich.beam/SingletonSpec.scala
+++ b/modules/beam/src/test/scala/com.snowplowanalytics.snowplow.enrich.beam/SingletonSpec.scala
@@ -16,6 +16,8 @@ package com.snowplowanalytics.snowplow.enrich.beam
 
 import io.circe.literal._
 
+import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer}
+
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry._
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf.AnonIpConf
 
@@ -25,6 +27,9 @@ import org.scalatest.freespec.AnyFreeSpec
 import com.snowplowanalytics.snowplow.enrich.beam.singleton._
 
 class SingletonSpec extends AnyFreeSpec {
+
+  val placeholder = SchemaKey("com.acme", "placeholder", "jsonschema", SchemaVer.Full(1, 0, 0))
+
   "the singleton object should" - {
     "make a ClientSingleton.get function available" - {
       "which throws if the resolver can't be parsed" in {
@@ -44,7 +49,7 @@ class SingletonSpec extends AnyFreeSpec {
       "which builds and stores the registry" in {
         val reg =
           EnrichmentRegistrySingleton.get(
-            List(AnonIpConf(AnonIPv4Octets.Two, AnonIPv6Segments.Two))
+            List(AnonIpConf(placeholder, AnonIPv4Octets.Two, AnonIPv6Segments.Two))
           )
         reg.anonIp shouldBe defined
       }

--- a/modules/beam/src/test/scala/com.snowplowanalytics.snowplow.enrich.beam/SpecHelpers.scala
+++ b/modules/beam/src/test/scala/com.snowplowanalytics.snowplow.enrich.beam/SpecHelpers.scala
@@ -114,7 +114,7 @@ object SpecHelpers {
     contentType: Option[String] = None,
     headers: List[String] = Nil,
     ipAddress: String = "",
-    networkUserId: String = java.util.UUID.randomUUID().toString(),
+    networkUserId: String = java.util.UUID.randomUUID().toString,
     path: String = "",
     querystring: Option[String] = None,
     refererUri: Option[String] = None,

--- a/modules/beam/src/test/scala/com.snowplowanalytics.snowplow.enrich.beam/enrichments/ApiRequestEnrichmentSpec.scala
+++ b/modules/beam/src/test/scala/com.snowplowanalytics.snowplow.enrich.beam/enrichments/ApiRequestEnrichmentSpec.scala
@@ -12,15 +12,18 @@
  * See the Apache License Version 2.0 for the specific language governing permissions and
  * limitations there under.
  */
-package com.snowplowanalytics.snowplow.enrich.beam
-package enrichments
+package com.snowplowanalytics.snowplow.enrich.beam.enrichments
 
 import java.nio.file.Paths
 
 import cats.syntax.option._
+
+import io.circe.literal._
+
+import com.snowplowanalytics.snowplow.enrich.beam.{CI, Enrich, SpecHelpers}
+
 import com.spotify.scio.io.PubsubIO
 import com.spotify.scio.testing._
-import io.circe.literal._
 
 object ApiRequestEnrichmentSpec {
   val contexts =
@@ -51,8 +54,8 @@ class ApiRequestEnrichmentSpec extends PipelineSpec {
         "--raw=in",
         "--enriched=out",
         "--bad=bad",
-        "--resolver=" + Paths.get(getClass.getResource("/iglu_resolver.json").toURI()),
-        "--enrichments=" + Paths.get(getClass.getResource("/api_request").toURI())
+        "--resolver=" + Paths.get(getClass.getResource("/iglu_resolver.json").toURI),
+        "--enrichments=" + Paths.get(getClass.getResource("/api_request").toURI)
       )
       .input(PubsubIO.readCoder[Array[Byte]]("in"), raw)
       .distCache(DistCacheIO(""), List.empty[Either[String, String]])

--- a/modules/beam/src/test/scala/com.snowplowanalytics.snowplow.enrich.beam/enrichments/IpLookupsEnrichmentSpec.scala
+++ b/modules/beam/src/test/scala/com.snowplowanalytics.snowplow.enrich.beam/enrichments/IpLookupsEnrichmentSpec.scala
@@ -72,7 +72,9 @@ class IpLookupsEnrichmentSpec extends PipelineSpec {
       .distCache(DistCacheIO(url), List(Right(localFile)))
       .output(PubsubIO.readString("out")) { o =>
         o should satisfySingleValue { c: String =>
-          expected.forall(c.contains) // Add `println(c);` before `expected` to see the enrichment output
+          // Add `println(c);` before `expected` to see the enrichment output
+          // see https://github.com/snowplow/enrich/issues/327
+          expected.forall(c.contains)
         }; ()
       }
       .output(PubsubIO.readString("bad")) { b =>

--- a/modules/beam/src/test/scala/com.snowplowanalytics.snowplow.enrich.beam/enrichments/SqlQueryEnrichmentSpec.scala
+++ b/modules/beam/src/test/scala/com.snowplowanalytics.snowplow.enrich.beam/enrichments/SqlQueryEnrichmentSpec.scala
@@ -12,15 +12,18 @@
  * See the Apache License Version 2.0 for the specific language governing permissions and
  * limitations there under.
  */
-package com.snowplowanalytics.snowplow.enrich.beam
-package enrichments
+package com.snowplowanalytics.snowplow.enrich.beam.enrichments
 
 import java.nio.file.Paths
 
+import io.circe.literal._
+
 import cats.syntax.option._
+
 import com.spotify.scio.io.PubsubIO
 import com.spotify.scio.testing._
-import io.circe.literal._
+
+import com.snowplowanalytics.snowplow.enrich.beam.{CI, Enrich, SpecHelpers}
 
 object SqlQueryEnrichmentSpec {
   val contexts =
@@ -48,8 +51,8 @@ class SqlQueryEnrichmentSpec extends PipelineSpec {
         "--raw=in",
         "--enriched=out",
         "--bad=bad",
-        "--resolver=" + Paths.get(getClass.getResource("/iglu_resolver.json").toURI()),
-        "--enrichments=" + Paths.get(getClass.getResource("/sql_query").toURI())
+        "--resolver=" + Paths.get(getClass.getResource("/iglu_resolver.json").toURI),
+        "--enrichments=" + Paths.get(getClass.getResource("/sql_query").toURI)
       )
       .input(PubsubIO.readCoder[Array[Byte]]("in"), raw)
       .distCache(DistCacheIO(""), List.empty[Either[String, String]])

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/snowplow/RedirectAdapter.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/snowplow/RedirectAdapter.scala
@@ -10,10 +10,7 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package com.snowplowanalytics.snowplow.enrich.common
-package adapters
-package registry
-package snowplow
+package com.snowplowanalytics.snowplow.enrich.common.adapters.registry.snowplow
 
 import cats.Monad
 import cats.data.{NonEmptyList, ValidatedNel}
@@ -26,15 +23,18 @@ import cats.effect.Clock
 import io.circe._
 import io.circe.syntax._
 
-import com.snowplowanalytics.iglu.client.Client
-import com.snowplowanalytics.iglu.client.resolver.registries.RegistryLookup
 import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer, SelfDescribingData}
 import com.snowplowanalytics.iglu.core.circe.CirceIgluCodecs._
 
+import com.snowplowanalytics.iglu.client.Client
+import com.snowplowanalytics.iglu.client.resolver.registries.RegistryLookup
+
 import com.snowplowanalytics.snowplow.badrows.FailureDetails
 
-import loaders.CollectorPayload
-import utils.{HttpClient, ConversionUtils => CU, JsonUtils => JU}
+import com.snowplowanalytics.snowplow.enrich.common.adapters.RawEvent
+import com.snowplowanalytics.snowplow.enrich.common.adapters.registry.Adapter
+import com.snowplowanalytics.snowplow.enrich.common.loaders.CollectorPayload
+import com.snowplowanalytics.snowplow.enrich.common.utils.{HttpClient, JsonUtils => JU, ConversionUtils => CU}
 
 /**
  * The Redirect Adapter is essentially a pre-processor for

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/snowplow/Tp1Adapter.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/snowplow/Tp1Adapter.scala
@@ -10,22 +10,25 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package com.snowplowanalytics.snowplow.enrich.common
-package adapters
-package registry
-package snowplow
+package com.snowplowanalytics.snowplow.enrich.common.adapters.registry.snowplow
 
 import cats.Monad
 import cats.data.{NonEmptyList, ValidatedNel}
+
 import cats.effect.Clock
 import cats.syntax.validated._
-import com.snowplowanalytics.iglu.client.Client
-import com.snowplowanalytics.iglu.client.resolver.registries.RegistryLookup
-import com.snowplowanalytics.snowplow.badrows._
+
 import io.circe.Json
 
-import loaders.CollectorPayload
-import utils.HttpClient
+import com.snowplowanalytics.iglu.client.Client
+import com.snowplowanalytics.iglu.client.resolver.registries.RegistryLookup
+
+import com.snowplowanalytics.snowplow.badrows.FailureDetails
+
+import com.snowplowanalytics.snowplow.enrich.common.adapters.RawEvent
+import com.snowplowanalytics.snowplow.enrich.common.adapters.registry.Adapter
+import com.snowplowanalytics.snowplow.enrich.common.loaders.CollectorPayload
+import com.snowplowanalytics.snowplow.enrich.common.utils.HttpClient
 
 /** Version 1 of the Tracker Protocol is GET only. All data comes in on the querystring. */
 object Tp1Adapter extends Adapter {

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/snowplow/Tp2Adapter.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/snowplow/Tp2Adapter.scala
@@ -10,16 +10,16 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package com.snowplowanalytics.snowplow.enrich.common
-package adapters
-package registry
-package snowplow
+package com.snowplowanalytics.snowplow.enrich.common.adapters.registry.snowplow
 
 import cats.Monad
 import cats.data.{EitherT, NonEmptyList, Validated, ValidatedNel}
 import cats.data.Validated._
 import cats.implicits._
+
 import cats.effect.Clock
+
+import io.circe.Json
 
 import com.snowplowanalytics.iglu.client.Client
 import com.snowplowanalytics.iglu.client.resolver.registries.RegistryLookup
@@ -28,10 +28,11 @@ import com.snowplowanalytics.iglu.core.circe.instances._
 
 import com.snowplowanalytics.snowplow.badrows.FailureDetails
 
-import io.circe.Json
-
-import loaders.CollectorPayload
-import utils.{HttpClient, JsonUtils => JU}
+import com.snowplowanalytics.snowplow.enrich.common.RawEventParameters
+import com.snowplowanalytics.snowplow.enrich.common.adapters.RawEvent
+import com.snowplowanalytics.snowplow.enrich.common.adapters.registry.Adapter
+import com.snowplowanalytics.snowplow.enrich.common.loaders.CollectorPayload
+import com.snowplowanalytics.snowplow.enrich.common.utils.{HttpClient, JsonUtils => JU}
 
 /**
  * Version 2 of the Tracker Protocol supports GET and POST. Note that with POST, data can still be

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/EnrichmentRegistry.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/EnrichmentRegistry.scala
@@ -10,32 +10,35 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package com.snowplowanalytics.snowplow.enrich.common
-package enrichments
+package com.snowplowanalytics.snowplow.enrich.common.enrichments
 
 import cats.Monad
 import cats.data.{EitherT, NonEmptyList, ValidatedNel}
+
 import cats.effect.Clock
 import cats.implicits._
 
 import io.circe._
 import io.circe.syntax._
 
-import com.snowplowanalytics.iglu.client.Client
-import com.snowplowanalytics.iglu.client.resolver.registries.RegistryLookup
 import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey, SelfDescribingData}
 import com.snowplowanalytics.iglu.core.circe.instances._
+
+import com.snowplowanalytics.iglu.client.Client
+import com.snowplowanalytics.iglu.client.resolver.registries.RegistryLookup
 
 import com.snowplowanalytics.forex.CreateForex
 import com.snowplowanalytics.maxmind.iplookups.CreateIpLookups
 import com.snowplowanalytics.refererparser.CreateParser
 import com.snowplowanalytics.weather.providers.openweather.CreateOWM
 
-import registry._
-import registry.apirequest.ApiRequestEnrichment
-import registry.pii.PiiPseudonymizerEnrichment
-import registry.sqlquery.SqlQueryEnrichment
-import utils.CirceUtils
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf._
+
+import com.snowplowanalytics.snowplow.enrich.common.utils.CirceUtils
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry._
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.apirequest.ApiRequestEnrichment
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.pii.PiiPseudonymizerEnrichment
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.sqlquery.SqlQueryEnrichment
 
 /** Companion which holds a constructor for the EnrichmentRegistry. */
 object EnrichmentRegistry {

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/AnonIpEnrichment.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/AnonIpEnrichment.scala
@@ -54,7 +54,7 @@ object AnonIpEnrichment extends ParseableEnrichment {
                             .toEither
       ipv4Octets <- AnonIPv4Octets.fromInt(paramIPv4Octet)
       ipv6Segment <- AnonIPv6Segments.fromInt(paramIPv6Segment)
-    } yield AnonIpConf(ipv4Octets, ipv6Segment)).toValidatedNel
+    } yield AnonIpConf(schemaKey, ipv4Octets, ipv6Segment)).toValidatedNel
 }
 
 /** How many octets (ipv4) to anonymize */

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/AnonIpEnrichment.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/AnonIpEnrichment.scala
@@ -10,20 +10,22 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package com.snowplowanalytics.snowplow.enrich.common
-package enrichments.registry
-
-import cats.data.ValidatedNel
-import cats.data.Validated
-import cats.syntax.either._
-import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey}
-import io.circe._
-
-import utils.CirceUtils
+package com.snowplowanalytics.snowplow.enrich.common.enrichments.registry
 
 import java.net.{Inet4Address, Inet6Address}
-import com.google.common.net.{InetAddresses => GuavaInetAddress}
+
 import scala.util.Try
+
+import cats.data.{Validated, ValidatedNel}
+import cats.syntax.either._
+
+import io.circe.Json
+
+import com.google.common.net.{InetAddresses => GuavaInetAddress}
+import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey}
+
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf.AnonIpConf
+import com.snowplowanalytics.snowplow.enrich.common.utils.CirceUtils
 
 /** Companion object. Lets us create a AnonIpConf from a Json. */
 object AnonIpEnrichment extends ParseableEnrichment {
@@ -32,7 +34,7 @@ object AnonIpEnrichment extends ParseableEnrichment {
 
   /**
    * Creates an AnonIpEnrichment instance from a Json.
-   * @param c The anon_ip enrichment JSON
+   * @param config The anon_ip enrichment JSON
    * @param schemaKey provided for the enrichment, must be supported by this enrichment
    * @return an AnonIpEnrichment configuration
    */

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/CampaignAttributionEnrichment.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/CampaignAttributionEnrichment.scala
@@ -61,6 +61,7 @@ object CampaignAttributionEnrichment extends ParseableEnrichment {
             .extract[Map[String, String]](c, "parameters", "fields", "mktClickId")
             .fold(_ => Map(), s => s)
           CampaignAttributionConf(
+            schemaKey,
             medium,
             source,
             term,

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/CampaignAttributionEnrichment.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/CampaignAttributionEnrichment.scala
@@ -10,16 +10,19 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package com.snowplowanalytics.snowplow.enrich.common
-package enrichments.registry
+package com.snowplowanalytics.snowplow.enrich.common.enrichments.registry
 
 import cats.data.{NonEmptyList, ValidatedNel}
 import cats.implicits._
-import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey}
+
 import io.circe._
 
-import utils.MapTransformer.SourceMap
-import utils.CirceUtils
+import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey}
+
+import com.snowplowanalytics.snowplow.enrich.common.QueryStringParameters
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf.CampaignAttributionConf
+import com.snowplowanalytics.snowplow.enrich.common.utils.MapTransformer.SourceMap
+import com.snowplowanalytics.snowplow.enrich.common.utils.CirceUtils
 
 /** Companion object. Lets us create a CampaignAttributionEnrichment from a Json */
 object CampaignAttributionEnrichment extends ParseableEnrichment {
@@ -97,7 +100,7 @@ final case class MarketingCampaign(
  * @param termParameters List of marketing term parameters
  * @param contentParameters List of marketing content parameters
  * @param campaignParameters List of marketing campaign parameters
- * @param mktClick Map of click ID parameters to networks
+ * @param clickIdParameters Map of click ID parameters to networks
  */
 final case class CampaignAttributionEnrichment(
   mediumParameters: List[String],
@@ -116,7 +119,7 @@ final case class CampaignAttributionEnrichment(
    * @return Option boxing the value of the campaign parameter
    */
   private def getFirstParameter(parameterList: List[String], sourceMap: SourceMap): Option[String] =
-    parameterList.find(sourceMap.contains(_)).map(sourceMap(_))
+    parameterList.find(sourceMap.contains).map(sourceMap(_))
 
   /**
    * Extract the marketing fields from a URL.

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/CookieExtractorEnrichment.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/CookieExtractorEnrichment.scala
@@ -10,20 +10,19 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package com.snowplowanalytics.snowplow.enrich.common
-package enrichments.registry
+package com.snowplowanalytics.snowplow.enrich.common.enrichments.registry
 
 import cats.data.ValidatedNel
 import cats.syntax.either._
-
-import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey, SchemaVer, SelfDescribingData}
 
 import io.circe._
 import io.circe.syntax._
 
 import org.apache.http.message.BasicHeaderValueParser
+import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey, SchemaVer, SelfDescribingData}
 
-import utils.CirceUtils
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf.CookieExtractorConf
+import com.snowplowanalytics.snowplow.enrich.common.utils.CirceUtils
 
 object CookieExtractorEnrichment extends ParseableEnrichment {
   override val supportedSchema =

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/CookieExtractorEnrichment.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/CookieExtractorEnrichment.scala
@@ -43,7 +43,7 @@ object CookieExtractorEnrichment extends ParseableEnrichment {
     (for {
       _ <- isParseable(config, schemaKey)
       cookieNames <- CirceUtils.extract[List[String]](config, "parameters", "cookies").toEither
-    } yield CookieExtractorConf(cookieNames)).toValidatedNel
+    } yield CookieExtractorConf(schemaKey, cookieNames)).toValidatedNel
 }
 
 /**

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/CurrencyConversionEnrichment.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/CurrencyConversionEnrichment.scala
@@ -10,23 +10,28 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package com.snowplowanalytics.snowplow.enrich.common
-package enrichments.registry
+package com.snowplowanalytics.snowplow.enrich.common.enrichments.registry
 
 import java.time.ZonedDateTime
 
 import cats.Monad
 import cats.data.{EitherT, NonEmptyList, ValidatedNel}
 import cats.implicits._
+
+import io.circe._
+
 import com.snowplowanalytics.forex.{CreateForex, Forex}
 import com.snowplowanalytics.forex.model._
-import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey}
-import com.snowplowanalytics.snowplow.badrows._
-import io.circe._
+
 import org.joda.money.CurrencyUnit
 import org.joda.time.DateTime
 
-import utils.CirceUtils
+import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey}
+
+import com.snowplowanalytics.snowplow.badrows.FailureDetails
+
+import com.snowplowanalytics.snowplow.enrich.common.utils.CirceUtils
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf.CurrencyConversionConf
 
 /** Companion object. Lets us create an CurrencyConversionEnrichment instance from a Json. */
 object CurrencyConversionEnrichment extends ParseableEnrichment {
@@ -101,10 +106,10 @@ final case class CurrencyConversionEnrichment[F[_]: Monad](
 
   /**
    * Attempt to convert if the initial currency and value are both defined
-   * @param inputCurrency Option boxing the initial currency if it is present
+   * @param initialCurrency Option boxing the initial currency if it is present
    * @param value Option boxing the amount to convert
    * @return None.success if the inputs were not both defined,
-   * otherwise Validation[Option[_]] boxing the result of the conversion
+   * otherwise `Validation[Option[_]]` boxing the result of the conversion
    */
   private def performConversion(
     initialCurrency: Option[Either[FailureDetails.EnrichmentFailure, CurrencyUnit]],

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/EnrichmentConf.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/EnrichmentConf.scala
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2012-2020 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.enrich.common.enrichments.registry
+
+import java.net.URI
+
+import cats.{Functor, Monad}
+import cats.data.EitherT
+
+import org.joda.money.CurrencyUnit
+
+import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer}
+
+import com.snowplowanalytics.forex.CreateForex
+import com.snowplowanalytics.forex.model.AccountType
+import com.snowplowanalytics.maxmind.iplookups.CreateIpLookups
+import com.snowplowanalytics.refererparser.CreateParser
+import com.snowplowanalytics.weather.providers.openweather.CreateOWM
+
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.apirequest.{
+  ApiRequestEnrichment,
+  CreateApiRequestEnrichment,
+  HttpApi
+}
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.sqlquery.{CreateSqlQueryEnrichment, Rdbms, SqlQueryEnrichment}
+
+sealed trait EnrichmentConf {
+  def schemaKey: SchemaKey =
+    SchemaKey(
+      "com.acme",
+      "placeholder",
+      "jsonschema",
+      SchemaVer.Full(1, 0, 0)
+    )
+
+  /**
+   * List of files, such as local DBs that need to be downloaded and distributed across workers
+   * First element of pair is URI to download file from, second is a local path to store it in
+   */
+  def filesToCache: List[(URI, String)] = Nil
+}
+
+object EnrichmentConf {
+
+  final case class ApiRequestConf(
+    override val schemaKey: SchemaKey,
+    inputs: List[apirequest.Input],
+    api: HttpApi,
+    outputs: List[apirequest.Output],
+    cache: apirequest.Cache
+  ) extends EnrichmentConf {
+    def enrichment[F[_]: CreateApiRequestEnrichment]: F[ApiRequestEnrichment[F]] =
+      ApiRequestEnrichment[F](this)
+  }
+
+  final case class PiiPseudonymizerConf(
+    fieldList: List[pii.PiiField],
+    emitIdentificationEvent: Boolean,
+    strategy: pii.PiiStrategy
+  ) extends EnrichmentConf {
+    def enrichment: pii.PiiPseudonymizerEnrichment =
+      pii.PiiPseudonymizerEnrichment(fieldList, emitIdentificationEvent, strategy)
+  }
+
+  final case class SqlQueryConf(
+    override val schemaKey: SchemaKey,
+    inputs: List[sqlquery.Input],
+    db: Rdbms,
+    query: SqlQueryEnrichment.Query,
+    output: sqlquery.Output,
+    cache: SqlQueryEnrichment.Cache
+  ) extends EnrichmentConf {
+    def enrichment[F[_]: Monad: CreateSqlQueryEnrichment]: F[SqlQueryEnrichment[F]] =
+      SqlQueryEnrichment[F](this)
+  }
+
+  final case class AnonIpConf(octets: AnonIPv4Octets.AnonIPv4Octets, segments: AnonIPv6Segments.AnonIPv6Segments) extends EnrichmentConf {
+    override val filesToCache: List[(URI, String)] = Nil
+    def enrichment: AnonIpEnrichment = AnonIpEnrichment(octets, segments)
+  }
+
+  final case class CampaignAttributionConf(
+    mediumParameters: List[String],
+    sourceParameters: List[String],
+    termParameters: List[String],
+    contentParameters: List[String],
+    campaignParameters: List[String],
+    clickIdParameters: List[(String, String)]
+  ) extends EnrichmentConf {
+    def enrichment: CampaignAttributionEnrichment =
+      CampaignAttributionEnrichment(
+        mediumParameters,
+        sourceParameters,
+        termParameters,
+        contentParameters,
+        campaignParameters,
+        clickIdParameters
+      )
+  }
+
+  final case class CookieExtractorConf(cookieNames: List[String]) extends EnrichmentConf {
+    def enrichment: CookieExtractorEnrichment = CookieExtractorEnrichment(cookieNames)
+  }
+
+  final case class CurrencyConversionConf(
+    override val schemaKey: SchemaKey,
+    accountType: AccountType,
+    apiKey: String,
+    baseCurrency: CurrencyUnit
+  ) extends EnrichmentConf {
+    def enrichment[F[_]: Monad: CreateForex]: F[CurrencyConversionEnrichment[F]] =
+      CurrencyConversionEnrichment[F](this)
+  }
+
+  final case class EventFingerprintConf(algorithm: String => String, excludedParameters: List[String]) extends EnrichmentConf {
+    def enrichment: EventFingerprintEnrichment =
+      EventFingerprintEnrichment(algorithm, excludedParameters)
+  }
+
+  final case class HttpHeaderExtractorConf(headersPattern: String) extends EnrichmentConf {
+    def enrichment: HttpHeaderExtractorEnrichment = HttpHeaderExtractorEnrichment(headersPattern)
+  }
+
+  final case class IabConf(
+    override val schemaKey: SchemaKey,
+    ipFile: (URI, String),
+    excludeUaFile: (URI, String),
+    includeUaFile: (URI, String)
+  ) extends EnrichmentConf {
+    override val filesToCache: List[(URI, String)] = List(ipFile, excludeUaFile, includeUaFile)
+    def enrichment[F[_]: Monad: CreateIabClient]: F[IabEnrichment] =
+      IabEnrichment[F](this)
+  }
+
+  final case class IpLookupsConf(
+    geoFile: Option[(URI, String)],
+    ispFile: Option[(URI, String)],
+    domainFile: Option[(URI, String)],
+    connectionTypeFile: Option[(URI, String)]
+  ) extends EnrichmentConf {
+    override val filesToCache: List[(URI, String)] =
+      List(geoFile, ispFile, domainFile, connectionTypeFile).flatten
+    def enrichment[F[_]: Functor: CreateIpLookups]: F[IpLookupsEnrichment[F]] =
+      IpLookupsEnrichment[F](this)
+  }
+
+  final case class JavascriptScriptConf(override val schemaKey: SchemaKey, rawFunction: String) extends EnrichmentConf {
+    def enrichment: JavascriptScriptEnrichment = JavascriptScriptEnrichment(schemaKey, rawFunction)
+  }
+
+  final case class RefererParserConf(refererDatabase: (URI, String), internalDomains: List[String]) extends EnrichmentConf {
+    override val filesToCache: List[(URI, String)] = List(refererDatabase)
+    def enrichment[F[_]: Monad: CreateParser]: EitherT[F, String, RefererParserEnrichment] =
+      RefererParserEnrichment[F](this)
+  }
+
+  final case class UaParserConf(override val schemaKey: SchemaKey, uaDatabase: Option[(URI, String)]) extends EnrichmentConf {
+    override val filesToCache: List[(URI, String)] = List(uaDatabase).flatten
+    def enrichment[F[_]: Monad: CreateUaParser]: EitherT[F, String, UaParserEnrichment] =
+      UaParserEnrichment[F](this)
+  }
+
+  final case class UserAgentUtilsConf(override val schemaKey: SchemaKey) extends EnrichmentConf {
+    def enrichment: UserAgentUtilsEnrichment = UserAgentUtilsEnrichment(schemaKey)
+  }
+
+  final case class WeatherConf(
+    override val schemaKey: SchemaKey,
+    apiHost: String,
+    apiKey: String,
+    timeout: Int,
+    cacheSize: Int,
+    geoPrecision: Int
+  ) extends EnrichmentConf {
+    def enrichment[F[_]: Monad: CreateOWM]: EitherT[F, String, WeatherEnrichment[F]] =
+      WeatherEnrichment[F](this)
+  }
+
+  final case class YauaaConf(cacheSize: Option[Int]) extends EnrichmentConf {
+    def enrichment: YauaaEnrichment = YauaaEnrichment(cacheSize)
+  }
+}

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/EventFingerprintEnrichment.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/EventFingerprintEnrichment.scala
@@ -10,16 +10,19 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package com.snowplowanalytics.snowplow.enrich.common
-package enrichments.registry
+package com.snowplowanalytics.snowplow.enrich.common.enrichments.registry
 
 import cats.data.{NonEmptyList, ValidatedNel}
 import cats.implicits._
-import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey}
+
 import io.circe._
+
 import org.apache.commons.codec.digest.DigestUtils
 
-import utils.CirceUtils
+import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey}
+
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf.EventFingerprintConf
+import com.snowplowanalytics.snowplow.enrich.common.utils.CirceUtils
 
 /** Lets us create an EventFingerprintEnrichment from a Json. */
 object EventFingerprintEnrichment extends ParseableEnrichment {

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/EventFingerprintEnrichment.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/EventFingerprintEnrichment.scala
@@ -57,7 +57,7 @@ object EventFingerprintEnrichment extends ParseableEnrichment {
                        ).mapN((_, _)).toEither
       algorithm <- getAlgorithm(paramsAndAlgo._2)
                      .leftMap(e => NonEmptyList.one(e))
-    } yield EventFingerprintConf(algorithm, paramsAndAlgo._1)).toValidated
+    } yield EventFingerprintConf(schemaKey, algorithm, paramsAndAlgo._1)).toValidated
 
   /**
    * Look up the fingerprinting algorithm by name

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/HttpHeaderExtractorEnrichment.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/HttpHeaderExtractorEnrichment.scala
@@ -48,7 +48,7 @@ object HttpHeaderExtractorEnrichment extends ParseableEnrichment {
     (for {
       _ <- isParseable(config, schemaKey)
       headersPattern <- CirceUtils.extract[String](config, "parameters", "headersPattern").toEither
-    } yield HttpHeaderExtractorConf(headersPattern)).toValidatedNel
+    } yield HttpHeaderExtractorConf(schemaKey, headersPattern)).toValidatedNel
 }
 
 /**

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/HttpHeaderExtractorEnrichment.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/HttpHeaderExtractorEnrichment.scala
@@ -10,18 +10,18 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package com.snowplowanalytics.snowplow.enrich.common
-package enrichments.registry
+package com.snowplowanalytics.snowplow.enrich.common.enrichments.registry
 
 import cats.data.ValidatedNel
 import cats.syntax.either._
 
-import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey, SchemaVer, SelfDescribingData}
-
 import io.circe._
 import io.circe.syntax._
 
-import utils.CirceUtils
+import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey, SchemaVer, SelfDescribingData}
+
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf.HttpHeaderExtractorConf
+import com.snowplowanalytics.snowplow.enrich.common.utils.CirceUtils
 
 object HttpHeaderExtractorEnrichment extends ParseableEnrichment {
   override val supportedSchema =

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/IabEnrichment.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/IabEnrichment.scala
@@ -10,31 +10,31 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package com.snowplowanalytics.snowplow.enrich.common
-package enrichments.registry
+package com.snowplowanalytics.snowplow.enrich.common.enrichments.registry
 
 import java.io.File
 import java.net.URI
-
-import inet.ipaddr.HostName
 
 import cats.{Id, Monad}
 import cats.data.{NonEmptyList, ValidatedNel}
 import cats.effect.Sync
 import cats.implicits._
 
-import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey, SchemaVer, SelfDescribingData}
+import org.joda.time.DateTime
 
-import com.snowplowanalytics.iab.spidersandrobotsclient.IabClient
-import com.snowplowanalytics.snowplow.badrows.FailureDetails
+import inet.ipaddr.HostName
 
 import io.circe._
 import io.circe.generic.auto._
 import io.circe.syntax._
 
-import org.joda.time.DateTime
+import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey, SchemaVer, SelfDescribingData}
 
-import utils.CirceUtils
+import com.snowplowanalytics.iab.spidersandrobotsclient.IabClient
+import com.snowplowanalytics.snowplow.badrows.FailureDetails
+
+import com.snowplowanalytics.snowplow.enrich.common.utils.CirceUtils
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf.IabConf
 
 /** Companion object. Lets us create an IabEnrichment instance from a Json. */
 object IabEnrichment extends ParseableEnrichment {
@@ -111,10 +111,8 @@ object IabEnrichment extends ParseableEnrichment {
 
 /**
  * Contains enrichments based on IAB Spiders&Robots lookup.
- * @param ipFile (Full URI to the IAB excluded IP list, database name)
- * @param excludeUaFile (Full URI to the IAB excluded user agent list, database name)
- * @param includeUaFile (Full URI to the IAB included user agent list, database name)
- * @param localMode Whether to use the local database file. Enabled for tests.
+ * @param schemaKey enrichment's static Iglu Schema Key
+ * @param iabClient worker object
  */
 final case class IabEnrichment(schemaKey: SchemaKey, iabClient: IabClient) extends Enrichment {
   val outputSchema =

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/IabEnrichment.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/IabEnrichment.scala
@@ -18,7 +18,7 @@ import java.net.URI
 
 import inet.ipaddr.HostName
 
-import cats.{Eval, Id, Monad}
+import cats.{Id, Monad}
 import cats.data.{NonEmptyList, ValidatedNel}
 import cats.effect.Sync
 import cats.implicits._
@@ -227,18 +227,6 @@ object CreateIabClient {
         includeUaFile: String
       ): F[IabClient] =
         Sync[F].delay {
-          new IabClient(new File(ipFile), new File(excludeUaFile), new File(includeUaFile))
-        }
-    }
-
-  implicit def evalCreateIabClient: CreateIabClient[Eval] =
-    new CreateIabClient[Eval] {
-      def create(
-        ipFile: String,
-        excludeUaFile: String,
-        includeUaFile: String
-      ): Eval[IabClient] =
-        Eval.later {
           new IabClient(new File(ipFile), new File(excludeUaFile), new File(includeUaFile))
         }
     }

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/IpLookupsEnrichment.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/IpLookupsEnrichment.scala
@@ -10,26 +10,25 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package com.snowplowanalytics.snowplow.enrich.common
-package enrichments
-package registry
+package com.snowplowanalytics.snowplow.enrich.common.enrichments.registry
 
 import java.net.URI
-
-import inet.ipaddr.HostName
 
 import cats.Functor
 import cats.data.{NonEmptyList, ValidatedNel}
 import cats.implicits._
 
-import com.snowplowanalytics.maxmind.iplookups._
-import com.snowplowanalytics.maxmind.iplookups.model._
+import io.circe._
+
+import inet.ipaddr.HostName
 
 import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey}
 
-import io.circe._
+import com.snowplowanalytics.maxmind.iplookups._
+import com.snowplowanalytics.maxmind.iplookups.model._
 
-import utils.CirceUtils
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf.IpLookupsConf
+import com.snowplowanalytics.snowplow.enrich.common.utils.CirceUtils
 
 /** Companion object. Lets us create an IpLookupsEnrichment instance from a Json. */
 object IpLookupsEnrichment extends ParseableEnrichment {

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/IpLookupsEnrichment.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/IpLookupsEnrichment.scala
@@ -57,6 +57,7 @@ object IpLookupsEnrichment extends ParseableEnrichment {
           getArgumentFromName(c, "connectionType").sequence
         ).mapN { (geo, isp, domain, connection) =>
           IpLookupsConf(
+            schemaKey,
             file(geo, localMode),
             file(isp, localMode),
             file(domain, localMode),
@@ -107,6 +108,7 @@ object IpLookupsEnrichment extends ParseableEnrichment {
         lruCacheSize = 20000
       )
       .map(i => IpLookupsEnrichment(i))
+
 }
 
 /**

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/JavascriptScriptEnrichment.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/JavascriptScriptEnrichment.scala
@@ -10,24 +10,24 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package com.snowplowanalytics.snowplow.enrich.common
-package enrichments.registry
+package com.snowplowanalytics.snowplow.enrich.common.enrichments.registry
 
 import cats.data.{NonEmptyList, ValidatedNel}
 import cats.implicits._
+
+import io.circe._
+import io.circe.parser._
+
+import javax.script._
 
 import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey, SelfDescribingData}
 import com.snowplowanalytics.iglu.core.circe.implicits._
 
 import com.snowplowanalytics.snowplow.badrows.FailureDetails
 
-import javax.script._
-
-import io.circe._
-import io.circe.parser._
-
-import outputs.EnrichedEvent
-import utils.{CirceUtils, ConversionUtils}
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf.JavascriptScriptConf
+import com.snowplowanalytics.snowplow.enrich.common.outputs.EnrichedEvent
+import com.snowplowanalytics.snowplow.enrich.common.utils.{CirceUtils, ConversionUtils}
 
 object JavascriptScriptEnrichment extends ParseableEnrichment {
   override val supportedSchema =

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/RefererParserEnrichment.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/RefererParserEnrichment.scala
@@ -10,20 +10,22 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package com.snowplowanalytics.snowplow.enrich.common
-package enrichments.registry
+package com.snowplowanalytics.snowplow.enrich.common.enrichments.registry
 
 import java.net.URI
 
 import cats.Monad
 import cats.data.{EitherT, NonEmptyList, ValidatedNel}
 import cats.implicits._
-import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey}
-import com.snowplowanalytics.refererparser._
+
 import io.circe.Json
 
-import utils.{ConversionUtils => CU}
-import utils.CirceUtils
+import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey}
+
+import com.snowplowanalytics.refererparser._
+
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf.RefererParserConf
+import com.snowplowanalytics.snowplow.enrich.common.utils.{ConversionUtils => CU, CirceUtils}
 
 /** Companion object. Lets us create a RefererParserEnrichment from a Json */
 object RefererParserEnrichment extends ParseableEnrichment {

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/RefererParserEnrichment.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/RefererParserEnrichment.scala
@@ -56,7 +56,7 @@ object RefererParserEnrichment extends ParseableEnrichment {
                 (uri, db, domains)
               }.toEither
       source <- getDatabaseUri(conf._1, conf._2).leftMap(NonEmptyList.one)
-    } yield RefererParserConf(file(source, conf._2, localFile, localMode), conf._3)).toValidated
+    } yield RefererParserConf(schemaKey, file(source, conf._2, localFile, localMode), conf._3)).toValidated
 
   private def file(
     uri: URI,

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/UaParserEnrichment.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/UaParserEnrichment.scala
@@ -15,7 +15,7 @@ package enrichments.registry
 import java.io.{FileInputStream, InputStream}
 import java.net.URI
 
-import cats.{Eval, Id, Monad}
+import cats.{Id, Monad}
 import cats.data.{EitherT, NonEmptyList, ValidatedNel}
 import cats.effect.Sync
 import cats.implicits._
@@ -166,12 +166,6 @@ object CreateUaParser {
     new CreateUaParser[F] {
       def create(uaFile: Option[String]): F[Either[String, Parser]] =
         Sync[F].delay(parser(uaFile))
-    }
-
-  implicit def evalCreateUaParser: CreateUaParser[Eval] =
-    new CreateUaParser[Eval] {
-      def create(uaFile: Option[String]): Eval[Either[String, Parser]] =
-        Eval.later(parser(uaFile))
     }
 
   implicit def idCreateUaParser: CreateUaParser[Id] =

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/UaParserEnrichment.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/UaParserEnrichment.scala
@@ -9,28 +9,29 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package com.snowplowanalytics.snowplow.enrich.common
-package enrichments.registry
+package com.snowplowanalytics.snowplow.enrich.common.enrichments.registry
 
 import java.io.{FileInputStream, InputStream}
 import java.net.URI
 
 import cats.{Id, Monad}
 import cats.data.{EitherT, NonEmptyList, ValidatedNel}
+
 import cats.effect.Sync
 import cats.implicits._
 
-import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey, SchemaVer, SelfDescribingData}
-
-import com.snowplowanalytics.snowplow.badrows.FailureDetails
-
-import io.circe._
+import io.circe.Json
 import io.circe.syntax._
 
 import ua_parser.Parser
 import ua_parser.Client
 
-import utils.CirceUtils
+import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey, SchemaVer, SelfDescribingData}
+
+import com.snowplowanalytics.snowplow.badrows.FailureDetails
+
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf.UaParserConf
+import com.snowplowanalytics.snowplow.enrich.common.utils.CirceUtils
 
 /** Companion object. Lets us create a UaParserEnrichment from a Json. */
 object UaParserEnrichment extends ParseableEnrichment {
@@ -105,7 +106,7 @@ final case class UaParserEnrichment(schemaKey: SchemaKey, parser: Parser) extend
   /**
    * Extracts the client attributes from a useragent string, using UserAgentEnrichment.
    * @param useragent to extract from. Should be encoded, i.e. not previously decoded.
-   * @return the json or the message of the exception, boxed in a Scalaz Validation
+   * @return the json or the message of the bad row details
    */
   def extractUserAgent(useragent: String): Either[FailureDetails.EnrichmentFailure, SelfDescribingData[Json]] =
     Either

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/UserAgentUtilsEnrichment.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/UserAgentUtilsEnrichment.scala
@@ -9,18 +9,24 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package com.snowplowanalytics.snowplow.enrich.common
-package enrichments.registry
+package com.snowplowanalytics.snowplow.enrich.common.enrichments.registry
 
 import scala.util.control.NonFatal
 
 import cats.data.ValidatedNel
 import cats.syntax.either._
 import cats.syntax.option._
-import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey}
-import com.snowplowanalytics.snowplow.badrows._
-import eu.bitwalker.useragentutils._
+
 import io.circe._
+
+import eu.bitwalker.useragentutils._
+
+import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey}
+
+import com.snowplowanalytics.snowplow.badrows.FailureDetails
+
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf.UserAgentUtilsConf
+
 import org.slf4j.LoggerFactory
 
 object UserAgentUtilsEnrichmentConfig extends ParseableEnrichment {

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/WeatherEnrichment.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/WeatherEnrichment.scala
@@ -10,8 +10,7 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package com.snowplowanalytics.snowplow.enrich.common
-package enrichments.registry
+package com.snowplowanalytics.snowplow.enrich.common.enrichments.registry
 
 import java.lang.{Float => JFloat}
 import java.time.{Instant, ZoneOffset, ZonedDateTime}
@@ -23,19 +22,21 @@ import cats.Monad
 import cats.data.{EitherT, NonEmptyList, ValidatedNel}
 import cats.implicits._
 
-import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey, SchemaVer, SelfDescribingData}
-import com.snowplowanalytics.snowplow.badrows.FailureDetails
-
-import com.snowplowanalytics.weather.providers.openweather._
-import com.snowplowanalytics.weather.providers.openweather.responses._
+import org.joda.time.{DateTime, DateTimeZone}
 
 import io.circe._
 import io.circe.generic.auto._
 import io.circe.syntax._
 
-import org.joda.time.{DateTime, DateTimeZone}
+import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey, SchemaVer, SelfDescribingData}
 
-import utils.CirceUtils
+import com.snowplowanalytics.snowplow.badrows.FailureDetails
+
+import com.snowplowanalytics.weather.providers.openweather._
+import com.snowplowanalytics.weather.providers.openweather.responses._
+
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf.WeatherConf
+import com.snowplowanalytics.snowplow.enrich.common.utils.CirceUtils
 
 /** Companion object. Lets us create an WeatherEnrichment instance from a Json */
 object WeatherEnrichment extends ParseableEnrichment {

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/YauaaEnrichment.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/YauaaEnrichment.scala
@@ -10,8 +10,7 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package com.snowplowanalytics.snowplow.enrich.common
-package enrichments.registry
+package com.snowplowanalytics.snowplow.enrich.common.enrichments.registry
 
 import scala.collection.JavaConverters._
 
@@ -21,11 +20,12 @@ import cats.syntax.either._
 import io.circe.Json
 import io.circe.syntax._
 
-import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey, SchemaVer, SelfDescribingData}
-
 import nl.basjes.parse.useragent.{UserAgent, UserAgentAnalyzer}
 
-import utils.CirceUtils
+import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey, SchemaVer, SelfDescribingData}
+
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf.YauaaConf
+import com.snowplowanalytics.snowplow.enrich.common.utils.CirceUtils
 
 /** Companion object to create an instance of YauaaEnrichment from the configuration. */
 object YauaaEnrichment extends ParseableEnrichment {

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/YauaaEnrichment.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/YauaaEnrichment.scala
@@ -54,7 +54,7 @@ object YauaaEnrichment extends ParseableEnrichment {
     (for {
       _ <- isParseable(c, schemaKey)
       cacheSize <- CirceUtils.extract[Option[Int]](c, "parameters", "cacheSize").toEither
-    } yield YauaaConf(cacheSize)).toValidatedNel
+    } yield YauaaConf(schemaKey, cacheSize)).toValidatedNel
 
   /** Helper to decapitalize a string. Used for the names of the fields returned in the context. */
   def decapitalize(s: String): String =

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/apirequest/ApiRequestEnrichment.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/apirequest/ApiRequestEnrichment.scala
@@ -10,10 +10,7 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package com.snowplowanalytics.snowplow.enrich.common
-package enrichments
-package registry
-package apirequest
+package com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.apirequest
 
 import java.util.UUID
 
@@ -21,17 +18,19 @@ import cats.{Id, Monad}
 import cats.data.{EitherT, NonEmptyList, ValidatedNel}
 import cats.implicits._
 
-import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey, SelfDescribingData}
-import com.snowplowanalytics.iglu.core.circe.implicits._
-import com.snowplowanalytics.lrumap._
-
-import com.snowplowanalytics.snowplow.badrows.FailureDetails
-
 import io.circe._
 import io.circe.generic.auto._
 
-import outputs.EnrichedEvent
-import utils.{CirceUtils, HttpClient}
+import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey, SelfDescribingData}
+import com.snowplowanalytics.iglu.core.circe.implicits._
+
+import com.snowplowanalytics.lrumap._
+import com.snowplowanalytics.snowplow.badrows.FailureDetails
+
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.{Enrichment, ParseableEnrichment}
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf.ApiRequestConf
+import com.snowplowanalytics.snowplow.enrich.common.outputs.EnrichedEvent
+import com.snowplowanalytics.snowplow.enrich.common.utils.{CirceUtils, HttpClient}
 
 object ApiRequestEnrichment extends ParseableEnrichment {
   override val supportedSchema =

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/enrichments.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/enrichments.scala
@@ -10,161 +10,21 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package com.snowplowanalytics.snowplow.enrich.common
-package enrichments.registry
+package com.snowplowanalytics.snowplow.enrich.common.enrichments.registry
 
 import java.net.URI
 
-import cats.{Functor, Monad}
-import cats.data.{EitherT, ValidatedNel}
+import cats.data.ValidatedNel
 import cats.syntax.either._
-import com.snowplowanalytics.forex.CreateForex
-import com.snowplowanalytics.forex.model.AccountType
-import com.snowplowanalytics.iglu.core._
-import com.snowplowanalytics.maxmind.iplookups.CreateIpLookups
-import com.snowplowanalytics.refererparser.CreateParser
-import com.snowplowanalytics.weather.providers.openweather.CreateOWM
-import io.circe._
-import org.joda.money.CurrencyUnit
 
-import apirequest._
-import sqlquery._
-import utils.ConversionUtils
+import io.circe._
+
+import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey}
+
+import com.snowplowanalytics.snowplow.enrich.common.utils.ConversionUtils
 
 /** Trait inherited by every enrichment config case class */
 trait Enrichment
-
-sealed trait EnrichmentConf {
-  def schemaKey: SchemaKey =
-    SchemaKey(
-      "com.acme",
-      "placeholder",
-      "jsonschema",
-      SchemaVer.Full(1, 0, 0)
-    )
-  def filesToCache: List[(URI, String)] = Nil
-}
-final case class ApiRequestConf(
-  override val schemaKey: SchemaKey,
-  inputs: List[apirequest.Input],
-  api: HttpApi,
-  outputs: List[apirequest.Output],
-  cache: apirequest.Cache
-) extends EnrichmentConf {
-  def enrichment[F[_]: CreateApiRequestEnrichment]: F[ApiRequestEnrichment[F]] =
-    ApiRequestEnrichment[F](this)
-}
-final case class PiiPseudonymizerConf(
-  fieldList: List[pii.PiiField],
-  emitIdentificationEvent: Boolean,
-  strategy: pii.PiiStrategy
-) extends EnrichmentConf {
-  def enrichment: pii.PiiPseudonymizerEnrichment =
-    pii.PiiPseudonymizerEnrichment(fieldList, emitIdentificationEvent, strategy)
-}
-final case class SqlQueryConf(
-  override val schemaKey: SchemaKey,
-  inputs: List[sqlquery.Input],
-  db: Rdbms,
-  query: SqlQueryEnrichment.Query,
-  output: sqlquery.Output,
-  cache: SqlQueryEnrichment.Cache
-) extends EnrichmentConf {
-  def enrichment[F[_]: Monad: CreateSqlQueryEnrichment]: F[SqlQueryEnrichment[F]] =
-    SqlQueryEnrichment[F](this)
-}
-final case class AnonIpConf(octets: AnonIPv4Octets.AnonIPv4Octets, segments: AnonIPv6Segments.AnonIPv6Segments) extends EnrichmentConf {
-  override val filesToCache: List[(URI, String)] = Nil
-  def enrichment: AnonIpEnrichment = AnonIpEnrichment(octets, segments)
-}
-final case class CampaignAttributionConf(
-  mediumParameters: List[String],
-  sourceParameters: List[String],
-  termParameters: List[String],
-  contentParameters: List[String],
-  campaignParameters: List[String],
-  clickIdParameters: List[(String, String)]
-) extends EnrichmentConf {
-  def enrichment: CampaignAttributionEnrichment =
-    CampaignAttributionEnrichment(
-      mediumParameters,
-      sourceParameters,
-      termParameters,
-      contentParameters,
-      campaignParameters,
-      clickIdParameters
-    )
-}
-final case class CookieExtractorConf(cookieNames: List[String]) extends EnrichmentConf {
-  def enrichment: CookieExtractorEnrichment = CookieExtractorEnrichment(cookieNames)
-}
-final case class CurrencyConversionConf(
-  override val schemaKey: SchemaKey,
-  accountType: AccountType,
-  apiKey: String,
-  baseCurrency: CurrencyUnit
-) extends EnrichmentConf {
-  def enrichment[F[_]: Monad: CreateForex]: F[CurrencyConversionEnrichment[F]] =
-    CurrencyConversionEnrichment[F](this)
-}
-final case class EventFingerprintConf(algorithm: String => String, excludedParameters: List[String]) extends EnrichmentConf {
-  def enrichment: EventFingerprintEnrichment =
-    EventFingerprintEnrichment(algorithm, excludedParameters)
-}
-final case class HttpHeaderExtractorConf(headersPattern: String) extends EnrichmentConf {
-  def enrichment: HttpHeaderExtractorEnrichment = HttpHeaderExtractorEnrichment(headersPattern)
-}
-final case class IabConf(
-  override val schemaKey: SchemaKey,
-  ipFile: (URI, String),
-  excludeUaFile: (URI, String),
-  includeUaFile: (URI, String)
-) extends EnrichmentConf {
-  override val filesToCache: List[(URI, String)] = List(ipFile, excludeUaFile, includeUaFile)
-  def enrichment[F[_]: Monad: CreateIabClient]: F[IabEnrichment] =
-    IabEnrichment[F](this)
-}
-final case class IpLookupsConf(
-  geoFile: Option[(URI, String)],
-  ispFile: Option[(URI, String)],
-  domainFile: Option[(URI, String)],
-  connectionTypeFile: Option[(URI, String)]
-) extends EnrichmentConf {
-  override val filesToCache: List[(URI, String)] =
-    List(geoFile, ispFile, domainFile, connectionTypeFile).flatten
-  def enrichment[F[_]: Functor: CreateIpLookups]: F[IpLookupsEnrichment[F]] =
-    IpLookupsEnrichment[F](this)
-}
-final case class JavascriptScriptConf(override val schemaKey: SchemaKey, rawFunction: String) extends EnrichmentConf {
-  def enrichment: JavascriptScriptEnrichment = JavascriptScriptEnrichment(schemaKey, rawFunction)
-}
-final case class RefererParserConf(refererDatabase: (URI, String), internalDomains: List[String]) extends EnrichmentConf {
-  override val filesToCache: List[(URI, String)] = List(refererDatabase)
-  def enrichment[F[_]: Monad: CreateParser]: EitherT[F, String, RefererParserEnrichment] =
-    RefererParserEnrichment[F](this)
-}
-final case class UaParserConf(override val schemaKey: SchemaKey, uaDatabase: Option[(URI, String)]) extends EnrichmentConf {
-  override val filesToCache: List[(URI, String)] = List(uaDatabase).flatten
-  def enrichment[F[_]: Monad: CreateUaParser]: EitherT[F, String, UaParserEnrichment] =
-    UaParserEnrichment[F](this)
-}
-final case class UserAgentUtilsConf(override val schemaKey: SchemaKey) extends EnrichmentConf {
-  def enrichment: UserAgentUtilsEnrichment = UserAgentUtilsEnrichment(schemaKey)
-}
-final case class WeatherConf(
-  override val schemaKey: SchemaKey,
-  apiHost: String,
-  apiKey: String,
-  timeout: Int,
-  cacheSize: Int,
-  geoPrecision: Int
-) extends EnrichmentConf {
-  def enrichment[F[_]: Monad: CreateOWM]: EitherT[F, String, WeatherEnrichment[F]] =
-    WeatherEnrichment[F](this)
-}
-final case class YauaaConf(cacheSize: Option[Int]) extends EnrichmentConf {
-  def enrichment: YauaaEnrichment = YauaaEnrichment(cacheSize)
-}
 
 /** Trait to hold helpers relating to enrichment config */
 trait ParseableEnrichment {

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/pii/PiiPseudonymizerEnrichment.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/pii/PiiPseudonymizerEnrichment.scala
@@ -10,9 +10,7 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package com.snowplowanalytics.snowplow.enrich.common
-package enrichments.registry
-package pii
+package com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.pii
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.MutableList
@@ -20,24 +18,26 @@ import scala.collection.mutable.MutableList
 import cats.data.ValidatedNel
 import cats.implicits._
 
+import io.circe._
+import io.circe.jackson._
+import io.circe.syntax._
+
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.{ArrayNode, ObjectNode, TextNode}
 
 import com.jayway.jsonpath.{Configuration, JsonPath => JJsonPath}
 import com.jayway.jsonpath.MapFunction
 
-import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey, SelfDescribingData}
-
-import io.circe._
-import io.circe.jackson._
-import io.circe.syntax._
-
 import org.apache.commons.codec.digest.DigestUtils
 
-import adapters.registry.Adapter
-import outputs.EnrichedEvent
-import serializers._
-import utils.CirceUtils
+import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey, SelfDescribingData}
+
+import com.snowplowanalytics.snowplow.enrich.common.adapters.registry.Adapter
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf.PiiPseudonymizerConf
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.{Enrichment, ParseableEnrichment}
+import com.snowplowanalytics.snowplow.enrich.common.outputs.EnrichedEvent
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.pii.serializers._
+import com.snowplowanalytics.snowplow.enrich.common.utils.CirceUtils
 
 /** Companion object. Lets us create a PiiPseudonymizerEnrichment from a Json. */
 object PiiPseudonymizerEnrichment extends ParseableEnrichment {

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/sqlquery/CreateSqlQueryEnrichment.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/sqlquery/CreateSqlQueryEnrichment.scala
@@ -13,11 +13,12 @@
 package com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.sqlquery
 
 import cats.Id
+
 import cats.effect.Sync
 import cats.syntax.functor._
 import cats.syntax.flatMap._
 
-import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.SqlQueryConf
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf.SqlQueryConf
 
 /** Initialize resources, necessary for SQL Query enrichment: cache and connection */
 sealed trait CreateSqlQueryEnrichment[F[_]] {

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/sqlquery/CreateSqlQueryEnrichment.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/sqlquery/CreateSqlQueryEnrichment.scala
@@ -12,7 +12,7 @@
  */
 package com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.sqlquery
 
-import cats.{Eval, Id}
+import cats.Id
 import cats.effect.Sync
 import cats.syntax.functor._
 import cats.syntax.flatMap._
@@ -34,28 +34,6 @@ object CreateSqlQueryEnrichment {
   ): CreateSqlQueryEnrichment[F] =
     new CreateSqlQueryEnrichment[F] {
       def create(conf: SqlQueryConf): F[SqlQueryEnrichment[F]] =
-        for {
-          cache <- CLM.create(conf.cache.size)
-          connection <- CN.create(1)
-        } yield SqlQueryEnrichment(
-          conf.schemaKey,
-          conf.inputs,
-          conf.db,
-          conf.query,
-          conf.output,
-          conf.cache.ttl,
-          cache,
-          connection
-        )
-    }
-
-  implicit def evalCreateSqlQueryEnrichment(
-    implicit CLM: SqlCacheInit[Eval],
-    CN: ConnectionRefInit[Eval],
-    DB: DbExecutor[Eval]
-  ): CreateSqlQueryEnrichment[Eval] =
-    new CreateSqlQueryEnrichment[Eval] {
-      def create(conf: SqlQueryConf): Eval[SqlQueryEnrichment[Eval]] =
         for {
           cache <- CLM.create(conf.cache.size)
           connection <- CN.create(1)

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/sqlquery/DbExecutor.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/sqlquery/DbExecutor.scala
@@ -358,12 +358,12 @@ object DbExecutor {
     connectionRef: ConnectionRef[F],
     sql: String,
     placeholderMap: Input.PlaceholderMap
-  ): F[Either[String, Unit]] =
+  ): F[Either[String, Input.PlaceholderMap]] =
     getPlaceholderCount(rdbms, connectionRef, sql).map {
       case Right(placeholderCount) =>
         placeholderMap match {
-          case Some(intMap) if intMap.keys.size == placeholderCount => ().asRight
-          case _ => s"The placeholder map error. The map: $placeholderMap, where count is: $placeholderCount".asLeft
+          case Some(intMap) if intMap.keys.size == placeholderCount => placeholderMap.asRight
+          case _ => None.asRight
         }
       case Left(error) =>
         error.getMessage.asLeft

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/sqlquery/SqlQueryEnrichment.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/sqlquery/SqlQueryEnrichment.scala
@@ -10,10 +10,7 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package com.snowplowanalytics.snowplow.enrich.common
-package enrichments
-package registry
-package sqlquery
+package com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.sqlquery
 
 import scala.collection.immutable.IntMap
 
@@ -21,15 +18,17 @@ import cats.Monad
 import cats.data.{EitherT, NonEmptyList, ValidatedNel}
 import cats.implicits._
 
+import io.circe._
+import io.circe.generic.semiauto._
+
 import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey, SelfDescribingData}
 
 import com.snowplowanalytics.snowplow.badrows.FailureDetails
 
-import io.circe._
-import io.circe.generic.semiauto._
-
-import outputs.EnrichedEvent
-import utils.CirceUtils
+import com.snowplowanalytics.snowplow.enrich.common.outputs.EnrichedEvent
+import com.snowplowanalytics.snowplow.enrich.common.utils.CirceUtils
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf.SqlQueryConf
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.{Enrichment, ParseableEnrichment}
 
 /** Lets us create an SqlQueryConf from a Json */
 object SqlQueryEnrichment extends ParseableEnrichment {

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/utils/HttpClient.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/utils/HttpClient.scala
@@ -14,7 +14,7 @@ package com.snowplowanalytics.snowplow.enrich.common.utils
 
 import scala.util.control.NonFatal
 
-import cats.{Eval, Id}
+import cats.Id
 import cats.effect.Sync
 import cats.syntax.either._
 import scalaj.http._
@@ -30,12 +30,6 @@ object HttpClient {
     new HttpClient[F] {
       override def getResponse(request: HttpRequest): F[Either[Throwable, String]] =
         Sync[F].delay(getBody(request))
-    }
-
-  implicit def evalHttpClient: HttpClient[Eval] =
-    new HttpClient[Eval] {
-      override def getResponse(request: HttpRequest): Eval[Either[Throwable, String]] =
-        Eval.later(getBody(request))
     }
 
   implicit def idHttpClient: HttpClient[Id] =

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/CurrencyConversionEnrichmentSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/CurrencyConversionEnrichmentSpec.scala
@@ -10,8 +10,7 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package com.snowplowanalytics.snowplow.enrich.common
-package enrichments.registry
+package com.snowplowanalytics.snowplow.enrich.common.enrichments.registry
 
 import cats.Id
 import cats.data.{NonEmptyList, Validated, ValidatedNel}
@@ -19,11 +18,15 @@ import cats.implicits._
 
 import com.snowplowanalytics.forex.CreateForex._
 import com.snowplowanalytics.forex.model._
+
 import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer}
-import com.snowplowanalytics.snowplow.badrows._
+
+import com.snowplowanalytics.snowplow.badrows.FailureDetails
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf.CurrencyConversionConf
 
 import org.joda.money.CurrencyUnit
 import org.joda.time.DateTime
+
 import org.specs2.Specification
 import org.specs2.matcher.DataTables
 
@@ -42,11 +45,10 @@ class CurrencyConversionEnrichmentSpec extends Specification with DataTables {
   """
 
   lazy val validAppKey = sys.env
-    .get(OerApiKey)
-    .getOrElse(
-      throw new IllegalStateException(
-        s"No ${OerApiKey} environment variable found, test should have been skipped"
-      )
+    .getOrElse(OerApiKey,
+               throw new IllegalStateException(
+                 s"No $OerApiKey environment variable found, test should have been skipped"
+               )
     )
   type Result = ValidatedNel[
     FailureDetails.EnrichmentFailure,

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/EnrichmentConfigsSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/EnrichmentConfigsSpec.scala
@@ -14,12 +14,17 @@ package com.snowplowanalytics.snowplow.enrich.common.enrichments.registry
 
 import java.net.URI
 
-import com.snowplowanalytics.forex.model._
-import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey, SchemaVer}
 import io.circe.literal._
 import io.circe.parser._
+
 import org.apache.commons.codec.binary.Base64
 import org.joda.money.CurrencyUnit
+
+import com.snowplowanalytics.forex.model._
+import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey, SchemaVer}
+
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf._
+
 import org.specs2.matcher.{DataTables, ValidatedMatchers}
 import org.specs2.mutable.Specification
 

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/EnrichmentConfigsSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/EnrichmentConfigsSpec.scala
@@ -47,7 +47,7 @@ class EnrichmentConfigsSpec extends Specification with ValidatedMatchers with Da
         SchemaVer.Full(1, 0, 1)
       )
       val result = AnonIpEnrichment.parse(ipAnonJson, schemaKey)
-      result must beValid(AnonIpConf(AnonIPv4Octets(2), AnonIPv6Segments(3)))
+      result must beValid(AnonIpConf(schemaKey, AnonIPv4Octets(2), AnonIPv6Segments(3)))
     }
 
     "successfully construct an AnonIpEnrichment case class with default value for IPv6" in {
@@ -64,7 +64,7 @@ class EnrichmentConfigsSpec extends Specification with ValidatedMatchers with Da
         SchemaVer.Full(1, 0, 0)
       )
       val result = AnonIpEnrichment.parse(ipAnonJson, schemaKey)
-      result must beValid(AnonIpConf(AnonIPv4Octets(2), AnonIPv6Segments(2)))
+      result must beValid(AnonIpConf(schemaKey, AnonIPv4Octets(2), AnonIPv6Segments(2)))
     }
   }
 
@@ -90,6 +90,7 @@ class EnrichmentConfigsSpec extends Specification with ValidatedMatchers with Da
         SchemaVer.Full(2, 0, 0)
       )
       val expected = IpLookupsConf(
+        schemaKey,
         Some(
           (
             new URI(
@@ -136,6 +137,7 @@ class EnrichmentConfigsSpec extends Specification with ValidatedMatchers with Da
         SchemaVer.Full(2, 0, 0)
       )
       val expected = RefererParserConf(
+        schemaKey,
         (
           new URI(
             "http://snowplow-hosted-assets.s3.amazonaws.com/third-party/referer/referer.json"
@@ -146,7 +148,6 @@ class EnrichmentConfigsSpec extends Specification with ValidatedMatchers with Da
       )
       val result = RefererParserEnrichment.parse(refererParserJson, schemaKey, false)
       result must beValid(expected)
-
     }
   }
 
@@ -179,6 +180,7 @@ class EnrichmentConfigsSpec extends Specification with ValidatedMatchers with Da
         SchemaVer.Full(1, 0, 0)
       )
       val expected = CampaignAttributionConf(
+        schemaKey,
         List("utm_medium", "medium"),
         List("utm_source", "source"),
         List("utm_term"),
@@ -336,7 +338,7 @@ class EnrichmentConfigsSpec extends Specification with ValidatedMatchers with Da
         SchemaVer.Full(1, 0, 0)
       )
       val result = CookieExtractorEnrichment.parse(cookieExtractorEnrichmentJson, schemaKey)
-      result must beValid(CookieExtractorConf(List("foo", "bar")))
+      result must beValid(CookieExtractorConf(schemaKey, List("foo", "bar")))
     }
   }
 

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/RefererParserEnrichmentSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/RefererParserEnrichmentSpec.scala
@@ -14,12 +14,15 @@ package com.snowplowanalytics.snowplow.enrich.common.enrichments.registry
 
 import java.net.URI
 
-import cats.Eval
+import cats.Id
 import cats.data.EitherT
 import cats.syntax.either._
+
+import io.circe.literal._
+
 import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer}
 import com.snowplowanalytics.refererparser._
-import io.circe.literal._
+
 import org.specs2.Specification
 import org.specs2.matcher.DataTables
 
@@ -57,7 +60,7 @@ class RefererParserEnrichmentSpec extends Specification with DataTables {
         Medium.Unknown
       ) |> { (_, refererUri, referer) =>
       (for {
-        c <- EitherT.fromEither[Eval](
+        c <- EitherT.fromEither[Id](
                RefererParserEnrichment
                  .parse(
                    json"""{
@@ -81,16 +84,16 @@ class RefererParserEnrichmentSpec extends Specification with DataTables {
                  .toEither
                  .leftMap(_.head)
              )
-        e <- c.enrichment[Eval]
+        e <- c.enrichment[Id]
         res = e.extractRefererDetails(new URI(refererUri), PageHost)
-      } yield res).value.value must beRight.like {
-        case o => o must_== Some(referer)
+      } yield res).value must beRight.like {
+        case o => o must beSome(referer)
       }
     }
 
   def e2 =
     (for {
-      c <- EitherT.fromEither[Eval](
+      c <- EitherT.fromEither[Id](
              RefererParserEnrichment
                .parse(
                  json"""{
@@ -114,16 +117,16 @@ class RefererParserEnrichmentSpec extends Specification with DataTables {
                .toEither
                .leftMap(_.head)
            )
-      e <- c.enrichment[Eval]
+      e <- c.enrichment[Id]
       res = e.extractRefererDetails(
               new URI(
                 "http://www.google.com/search?q=%0Agateway%09oracle%09cards%09denise%09linn&hl=en&client=safari"
               ),
               PageHost
             )
-    } yield res).value.value must beRight.like {
+    } yield res).value must beRight.like {
       case o =>
-        o must_== Some(
+        o must beSome(
           SearchReferer(
             Medium.Search,
             "Google",

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/UaParserEnrichmentSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/UaParserEnrichmentSpec.scala
@@ -14,7 +14,7 @@ package com.snowplowanalytics.snowplow.enrich.common.enrichments.registry
 
 import java.net.URI
 
-import cats.Eval
+import cats.Id
 import cats.data.EitherT
 
 import io.circe.literal._
@@ -75,10 +75,10 @@ class UaParserEnrichmentSpec extends Specification with DataTables {
       "Custom Rules" | "Input UserAgent" | "Parsed UserAgent" |
         Some(badRulefile) !! mobileSafariUserAgent !! "Failed to initialize ua parser" |> { (rules, input, errorPrefix) =>
         (for {
-          c <- EitherT.rightT[Eval, String](UaParserConf(schemaKey, rules))
-          e <- c.enrichment[Eval]
+          c <- EitherT.rightT[Id, String](UaParserConf(schemaKey, rules))
+          e <- c.enrichment[Id]
           res = e.extractUserAgent(input)
-        } yield res).value.value must beLeft.like {
+        } yield res).value must beLeft.like {
           case a => a must startWith(errorPrefix)
         }
       }
@@ -90,11 +90,11 @@ class UaParserEnrichmentSpec extends Specification with DataTables {
         None !! safariUserAgent !! safariJson |
         Some(customRules) !! mobileSafariUserAgent !! testAgentJson |> { (rules, input, expected) =>
         val json = for {
-          c <- EitherT.rightT[Eval, String](UaParserConf(schemaKey, rules))
-          e <- c.enrichment[Eval].leftMap(_.toString)
-          res <- EitherT.fromEither[Eval](e.extractUserAgent(input)).leftMap(_.toString)
+          c <- EitherT.rightT[Id, String](UaParserConf(schemaKey, rules))
+          e <- c.enrichment[Id].leftMap(_.toString)
+          res <- EitherT.fromEither[Id](e.extractUserAgent(input)).leftMap(_.toString)
         } yield res
-        json.value.value must beRight(expected)
+        json.value must beRight(expected)
       }
     }
   }

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/UaParserEnrichmentSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/UaParserEnrichmentSpec.scala
@@ -21,6 +21,8 @@ import io.circe.literal._
 
 import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer, SelfDescribingData}
 
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf.UaParserConf
+
 import org.specs2.matcher.DataTables
 import org.specs2.mutable.Specification
 

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/WeatherEnrichmentSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/WeatherEnrichmentSpec.scala
@@ -24,6 +24,8 @@ import org.joda.time.DateTime
 
 import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer}
 
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf.WeatherConf
+
 import org.specs2.Specification
 
 object WeatherEnrichmentSpec {

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/YauaaEnrichmentSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/YauaaEnrichmentSpec.scala
@@ -10,16 +10,16 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package com.snowplowanalytics.snowplow.enrich.common
-package enrichments
-package registry
-
-import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer, SelfDescribingData}
+package com.snowplowanalytics.snowplow.enrich.common.enrichments.registry
 
 import io.circe.parser._
 import io.circe.literal._
 
 import nl.basjes.parse.useragent.UserAgent
+
+import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer, SelfDescribingData}
+
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf.YauaaConf
 
 import org.specs2.matcher.ValidatedMatchers
 import org.specs2.mutable.Specification

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/YauaaEnrichmentSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/YauaaEnrichmentSpec.scala
@@ -246,7 +246,7 @@ class YauaaEnrichmentSpec extends Specification with ValidatedMatchers {
         }
       }""").toOption.get
 
-      val expected = YauaaConf(Some(cacheSize))
+      val expected = YauaaConf(schemaKey, Some(cacheSize))
       val actual = YauaaEnrichment.parse(yauaaConfigJson, schemaKey)
       actual must beValid(expected)
     }
@@ -256,7 +256,7 @@ class YauaaEnrichmentSpec extends Specification with ValidatedMatchers {
         "enabled": true
       }""").toOption.get
 
-      val expected = YauaaConf(None)
+      val expected = YauaaConf(schemaKey, None)
       val actual = YauaaEnrichment.parse(yauaaConfigJson, schemaKey)
       actual must beValid(expected)
     }

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/apirequest/ApiRequestEnrichmentSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/apirequest/ApiRequestEnrichmentSpec.scala
@@ -10,9 +10,7 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package com.snowplowanalytics.snowplow.enrich.common
-package enrichments.registry
-package apirequest
+package com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.apirequest
 
 import cats.Id
 import cats.syntax.either._
@@ -21,16 +19,17 @@ import io.circe.Json
 import io.circe.literal._
 import io.circe.parser._
 
-import org.specs2.Specification
-import org.specs2.matcher.ValidatedMatchers
-import org.specs2.mock.Mockito
-
 import scalaj.http.HttpRequest
 
 import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey, SchemaVer, SelfDescribingData}
 
-import outputs.EnrichedEvent
-import utils.HttpClient
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf.ApiRequestConf
+import com.snowplowanalytics.snowplow.enrich.common.outputs.EnrichedEvent
+import com.snowplowanalytics.snowplow.enrich.common.utils.HttpClient
+
+import org.specs2.Specification
+import org.specs2.matcher.ValidatedMatchers
+import org.specs2.mock.Mockito
 
 class ApiRequestEnrichmentSpec extends Specification with ValidatedMatchers with Mockito {
   def is = s2"""

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/apirequest/HttpApiSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/apirequest/HttpApiSpec.scala
@@ -10,12 +10,15 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package com.snowplowanalytics.snowplow.enrich.common
-package enrichments.registry
-package apirequest
+package com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.apirequest
 
 import cats.Id
+
 import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer}
+
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf.ApiRequestConf
+import com.snowplowanalytics.snowplow.enrich.common.outputs.EnrichedEvent
+
 import org.specs2.Specification
 import org.specs2.matcher.ValidatedMatchers
 import org.specs2.mock.Mockito
@@ -49,7 +52,6 @@ class HttpApiSpec extends Specification with ValidatedMatchers with Mockito {
     request must beSome("http://thishostdoesntexist31337:8123/admin/foo/November+2015/admin")
   }
 
-  // This one uses real actor system
   def e3 = {
     val schemaKey = SchemaKey("vendor", "name", "format", SchemaVer.Full(1, 0, 0))
     val enrichment = ApiRequestConf(
@@ -60,7 +62,7 @@ class HttpApiSpec extends Specification with ValidatedMatchers with Mockito {
       Cache(1, 1)
     ).enrichment[Id]
 
-    val event = new outputs.EnrichedEvent
+    val event = new EnrichedEvent
     val request = enrichment.lookup(event, Nil, Nil, None)
     request must beInvalid
   }

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/apirequest/InputSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/apirequest/InputSpec.scala
@@ -10,9 +10,7 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package com.snowplowanalytics.snowplow.enrich.common
-package enrichments.registry
-package apirequest
+package com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.apirequest
 
 import cats.Id
 import cats.data.ValidatedNel
@@ -22,9 +20,11 @@ import io.circe.literal._
 
 import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey, SchemaVer, SelfDescribingData}
 
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf.ApiRequestConf
+import com.snowplowanalytics.snowplow.enrich.common.outputs.EnrichedEvent
+
 import org.specs2.Specification
 import org.specs2.matcher.ValidatedMatchers
-import outputs.EnrichedEvent
 
 class InputSpec extends Specification with ValidatedMatchers {
   def is = s2"""
@@ -253,7 +253,7 @@ class InputSpec extends Specification with ValidatedMatchers {
       List(Output("iglu:someschema", JsonOutput("$").some)),
       Cache(10, 5)
     ).enrichment[Id]
-    val event = new outputs.EnrichedEvent
+    val event = new EnrichedEvent
     event.setUser_id("chuwy")
     // time in true_tstamp won't be found
     val request = enrichment.lookup(event, Nil, Nil, None)
@@ -276,7 +276,7 @@ class InputSpec extends Specification with ValidatedMatchers {
         json"""{ "somekey": "somevalue" }"""
       )
 
-    input.pull(new outputs.EnrichedEvent, Nil, List(obj), None) must beValid.like {
+    input.pull(new EnrichedEvent, Nil, List(obj), None) must beValid.like {
       case Some(context) =>
         context must beEqualTo(Map("permissive" -> "somevalue"))
       case None =>

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/sqlquery/SqlQueryEnrichmentIntegrationTest.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/sqlquery/SqlQueryEnrichmentIntegrationTest.scala
@@ -22,8 +22,6 @@ import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer, SelfDescribingData
 import org.specs2.Specification
 
 import outputs.EnrichedEvent
-import com.snowplowanalytics.snowplow.badrows.FailureDetails.EnrichmentFailure
-import com.snowplowanalytics.snowplow.badrows.FailureDetails
 
 object SqlQueryEnrichmentIntegrationTest {
   def continuousIntegration: Boolean =
@@ -407,12 +405,7 @@ class SqlQueryEnrichmentIntegrationTest extends Specification {
     val config = SqlQueryEnrichment.parse(configuration, SCHEMA_KEY).map(_.enrichment)
     val context = config.toEither.flatMap(_.lookup(event, Nil, Nil, None).toEither)
 
-    context must beLeft.like {
-      case nel =>
-        nel.head.asInstanceOf[EnrichmentFailure].message must beEqualTo(
-          FailureDetails.EnrichmentFailureMessage.Simple("The placeholder map error. The map: Some(IntMap()), where count is: 1")
-        )
-    }
+    context must beRight(Nil)
   }
 
 }

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/sqlquery/SqlQueryEnrichmentSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/sqlquery/SqlQueryEnrichmentSpec.scala
@@ -10,14 +10,14 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package com.snowplowanalytics.snowplow.enrich.common.enrichments.registry
-package sqlquery
+package com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.sqlquery
 
 import io.circe.parser._
 import io.circe.literal._
 
 import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey, SchemaVer}
 
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf.SqlQueryConf
 import com.snowplowanalytics.snowplow.enrich.common.utils.CirceUtils
 
 import org.specs2.Specification

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/utils/Clock.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/utils/Clock.scala
@@ -15,17 +15,10 @@ package utils
 
 import java.util.concurrent.TimeUnit
 
-import cats.{Eval, Id}
+import cats.Id
 import cats.effect.{Clock => CEClock}
 
 object Clock {
-  implicit val evalClock: CEClock[Eval] = new CEClock[Eval] {
-    final def realTime(unit: TimeUnit): Eval[Long] =
-      Eval.later(unit.convert(System.currentTimeMillis(), TimeUnit.MILLISECONDS))
-    final def monotonic(unit: TimeUnit): Eval[Long] =
-      Eval.later(unit.convert(System.nanoTime(), TimeUnit.NANOSECONDS))
-  }
-
   implicit val idClock: CEClock[Id] = new CEClock[Id] {
     final def realTime(unit: TimeUnit): Id[Long] =
       unit.convert(System.currentTimeMillis(), TimeUnit.MILLISECONDS)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -75,8 +75,8 @@ object Dependencies {
     val jinJava          = "2.5.0"
 
     val sentry           = "1.7.30"
-    val scio             = "0.9.2"
-    val beam             = "2.22.0"
+    val scio             = "0.9.3"
+    val beam             = "2.23.0"
     val macros           = "2.1.1"
     val scalaTest        = "3.0.8"
   }


### PR DESCRIPTION
Couldn't come up with a meaningful unit-test. One possible scenario that I see is to:

1. Specify an enrichment config with `file:` URI to fake DB MaxMind DB
2. Simulate a 2 minutes delay between two raw event elements
3. Run a pipeline with 1 minute refresh rate
4. Right after the start (when 1st element is already enriched) manually replace the file

But it feels like its way too much work and will slow-down the tests with 2 minutes - I'd prefer to get away with real-world test only. WDYT, @snowplow/com-snowplowanalytics-engineering-datacapability?