### PR TITLE
FS2: StatsD reporter for metrics

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -219,6 +219,7 @@ lazy val fs2 = project
       Dependencies.Libraries.fs2BlobS3,
       Dependencies.Libraries.fs2BlobGcs,
       Dependencies.Libraries.metrics,
+      Dependencies.Libraries.dogStatsD,
       Dependencies.Libraries.pureconfig.withRevision(Dependencies.V.pureconfig013),
       Dependencies.Libraries.pureconfigCats.withRevision(Dependencies.V.pureconfig013),
       Dependencies.Libraries.pureconfigCirce.withRevision(Dependencies.V.pureconfig013),

--- a/build.sbt
+++ b/build.sbt
@@ -74,6 +74,7 @@ lazy val allStreamSettings = BuildSettings.basicSettings ++ BuildSettings.sbtAss
     Dependencies.Libraries.sentry,
     Dependencies.Libraries.slf4j,
     Dependencies.Libraries.log4jOverSlf4j,
+    Dependencies.Libraries.authSdk,
     Dependencies.Libraries.s3Sdk,
     Dependencies.Libraries.gsSdk,
     Dependencies.Libraries.scopt,
@@ -103,7 +104,6 @@ lazy val kinesis = project
   .settings(packageName in Docker := "snowplow/stream-enrich-kinesis")
   .settings(libraryDependencies ++= Seq(
     Dependencies.Libraries.kinesisClient,
-    Dependencies.Libraries.kinesisSdk,
     Dependencies.Libraries.dynamodbSdk,
     Dependencies.Libraries.jacksonCbor
   ))

