### PR TITLE
Rename 'internal' to 'interval'. Fixes #410

### DIFF
--- a/modules/stream/src/main/scala/com.snowplowanalytics.snowplow.enrich.stream/SnowplowTracking.scala
+++ b/modules/stream/src/main/scala/com.snowplowanalytics.snowplow.enrich.stream/SnowplowTracking.scala
@@ -185,7 +185,7 @@ object SnowplowTracking {
           "jsonschema",
           SchemaVer.Full(1, 0, 0)
         ),
-        Json.obj(("internal", Json.fromLong(heartbeatInterval)))
+        Json.obj(("interval", Json.fromLong(heartbeatInterval)))
       )
     )
 }


### PR DESCRIPTION
Rename property so that it correctly validates against the `app_heartbeat` schema.