--- a/config/config.fs2.hocon.sample
+++ b/config/config.fs2.hocon.sample
@@ -42,6 +42,19 @@ sentry = {
 // no assets will be updated if the key is absent
 assetsUpdatePeriod = "7 days"
 
-// Optional, period after Dropwizard will print out its metrics
-// no metrics will be printed if the key is absent
-metricsReportPeriod = "1 second"
+metricsReporter = {
+  type = "StatsD"
+  period = "10 second"
+  hostname = "localhost"
+  port = 8125
+
+  // Any key-value pairs to be tagged on every metric
+  tags = {
+    app = enrich
+    host = ${HOSTNAME}
+  }
+
+  // Metrics can be reported to Stdout for testing purposes
+  // type = "Stdout"
+  // period = "10 second"
+}

--- a/config/config.hocon.sample
+++ b/config/config.hocon.sample
@@ -74,6 +74,10 @@ enrich {
       # dynamodbCustomEndpoint = "http://localhost:4569"
       # dynamodbCustomEndpoint = ${?ENRICH_DYNAMODB_CUSTOM_ENDPOINT}
 
+      # Initial RCU/WCU are optional. These are the settings for Dynamodb lease table throughput initialization
+      # dynamodbInitialRCU = "{{leastTableInitialRCU}}"
+      # dynamodbInitialWCU = "{{leastTableInitialWCU}}"
+
       # Optional override to disable cloudwatch
       # disableCloudWatch = true
       # disableCloudWatch = ${?ENRICH_DISABLE_CLOUDWATCH}
@@ -96,7 +100,8 @@ enrich {
       #   creds = ${?GOOGLE_APPLICATION_CREDENTIALS}
       # }
 
-      # Maximum number of records to get from Kinesis per call to GetRecords
+      # If maxRecords is specified, KCL will use polling mode (shared read throughput) and will get max maxRecords from Kinesis per call to GetRecords.
+      # If not specified, KCL will use enhanced fan out (dedicated read throughput).
       # maxRecords = 10000
       # maxRecords = ${?ENRICH_MAX_RECORDS}
 

--- a/modules/fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/fs2/Environment.scala
+++ b/modules/fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/fs2/Environment.scala
@@ -119,7 +119,7 @@ object Environment {
       for {
         client <- Client.parseDefault[F](parsedConfigs.igluJson).resource
         blocker <- Blocker[F]
-        metrics <- Metrics.resource[F]
+        metrics <- file.metricsReporter.map(Metrics.resource[F](_)).getOrElse(Resource.pure[F, Metrics[F]](Metrics.noop[F]))
         rawSource = Source.read[F](blocker, file.auth, file.input)
         goodSink <- Sinks.goodSink[F](blocker, file.auth, file.good)
         badSink <- Sinks.badSink[F](blocker, file.auth, file.bad)
@@ -143,7 +143,7 @@ object Environment {
                              sentry,
                              metrics,
                              file.assetsUpdatePeriod,
-                             file.metricsReportPeriod
+                             file.metricsReporter.map(_.period)
       )
     }
 

--- a/modules/fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/fs2/config/ConfigFile.scala
+++ b/modules/fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/fs2/config/ConfigFile.scala
@@ -23,7 +23,7 @@ import _root_.io.circe.{Decoder, Encoder, Json}
 import _root_.io.circe.config.syntax._
 import _root_.io.circe.generic.extras.semiauto.{deriveConfiguredDecoder, deriveConfiguredEncoder}
 
-import com.snowplowanalytics.snowplow.enrich.fs2.config.io.{Authentication, Input, Output}
+import com.snowplowanalytics.snowplow.enrich.fs2.config.io.{Authentication, Input, MetricsReporter, Output}
 
 import pureconfig.ConfigSource
 import pureconfig.module.catseffect.syntax._
@@ -45,7 +45,7 @@ final case class ConfigFile(
   bad: Output,
   assetsUpdatePeriod: Option[FiniteDuration],
   sentry: Option[Sentry],
-  metricsReportPeriod: Option[FiniteDuration]
+  metricsReporter: Option[MetricsReporter]
 )
 
 object ConfigFile {
@@ -58,8 +58,6 @@ object ConfigFile {
     deriveConfiguredDecoder[ConfigFile].emap {
       case ConfigFile(_, _, _, _, Some(aup), _, _) if aup._1 <= 0L =>
         "assetsUpdatePeriod in config file cannot be less than 0".asLeft // TODO: use newtype
-      case ConfigFile(_, _, _, _, _, _, Some(mrp)) if mrp._1 <= 0L =>
-        "metricsReportPeriod in config file cannot be less than 0".asLeft
       case other => other.asRight
     }
   implicit val configFileEncoder: Encoder[ConfigFile] =

--- a/modules/fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/fs2/io/StatsDReporter.scala
+++ b/modules/fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/fs2/io/StatsDReporter.scala
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2020 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.enrich.fs2.io
+
+import java.util.concurrent.TimeUnit
+import java.util.SortedMap
+
+import cats.effect.{Resource, Sync}
+import com.codahale.metrics._
+import com.timgroup.statsd.{NonBlockingStatsDClient, NonBlockingStatsDClientBuilder}
+import scala.jdk.CollectionConverters._
+
+import com.snowplowanalytics.snowplow.enrich.fs2.config.io.MetricsReporter
+
+/**
+ * A reporter that sends metrics to a statsd server.
+ *
+ * The reporter is backed by a third-party StatsD client, which is non-blocking and runs on a dedicated thread.
+ *
+ * We use the DogStatsD extension to the StatsD protocol, which adds arbitrary key-value tags to the metric, e.g:
+ * `snowplow.enrich.good.count:20000|g|#app_id:12345,env:prod`
+ *
+ * @param registry The metric registry we report on
+ * @param client The statsD client
+ * @param tags Arbitrary tags to add to each metric
+ */
+class StatsDReporter(
+  registry: MetricRegistry,
+  client: NonBlockingStatsDClient,
+  tags: List[String]
+) extends ScheduledReporter(registry, "statsd", MetricFilter.ALL, TimeUnit.SECONDS, TimeUnit.MILLISECONDS) {
+
+  override def report(
+    gauges: SortedMap[String, Gauge[_]],
+    counters: SortedMap[String, Counter],
+    histograms: SortedMap[String, Histogram],
+    meters: SortedMap[String, Meter],
+    timers: SortedMap[String, Timer]
+  ): Unit = {
+    reportGauges(gauges)
+    reportCounters(counters)
+    reportHistograms(histograms)
+    reportMeters(meters)
+    reportTimers(timers)
+  }
+
+  /* Handlers for the five DropWizard metric classes */
+
+  def reportGauges(gauges: SortedMap[String, Gauge[_]]): Unit =
+    gauges.asScala
+      .map { case (k, v) => k -> v.getValue }
+      .foreach {
+        case (k, v: Long) => client.gauge(k, v, tags: _*)
+        case (k, v: Double) => client.gauge(k, v, tags: _*)
+        case _ => ()
+      }
+
+  // Counters implement the `Counting` interface
+  def reportCounters(counters: SortedMap[String, Counter]): Unit =
+    counters.asScala.foreach { case (k, v) => reportCounting(k, v) }
+
+  // Counters implement the `Counting` and `Sampling` interfaces
+  def reportHistograms(histograms: SortedMap[String, Histogram]): Unit =
+    histograms.asScala.foreach {
+      case (k, v) =>
+        reportCounting(k, v)
+        reportSampling(k, v)
+    }
+
+  // Meters implement the `Counting` and `Metered` interfaces
+  def reportMeters(meters: SortedMap[String, Meter]): Unit =
+    meters.asScala.foreach {
+      case (k, v) =>
+        reportCounting(k, v)
+        reportMetered(k, v)
+    }
+
+  // Timers implement the `Counting`, `Metered` and `Sampling` interfaces
+  def reportTimers(timers: SortedMap[String, Timer]): Unit =
+    timers.asScala.foreach {
+      case (k, v) =>
+        reportCounting(k, v)
+        reportMetered(k, v)
+        reportSampling(k, v)
+    }
+
+  /* Handlers for the traits implemented by the Metric classes */
+
+  def reportCounting(key: String, counting: Counting): Unit =
+    client.gauge(s"$key.count", counting.getCount, tags: _*)
+
+  def reportMetered(key: String, metered: Metered): Unit = {
+    client.gauge(s"$key.fifteenMinuteRate", metered.getFifteenMinuteRate, tags: _*)
+    client.gauge(s"$key.fiveMinuteRate", metered.getFiveMinuteRate, tags: _*)
+    client.gauge(s"$key.oneMinuteRate", metered.getOneMinuteRate, tags: _*)
+    client.gauge(s"$key.meanRate", metered.getMeanRate, tags: _*)
+  }
+
+  def reportSampling(key: String, sampling: Sampling): Unit = {
+    val snapshot = sampling.getSnapshot
+    client.gauge(s"$key.min", snapshot.getMin, tags: _*)
+    client.gauge(s"$key.max", snapshot.getMax, tags: _*)
+    client.gauge(s"$key.mean", snapshot.getMean, tags: _*)
+    client.gauge(s"$key.median", snapshot.getMedian, tags: _*)
+    client.gauge(s"$key.stdDev", snapshot.getStdDev, tags: _*)
+    client.gauge(s"$key.size", snapshot.size.toLong, tags: _*)
+    client.gauge(s"$key.75thPercentile", snapshot.get75thPercentile, tags: _*)
+    client.gauge(s"$key.95thPercentile", snapshot.get95thPercentile, tags: _*)
+    client.gauge(s"$key.98thPercentile", snapshot.get98thPercentile, tags: _*)
+    client.gauge(s"$key.99thPercentile", snapshot.get99thPercentile, tags: _*)
+    client.gauge(s"$key.999thPercentile", snapshot.get999thPercentile, tags: _*)
+  }
+
+}
+
+object StatsDReporter {
+
+  def resource[F[_]: Sync](config: MetricsReporter.StatsD, registry: MetricRegistry): Resource[F, StatsDReporter] =
+    for {
+      client <- clientResource(config)
+      tags = (config.tags).toList.map { case (k, v) => s"$k:$v" }
+      reporter <- Resource.fromAutoCloseable(Sync[F].delay(new StatsDReporter(registry, client, tags)))
+    } yield reporter
+
+  private def clientResource[F[_]: Sync](config: MetricsReporter.StatsD): Resource[F, NonBlockingStatsDClient] =
+    Resource.fromAutoCloseable {
+      Sync[F]
+        .delay {
+          new NonBlockingStatsDClientBuilder()
+            .hostname(config.hostname)
+            .port(config.port)
+            .enableTelemetry(false)
+            .build
+        }
+    }
+
+}

--- a/modules/fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/fs2/config/ConfigFileSpec.scala
+++ b/modules/fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/fs2/config/ConfigFileSpec.scala
@@ -37,7 +37,7 @@ class ConfigFileSpec extends Specification with CatsIO {
         io.Output.PubSub("projects/test-project/topics/bad-topic"),
         Some(7.days),
         Some(Sentry(URI.create("http://sentry.acme.com"))),
-        Some(1.second)
+        Some(io.MetricsReporter.StatsD(1.second, "localhost", 8125, Map()))
       )
       ConfigFile.parse[IO](configPath.asRight).value.map(result => result must beRight(expected))
     }

--- a/modules/kinesis/src/main/scala/com.snowplowanalytics.snowplow.enrich.stream/sources/KinesisSource.scala
+++ b/modules/kinesis/src/main/scala/com.snowplowanalytics.snowplow.enrich.stream/sources/KinesisSource.scala
@@ -19,7 +19,7 @@
 package com.snowplowanalytics.snowplow.enrich.stream
 package sources
 
-import java.net.InetAddress
+import java.net.{InetAddress, URI}
 import java.util.{List, UUID}
 
 import scala.util.control.Breaks._
@@ -28,14 +28,28 @@ import scala.util.control.NonFatal
 
 import cats.Id
 import cats.syntax.either._
-import com.amazonaws.auth.AWSCredentialsProvider
-import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
-import com.amazonaws.services.kinesis.AmazonKinesisClientBuilder
-import com.amazonaws.services.kinesis.clientlibrary.interfaces._
-import com.amazonaws.services.kinesis.clientlibrary.exceptions._
-import com.amazonaws.services.kinesis.clientlibrary.lib.worker._
-import com.amazonaws.services.kinesis.model.Record
-import com.amazonaws.services.kinesis.metrics.impl.NullMetricsFactory
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
+import software.amazon.kinesis.common.{InitialPositionInStream, InitialPositionInStreamExtended}
+import software.amazon.kinesis.exceptions.ThrottlingException
+import software.amazon.kinesis.metrics.NullMetricsFactory
+import software.amazon.kinesis.processor.{RecordProcessorCheckpointer, ShardRecordProcessorFactory}
+import software.amazon.kinesis.retrieval.KinesisClientRecord
+import software.amazon.kinesis.retrieval.polling.PollingConfig
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient
+import software.amazon.awssdk.services.kinesis.KinesisAsyncClient
+import software.amazon.awssdk.regions.Region
+import software.amazon.kinesis.common.ConfigsBuilder
+import software.amazon.kinesis.common.KinesisClientUtil
+import software.amazon.kinesis.coordinator.Scheduler
+import software.amazon.kinesis.exceptions.InvalidStateException
+import software.amazon.kinesis.exceptions.ShutdownException
+import software.amazon.kinesis.lifecycle.events.InitializationInput
+import software.amazon.kinesis.lifecycle.events.LeaseLostInput
+import software.amazon.kinesis.lifecycle.events.ProcessRecordsInput
+import software.amazon.kinesis.lifecycle.events.ShardEndedInput
+import software.amazon.kinesis.lifecycle.events.ShutdownRequestedInput
+import software.amazon.kinesis.processor.ShardRecordProcessor
 import com.snowplowanalytics.iglu.client.Client
 import com.snowplowanalytics.snowplow.badrows.Processor
 import com.snowplowanalytics.snowplow.enrich.common.adapters.AdapterRegistry
@@ -45,7 +59,7 @@ import io.circe.Json
 
 import model.{Kinesis, SentryConfig, StreamsConfig}
 import sinks._
-import utils.getAWSCredentialsProvider
+import utils.getAwsCredentialsProvider
 
 /** KinesisSource companion object with factory method */
 object KinesisSource {
@@ -64,12 +78,14 @@ object KinesisSource {
                          case _ => "Configured source/sink is not Kinesis".asLeft
                        }
       emitPii = utils.emitPii(enrichmentRegistry)
-      _ <- KinesisSink.validate(kinesisConfig, config.out.enriched)
+      credentialsProvider <- getAwsCredentialsProvider(kinesisConfig.aws)
+      kClient = kinesisClient(credentialsProvider, kinesisConfig)
+      _ <- KinesisSink.validate(kClient, config.out.enriched)
       _ <- utils.validatePii(emitPii, config.out.pii)
-      _ <- KinesisSink.validate(kinesisConfig, config.out.bad)
-      provider <- getAWSCredentialsProvider(kinesisConfig.aws)
+      _ <- KinesisSink.validate(kClient, config.out.bad)
     } yield new KinesisSource(
       client,
+      kClient,
       adapterRegistry,
       enrichmentRegistry,
       tracker,
@@ -77,13 +93,23 @@ object KinesisSource {
       config,
       kinesisConfig,
       sentryConfig,
-      provider
+      credentialsProvider
+    )
+
+  private def kinesisClient(credentialsProvider: AwsCredentialsProvider, kinesisConfig: Kinesis): KinesisAsyncClient =
+    KinesisClientUtil.createKinesisAsyncClient(
+      KinesisAsyncClient
+        .builder()
+        .credentialsProvider(credentialsProvider)
+        .endpointOverride(new URI(kinesisConfig.streamEndpoint))
+        .region(Region.of(kinesisConfig.region))
     )
 }
 
 /** Source to read events from a Kinesis stream */
 class KinesisSource private (
   client: Client[Id, Json],
+  kinesisClient: KinesisAsyncClient,
   adapterRegistry: AdapterRegistry,
   enrichmentRegistry: EnrichmentRegistry[Id],
   tracker: Option[Tracker[Id]],
@@ -91,25 +117,17 @@ class KinesisSource private (
   config: StreamsConfig,
   kinesisConfig: Kinesis,
   sentryConfig: Option[SentryConfig],
-  provider: AWSCredentialsProvider
+  credentialsProvider: AwsCredentialsProvider
 ) extends Source(client, adapterRegistry, enrichmentRegistry, processor, config.out.partitionKey, sentryConfig) {
 
   override val MaxRecordSize = Some(1000000)
-
-  private val kClient = {
-    val endpointConfiguration =
-      new EndpointConfiguration(kinesisConfig.streamEndpoint, kinesisConfig.region)
-    AmazonKinesisClientBuilder
-      .standard()
-      .withCredentials(provider)
-      .withEndpointConfiguration(endpointConfiguration)
-      .build()
-  }
+  private val DYNAMODB_DEFAULT_INITIAL_RCU = 10
+  private val DYNAMODB_DEFAULT_INITIAL_WCU = 10
 
   override val threadLocalGoodSink: ThreadLocal[Sink] = new ThreadLocal[Sink] {
     override def initialValue: Sink =
       new KinesisSink(
-        kClient,
+        kinesisClient,
         kinesisConfig.backoffPolicy,
         config.buffer,
         config.out.enriched,
@@ -126,7 +144,7 @@ class KinesisSource private (
           new ThreadLocal[Sink] {
             override def initialValue: Sink =
               new KinesisSink(
-                kClient,
+                kinesisClient,
                 kinesisConfig.backoffPolicy,
                 config.buffer,
                 piiStreamName,
@@ -139,7 +157,7 @@ class KinesisSource private (
 
   override val threadLocalBadSink: ThreadLocal[Sink] = new ThreadLocal[Sink] {
     override def initialValue: Sink =
-      new KinesisSink(kClient, kinesisConfig.backoffPolicy, config.buffer, config.out.bad, tracker)
+      new KinesisSink(kinesisClient, kinesisConfig.backoffPolicy, config.buffer, config.out.bad, tracker)
   }
 
   /** Never-ending processing loop over source stream. */
@@ -147,78 +165,106 @@ class KinesisSource private (
     val workerId = InetAddress.getLocalHost().getCanonicalHostName() + ":" + UUID.randomUUID()
     log.info("Using workerId: " + workerId)
 
-    val kinesisClientLibConfiguration = {
-      val kclc = new KinesisClientLibConfiguration(
-        config.appName,
-        config.in.raw,
-        provider,
-        workerId
-      ).withKinesisEndpoint(kinesisConfig.streamEndpoint)
-        .withMaxRecords(kinesisConfig.maxRecords)
-        .withRegionName(kinesisConfig.region)
-        // If the record list is empty, we still check whether it is time to flush the buffer
-        .withCallProcessRecordsEvenForEmptyRecordList(true)
-        .withDynamoDBEndpoint(kinesisConfig.dynamodbEndpoint)
-
-      val position = InitialPositionInStream.valueOf(kinesisConfig.initialPosition)
-      kinesisConfig.timestamp.right.toOption
-        .filter(_ => position == InitialPositionInStream.AT_TIMESTAMP)
-        .map(kclc.withTimestampAtInitialPositionInStream(_))
-        .getOrElse(kclc.withInitialPositionInStream(position))
-    }
+    val dynamoClient = DynamoDbAsyncClient.builder
+      .credentialsProvider(credentialsProvider)
+      .endpointOverride(new URI(kinesisConfig.dynamodbEndpoint))
+      .region(Region.of(kinesisConfig.region))
+      .build
+    val cloudWatchClient = CloudWatchAsyncClient.builder
+      .credentialsProvider(credentialsProvider)
+      .region(Region.of(kinesisConfig.region))
+      .build
 
     log.info(s"Running: ${config.appName}.")
     log.info(s"Processing raw input stream: ${config.in.raw}")
 
     val rawEventProcessorFactory = new RawEventProcessorFactory()
-    val worker = kinesisConfig.disableCloudWatch match {
-      case Some(true) =>
-        new Worker.Builder()
-          .recordProcessorFactory(rawEventProcessorFactory)
-          .config(kinesisClientLibConfiguration)
-          .metricsFactory(new NullMetricsFactory())
-          .build()
-      case _ =>
-        new Worker.Builder()
-          .recordProcessorFactory(rawEventProcessorFactory)
-          .config(kinesisClientLibConfiguration)
-          .build()
+
+    val configsBuilder = new ConfigsBuilder(
+      config.in.raw,
+      config.appName,
+      kinesisClient,
+      dynamoClient,
+      cloudWatchClient,
+      workerId,
+      rawEventProcessorFactory
+    )
+
+    val positionValue = InitialPositionInStream.valueOf(kinesisConfig.initialPosition)
+    val position = kinesisConfig.timestamp.right.toOption
+      .filter(_ => positionValue == InitialPositionInStream.AT_TIMESTAMP)
+      .map(InitialPositionInStreamExtended.newInitialPositionAtTimestamp(_))
+      .getOrElse(InitialPositionInStreamExtended.newInitialPosition(positionValue))
+
+    val metricFactory = kinesisConfig.disableCloudWatch match {
+      case Some(true) => new NullMetricsFactory()
+      case _ => null // KCL internally creates it.
     }
 
-    worker.run()
+    //Enhanced fan-out is the default retrieval behavior for KCL 2.x. We need to override it if we want to use polling mode.
+    val retrievalConfig = kinesisConfig.maxRecords match {
+      case Some(maxRecordsCount) =>
+        configsBuilder
+          .retrievalConfig()
+          .retrievalSpecificConfig(
+            new PollingConfig(config.in.raw, kinesisClient).maxRecords(maxRecordsCount)
+          )
+      case None => configsBuilder.retrievalConfig()
+    }
+
+    val scheduler = new Scheduler(
+      configsBuilder.checkpointConfig(),
+      configsBuilder.coordinatorConfig(),
+      configsBuilder
+        .leaseManagementConfig()
+        .initialLeaseTableReadCapacity(
+          kinesisConfig.dynamodbInitialRCU.getOrElse(DYNAMODB_DEFAULT_INITIAL_RCU)
+        )
+        .initialLeaseTableWriteCapacity(
+          kinesisConfig.dynamodbInitialWCU.getOrElse(DYNAMODB_DEFAULT_INITIAL_WCU)
+        )
+        .initialPositionInStream(position),
+      configsBuilder.lifecycleConfig(),
+      configsBuilder.metricsConfig().metricsFactory(metricFactory),
+      configsBuilder.processorConfig().callProcessRecordsEvenForEmptyRecordList(true),
+      retrievalConfig
+    )
+
+    scheduler.run()
   }
 
   // Factory needed by the Amazon Kinesis Consumer library to
   // create a processor.
-  class RawEventProcessorFactory extends IRecordProcessorFactory {
-    override def createProcessor: IRecordProcessor = new RawEventProcessor()
+  class RawEventProcessorFactory extends ShardRecordProcessorFactory {
+    override def shardRecordProcessor: ShardRecordProcessor = new RawEventProcessor()
   }
 
   // Process events from a Kinesis stream.
-  class RawEventProcessor extends IRecordProcessor {
+  class RawEventProcessor extends ShardRecordProcessor {
     private var kinesisShardId: String = _
 
     // Backoff and retry settings.
+    // make these configurations with default values.
     private val BACKOFF_TIME_IN_MILLIS = 3000L
     private val NUM_RETRIES = 10
 
-    override def initialize(shardId: String) = {
-      log.info("Initializing record processor for shard: " + shardId)
-      this.kinesisShardId = shardId
+    override def initialize(initializationInput: InitializationInput) = {
+      log.info(s"Initializing record processor for shard: ${initializationInput.shardId()}")
+      this.kinesisShardId = initializationInput.shardId()
     }
 
-    override def processRecords(records: List[Record], checkpointer: IRecordProcessorCheckpointer) = {
+    override def processRecords(processRecordsInput: ProcessRecordsInput) = {
 
-      if (!records.isEmpty)
-        log.info(s"Processing ${records.size} records from $kinesisShardId")
-      val shouldCheckpoint = processRecordsWithRetries(records)
+      if (!processRecordsInput.records().isEmpty)
+        log.info(s"Processing ${processRecordsInput.records().size()} records from $kinesisShardId")
+      val shouldCheckpoint = processRecordsWithRetries(processRecordsInput.records())
 
       if (shouldCheckpoint)
-        checkpoint(checkpointer)
+        checkpoint(processRecordsInput.checkpointer())
     }
 
-    private def processRecordsWithRetries(records: List[Record]): Boolean =
-      try enrichAndStoreEvents(records.asScala.map(_.getData.array).toList)
+    private def processRecordsWithRetries(records: List[KinesisClientRecord]): Boolean =
+      try enrichAndStoreEvents(records.asScala.map(_.data().array).toList)
       catch {
         case NonFatal(e) =>
           // TODO: send an event when something goes wrong here
@@ -226,13 +272,33 @@ class KinesisSource private (
           false
       }
 
-    override def shutdown(checkpointer: IRecordProcessorCheckpointer, reason: ShutdownReason) = {
-      log.info(s"Shutting down record processor for shard: $kinesisShardId")
-      if (reason == ShutdownReason.TERMINATE)
-        checkpoint(checkpointer)
-    }
+    def leaseLost(leaseLostInput: LeaseLostInput) =
+      // do nothing, the new shard processor will take care of it.
+      log.info(s"Lease lost  ${leaseLostInput}")
 
-    private def checkpoint(checkpointer: IRecordProcessorCheckpointer) = {
+    def shardEnded(shardEndedInput: ShardEndedInput) =
+      try {
+        log.info(s"Shard ended for shard: $kinesisShardId")
+        shardEndedInput.checkpointer().checkpoint()
+      } catch {
+        case e: ShutdownException =>
+          log.error(s"Caught ShutdownException for endedShard ", e)
+        case e: InvalidStateException =>
+          log.error(s"Caught InvalidStateException for endedShard ", e)
+      }
+
+    def shutdownRequested(shutdownRequestedInput: ShutdownRequestedInput) =
+      try {
+        log.info(s"Shutting down record processor for shard: $kinesisShardId")
+        shutdownRequestedInput.checkpointer().checkpoint()
+      } catch {
+        case e: ShutdownException =>
+          log.error(s"Caught ShutdownException for shutdownRequestedInput", e)
+        case e: InvalidStateException =>
+          log.error(s"Caught InvalidStateException for shutdownRequestedInput", e)
+      }
+
+    private def checkpoint(checkpointer: RecordProcessorCheckpointer) = {
       log.info(s"Checkpointing shard $kinesisShardId")
       breakable {
         for (i <- 0 to NUM_RETRIES - 1) {

--- a/modules/stream/src/main/scala/com.snowplowanalytics.snowplow.enrich.stream/model.scala
+++ b/modules/stream/src/main/scala/com.snowplowanalytics.snowplow.enrich.stream/model.scala
@@ -96,12 +96,14 @@ object model {
     aws: AWSCredentials,
     gcp: Option[GCPCredentials],
     region: String,
-    maxRecords: Int,
+    maxRecords: Option[Int],
     initialPosition: String,
     initialTimestamp: Option[String],
     backoffPolicy: KinesisBackoffPolicyConfig,
     customEndpoint: Option[String],
     dynamodbCustomEndpoint: Option[String],
+    dynamodbInitialRCU: Option[Int],
+    dynamodbInitialWCU: Option[Int],
     disableCloudWatch: Option[Boolean]
   ) extends AWSNativePlatformConfig {
     val timestamp = initialTimestamp

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -107,6 +107,11 @@ object BuildSettings {
       case x if x.endsWith("public-suffix-list.txt") => MergeStrategy.first
       case x if x.endsWith("ProjectSettings$.class") => MergeStrategy.first
       case x if x.endsWith("module-info.class") => MergeStrategy.first
+      // Below are AWS SDK v2 configuration files - can be discarded
+      case PathList(ps@_*) if Set("codegen.config" , "service-2.json" , "waiters-2.json" ,
+        "customization.config" , "examples-1.json" , "paginators-1.json", "mime.types", "io.netty.versions.properties")
+        .contains(ps.last) =>
+        MergeStrategy.discard
       case x =>
         val oldStrategy = (assemblyMergeStrategy in assembly).value
         oldStrategy(x)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -38,7 +38,7 @@ object Dependencies {
     val mysqlConnector   = "8.0.16"
     val jaywayJsonpath   = "2.4.0"
     val iabClient        = "0.2.0"
-    val yauaa            = "5.19"
+    val yauaa            = "5.23"
     val guava            = "28.1-jre"
     val slf4j            = "1.7.26"
     val log4j            = "2.13.3"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -77,6 +77,7 @@ object Dependencies {
     val log4cats         = "1.1.1"
     val catsRetry        = "1.1.1"
     val metrics          = "4.1.12.1"
+    val dogStatsD        = "2.11.0"
 
     val scopt            = "3.7.1"
     val pureconfig       = "0.11.0"
@@ -180,6 +181,7 @@ object Dependencies {
     val pureconfigCats   = "com.github.pureconfig"            %% "pureconfig-cats-effect"            % V.pureconfig
     val pureconfigCirce  = "com.github.pureconfig"            %% "pureconfig-circe"                  % V.pureconfig
     val metrics          = "io.dropwizard.metrics"            %  "metrics-core"                      % V.metrics
+    val dogStatsD        = "com.datadoghq"                    %  "java-dogstatsd-client"             % V.dogStatsD
     val http4sDsl        = "org.http4s"                       %% "http4s-dsl"                        % V.http4s          % Test
     val http4sServer     = "org.http4s"                       %% "http4s-blaze-server"               % V.http4s          % Test
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -60,9 +60,9 @@ object Dependencies {
     val collectorPayload = "0.0.0"
     val schemaSniffer    = "0.0.0"
 
-    val awsSdk           = "1.11.728"
+    val awsSdk           = "2.16.21"
     val gcpSdk           = "1.106.0"
-    val kinesisClient    = "1.13.3"
+    val kinesisClient    = "2.3.4"
     val kafka            = "2.2.1"
     val nsqClient        = "1.2.0"
     val jackson          = "2.10.5"
@@ -149,10 +149,10 @@ object Dependencies {
     val scalaTest        = "org.scalatest"              %% "scalatest"                                % V.scalaTest       % Test
 
     // Stream
-    val kinesisSdk       = "com.amazonaws"                    %  "aws-java-sdk-kinesis"              % V.awsSdk
-    val dynamodbSdk      = "com.amazonaws"                    %  "aws-java-sdk-dynamodb"             % V.awsSdk
-    val s3Sdk            = "com.amazonaws"                    %  "aws-java-sdk-s3"                   % V.awsSdk
-    val kinesisClient    = "com.amazonaws"                    %  "amazon-kinesis-client"             % V.kinesisClient
+    val authSdk          = "software.amazon.awssdk"           %  "auth"                              % V.awsSdk
+    val dynamodbSdk      = "software.amazon.awssdk"           %  "dynamodb"                          % V.awsSdk
+    val s3Sdk            = "software.amazon.awssdk"           %  "s3"                                % V.awsSdk
+    val kinesisClient    = "software.amazon.kinesis"          %  "amazon-kinesis-client"             % V.kinesisClient
     val gsSdk            = "com.google.cloud"                 %  "google-cloud-storage"              % V.gcpSdk
     val kafkaClients     = "org.apache.kafka"                 %  "kafka-clients"                     % V.kafka
     val jacksonCbor      = "com.fasterxml.jackson.dataformat" %  "jackson-dataformat-cbor"           % V.jackson


### PR DESCRIPTION
<!--
Thank you for contributing to Snowplow Enrich!

You'll find a small checklist below which should help speed up the review process:

- [ ] Have you signed the [contributor license agreement](https://github.com/snowplow/snowplow/wiki/CLA)?
- [ ] Have you read the [contributing guide](https://github.com/snowplow/enrich/blob/master/CONTRIBUTING.md)?
- [ ] Have you added the appropriate unit tests?
- [ ] Have you run the tests through `sbt test`?
- [ ] Is your pull request against the `master` branch?
-->

This adds a custom dropwizard reporter -- which actually has more functionality that what is needed for Enrich! (e.g. histograms, timers).  But we could re-use the reporter for other apps, where we may need the extra functionality.  The new reporter is backed by the [dogstatsd client](https://github.com/DataDog/java-dogstatsd-client), which is non-blocking and runs on a dedicated thread.

There are some features I considered adding, but chose not to yet:
- Option to have both statsd and stdout reporters both running at the same time.
- Option to filter out some metrics from the reporter
- Option to configure the time unit of the metrics (seconds vs millis)

I also chose *not* to generate a random UUID to be a `worker_id` tag on the metrics.  I believe it is possible to add worker identifiers through configuration at run time.  For example, in a Kubernetes environment we can add the pod_name, which uniquely identifies the worker:
```
tags = {
  pod_name = ${HOSTNAME}
}
```