### PR TITLE
Stream FS2: Add sink for Pii Events (close #416)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -74,6 +74,7 @@ lazy val allStreamSettings = BuildSettings.basicSettings ++ BuildSettings.sbtAss
     Dependencies.Libraries.sentry,
     Dependencies.Libraries.slf4j,
     Dependencies.Libraries.log4jOverSlf4j,
+    Dependencies.Libraries.authSdk,
     Dependencies.Libraries.s3Sdk,
     Dependencies.Libraries.gsSdk,
     Dependencies.Libraries.scopt,
@@ -103,7 +104,6 @@ lazy val kinesis = project
   .settings(packageName in Docker := "snowplow/stream-enrich-kinesis")
   .settings(libraryDependencies ++= Seq(
     Dependencies.Libraries.kinesisClient,
-    Dependencies.Libraries.kinesisSdk,
     Dependencies.Libraries.dynamodbSdk,
     Dependencies.Libraries.jacksonCbor
   ))

--- a/config/config.fs2.hocon.sample
+++ b/config/config.fs2.hocon.sample
@@ -23,6 +23,16 @@ good = {
   // dir = "/var/enriched"
 }
 
+// Pii events output
+pii = {
+  type = "PubSub"
+  topic = "projects/test-project/topics/pii-topic"
+
+  // Local FS supported for testing purposes
+  // type = "FileSystem"
+  // dir = "/var/pii"
+}
+
 // Bad rows output
 bad = {
   type = "PubSub"

--- a/config/config.hocon.sample
+++ b/config/config.hocon.sample
@@ -74,6 +74,10 @@ enrich {
       # dynamodbCustomEndpoint = "http://localhost:4569"
       # dynamodbCustomEndpoint = ${?ENRICH_DYNAMODB_CUSTOM_ENDPOINT}
 
+      # Initial RCU/WCU are optional. These are the settings for Dynamodb lease table throughput initialization
+      # dynamodbInitialRCU = "{{leastTableInitialRCU}}"
+      # dynamodbInitialWCU = "{{leastTableInitialWCU}}"
+
       # Optional override to disable cloudwatch
       # disableCloudWatch = true
       # disableCloudWatch = ${?ENRICH_DISABLE_CLOUDWATCH}
@@ -96,7 +100,8 @@ enrich {
       #   creds = ${?GOOGLE_APPLICATION_CREDENTIALS}
       # }
 
-      # Maximum number of records to get from Kinesis per call to GetRecords
+      # If maxRecords is specified, KCL will use polling mode (shared read throughput) and will get max maxRecords from Kinesis per call to GetRecords.
+      # If not specified, KCL will use enhanced fan out (dedicated read throughput).
       # maxRecords = 10000
       # maxRecords = ${?ENRICH_MAX_RECORDS}
 

--- a/modules/beam/src/main/scala/com.snowplowanalytics.snowplow.enrich.beam/Enrich.scala
+++ b/modules/beam/src/main/scala/com.snowplowanalytics.snowplow.enrich.beam/Enrich.scala
@@ -216,7 +216,7 @@ object Enrich {
         if (metrics)
           getEnrichedEventMetrics(enrichedEvent).foreach(metric => ScioMetrics.counter(MetricsNamespace, metric).inc())
         else ()
-        val formattedEnrichedEvent = tabSeparatedEnrichedEvent(enrichedEvent)
+        val formattedEnrichedEvent = ConversionUtils.tabSeparatedEnrichedEvent(enrichedEvent)
         val size = getSize(formattedEnrichedEvent)
         if (metrics) enrichedEventSizeDistribution.update(size.toLong) else ()
         (formattedEnrichedEvent, size)
@@ -242,7 +242,7 @@ object Enrich {
         .map { enrichedEvent =>
           ConversionUtils
             .getPiiEvent(processor, enrichedEvent)
-            .map(tabSeparatedEnrichedEvent)
+            .map(ConversionUtils.tabSeparatedEnrichedEvent)
             .map(formatted => (formatted, getSize(formatted)))
         }
         .withName("flatten-pii-events")

--- a/modules/beam/src/main/scala/com.snowplowanalytics.snowplow.enrich.beam/Enrich.scala
+++ b/modules/beam/src/main/scala/com.snowplowanalytics.snowplow.enrich.beam/Enrich.scala
@@ -32,6 +32,7 @@ import com.snowplowanalytics.snowplow.enrich.common.enrichments.EnrichmentRegist
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf
 import com.snowplowanalytics.snowplow.enrich.common.loaders.ThriftLoader
 import com.snowplowanalytics.snowplow.enrich.common.outputs.EnrichedEvent
+import com.snowplowanalytics.snowplow.enrich.common.utils.ConversionUtils
 
 import com.spotify.scio._
 import com.spotify.scio.coders.Coder
@@ -239,7 +240,8 @@ object Enrich {
       val (tooBigPiis, properlySizedPiis) = enriched
         .withName("generate-pii-events")
         .map { enrichedEvent =>
-          getPiiEvent(enrichedEvent)
+          ConversionUtils
+            .getPiiEvent(processor, enrichedEvent)
             .map(tabSeparatedEnrichedEvent)
             .map(formatted => (formatted, getSize(formatted)))
         }

--- a/modules/beam/src/main/scala/com.snowplowanalytics.snowplow.enrich.beam/utils.scala
+++ b/modules/beam/src/main/scala/com.snowplowanalytics.snowplow.enrich.beam/utils.scala
@@ -33,16 +33,6 @@ import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.Enrichm
 
 object utils {
 
-  /** Format an [[EnrichedEvent]] as a TSV. */
-  def tabSeparatedEnrichedEvent(enrichedEvent: EnrichedEvent): String =
-    enrichedEvent.getClass.getDeclaredFields
-      .filterNot(_.getName.equals("pii"))
-      .map { field =>
-        field.setAccessible(true)
-        Option(field.get(enrichedEvent)).getOrElse("")
-      }
-      .mkString("\t")
-
   /** Determine if we have to emit pii transformation events. */
   def emitPii(confs: List[EnrichmentConf]): Boolean =
     confs

--- a/modules/beam/src/test/scala/com.snowplowanalytics.snowplow.enrich.beam/UtilsSpec.scala
+++ b/modules/beam/src/test/scala/com.snowplowanalytics.snowplow.enrich.beam/UtilsSpec.scala
@@ -150,34 +150,6 @@ class UtilsSpec extends AnyFreeSpec with Matchers {
         tabSeparatedEnrichedEvent(event) should not include "pii"
       }
     }
-    "make a getPii function available" - {
-      "which return None if the pii field is null" in {
-        val event = {
-          val e = new EnrichedEvent
-          e.platform = "web"
-          e
-        }
-        getPiiEvent(event) shouldEqual None
-      }
-      "which return a new event if the pii field is present" in {
-        val event = {
-          val e = new EnrichedEvent
-          e.pii = "pii"
-          e.event_id = "id"
-          e
-        }
-        val Some(e) = getPiiEvent(event)
-        e.unstruct_event shouldEqual "pii"
-        e.platform shouldEqual "srv"
-        e.event shouldEqual "pii_transformation"
-        e.event_vendor shouldEqual "com.snowplowanalytics.snowplow"
-        e.event_format shouldEqual "jsonschema"
-        e.event_name shouldEqual "pii_transformation"
-        e.event_version shouldEqual "1-0-0"
-        e.contexts should include
-        """{"schema":"iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-0","data":[{"schema":"iglu:com.snowplowanalytics.snowplow/parent_event/jsonschema/1-0-0","data":{"parentEventId":"""
-      }
-    }
   }
 
   def parseBadRow(jsonStr: String): Either[String, BadRow] =

--- a/modules/beam/src/test/scala/com.snowplowanalytics.snowplow.enrich.beam/UtilsSpec.scala
+++ b/modules/beam/src/test/scala/com.snowplowanalytics.snowplow.enrich.beam/UtilsSpec.scala
@@ -131,25 +131,6 @@ class UtilsSpec extends AnyFreeSpec with Matchers {
         badRowSizeViolation.processor shouldEqual processor
       }
     }
-    "make a tabSeparatedEnrichedEvent function available" - {
-      "which tsv format an enriched event" in {
-        val event = {
-          val e = new EnrichedEvent
-          e.platform = "web"
-          e
-        }
-        tabSeparatedEnrichedEvent(event) should include("web")
-      }
-      "which filter the pii field" in {
-        val event = {
-          val e = new EnrichedEvent
-          e.platform = "web"
-          e.pii = "pii"
-          e
-        }
-        tabSeparatedEnrichedEvent(event) should not include "pii"
-      }
-    }
   }
 
   def parseBadRow(jsonStr: String): Either[String, BadRow] =

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/utils/conversionUtilsSpecs.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/utils/conversionUtilsSpecs.scala
@@ -554,3 +554,26 @@ class GetPiiEventSpec extends MSpecification {
     }
   }
 }
+
+class TabSeparatedEnrichedEventSpec extends MSpecification {
+
+  "make a tabSeparatedEnrichedEvent function available" >> {
+    "which tsv format an enriched event" >> {
+      val event = {
+        val e = new EnrichedEvent
+        e.platform = "web"
+        e
+      }
+      ConversionUtils.tabSeparatedEnrichedEvent(event) must contain("web")
+    }
+    "which filter the pii field" in {
+      val event = {
+        val e = new EnrichedEvent
+        e.platform = "web"
+        e.pii = "pii"
+        e
+      }
+      ConversionUtils.tabSeparatedEnrichedEvent(event) must not(contain("pii"))
+    }
+  }
+}

--- a/modules/fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/fs2/Enrich.scala
+++ b/modules/fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/fs2/Enrich.scala
@@ -17,12 +17,13 @@ import java.util.Base64
 import java.util.concurrent.TimeUnit
 
 import org.joda.time.DateTime
-import cats.data.{NonEmptyList, ValidatedNel}
+import cats.data.{NonEmptyList, Validated, ValidatedNel}
+import cats.Applicative
 import cats.implicits._
 
 import cats.effect.{Blocker, Clock, Concurrent, ContextShift, Sync}
 
-import fs2.Stream
+import fs2.{Pipe, Stream}
 
 import _root_.io.sentry.SentryClient
 import _root_.io.circe.Json
@@ -38,6 +39,7 @@ import com.snowplowanalytics.snowplow.enrich.common.outputs.EnrichedEvent
 import com.snowplowanalytics.snowplow.enrich.common.adapters.AdapterRegistry
 import com.snowplowanalytics.snowplow.enrich.common.loaders.{CollectorPayload, ThriftLoader}
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.EnrichmentRegistry
+import com.snowplowanalytics.snowplow.enrich.common.utils.ConversionUtils
 
 object Enrich {
 
@@ -69,17 +71,39 @@ object Enrich {
   def run[F[_]: Concurrent: ContextShift: Clock](env: Environment[F]): Stream[F, Unit] = {
     val registry: F[EnrichmentRegistry[F]] = env.enrichments.get.map(_.registry)
     val enrich: Enrich[F] = enrichWith[F](registry, env.blocker, env.igluClient, env.sentry, env.metrics.enrichLatency)
-    val badSink: BadSink[F] = _.evalTap(_ => env.metrics.badCount).through(env.bad)
-    val goodSink: GoodSink[F] = _.evalTap(_ => env.metrics.goodCount).through(env.good)
 
     env.source
       .pauseWhen(env.pauseEnrich)
       .evalTap(_ => env.metrics.rawCount)
       .parEvalMapUnordered(ConcurrencyLevel)(enrich)
-      .flatMap(_.decompose[BadRow, EnrichedEvent])
-      .observeEither(badSink, goodSink)
-      .void
+      .through(Payload.sink(resultSink(env)))
   }
+
+  def resultSink[F[_]: Concurrent](env: Environment[F]): Pipe[F, List[Validated[BadRow, EnrichedEvent]], Nothing] =
+    _.flatMap(Stream.emits(_))
+      .flatMap(toOutputs)
+      .observe(Output.sink(badSink(env), goodSink(env), piiSink(env)))
+      .drain
+
+  def badSink[F[_]: Applicative](env: Environment[F]): BadSink[F] =
+    _.evalTap(_ => env.metrics.badCount)
+      .through(env.bad)
+
+  def goodSink[F[_]: Applicative](env: Environment[F]): GoodSink[F] =
+    _.evalTap(_ => env.metrics.goodCount)
+      .through(env.good)
+
+  def piiSink[F[_]: Applicative](env: Environment[F]): GoodSink[F] =
+    _.through(env.pii)
+
+  def toOutputs[F[_]](result: Validated[BadRow, EnrichedEvent]): Stream[F, Output] =
+    result match {
+      case Validated.Valid(ee) =>
+        val toEmit = List(Output.Good(ee)) ++ ConversionUtils.getPiiEvent(processor, ee).map(Output.Pii(_))
+        Stream.emits(toEmit)
+      case Validated.Invalid(bad) =>
+        Stream.emit(Output.Bad(bad))
+    }
 
   /**
    * Enrich a single `CollectorPayload` to get list of bad rows and/or enriched events

--- a/modules/fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/fs2/Environment.scala
+++ b/modules/fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/fs2/Environment.scala
@@ -54,6 +54,7 @@ import com.snowplowanalytics.snowplow.enrich.fs2.io.{FileSystem, Metrics, Sinks,
  * @param blocker             thread pool for blocking operations and enrichments themselves
  * @param source              a stream of raw collector payloads
  * @param good                a sink for successfully enriched events
+ * @param pii                 a sink for pii enriched events
  * @param bad                 a sink for events that failed validation or enrichment
  * @param sentry              optional sentry client
  * @param metrics             common counters
@@ -68,6 +69,7 @@ final case class Environment[F[_]](
   blocker: Blocker,
   source: RawSource[F],
   good: GoodSink[F],
+  pii: GoodSink[F],
   bad: BadSink[F],
   sentry: Option[SentryClient],
   metrics: Metrics[F],
@@ -122,6 +124,7 @@ object Environment {
         metrics <- Metrics.resource[F]
         rawSource = Source.read[F](blocker, file.auth, file.input)
         goodSink <- Sinks.goodSink[F](blocker, file.auth, file.good)
+        piiSink <- file.pii.map(f => Sinks.goodSink[F](blocker, file.auth, f)).sequence
         badSink <- Sinks.badSink[F](blocker, file.auth, file.bad)
         assets = parsedConfigs.enrichmentConfigs.flatMap(_.filesToCache)
         pauseEnrich <- makePause[F]
@@ -132,18 +135,20 @@ object Environment {
                     case None => Resource.pure[F, Option[SentryClient]](none[SentryClient])
                   }
         _ <- Resource.liftF(pauseEnrich.set(false) *> Logger[F].info("Enrich environment initialized"))
-      } yield Environment[F](client,
-                             enrichments,
-                             pauseEnrich,
-                             assets,
-                             blocker,
-                             rawSource,
-                             goodSink,
-                             badSink,
-                             sentry,
-                             metrics,
-                             file.assetsUpdatePeriod,
-                             file.metricsReportPeriod
+      } yield Environment[F](
+        client,
+        enrichments,
+        pauseEnrich,
+        assets,
+        blocker,
+        rawSource,
+        goodSink,
+        piiSink.getOrElse(_.drain),
+        badSink,
+        sentry,
+        metrics,
+        file.assetsUpdatePeriod,
+        file.metricsReportPeriod
       )
     }
 

--- a/modules/fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/fs2/Environment.scala
+++ b/modules/fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/fs2/Environment.scala
@@ -68,9 +68,9 @@ final case class Environment[F[_]](
   assetsState: Assets.State[F],
   blocker: Blocker,
   source: RawSource[F],
-  good: GoodSink[F],
-  pii: GoodSink[F],
-  bad: BadSink[F],
+  good: ByteSink[F],
+  pii: ByteSink[F],
+  bad: ByteSink[F],
   sentry: Option[SentryClient],
   metrics: Metrics[F],
   assetsUpdatePeriod: Option[FiniteDuration],
@@ -123,9 +123,9 @@ object Environment {
         blocker <- Blocker[F]
         metrics <- Metrics.resource[F]
         rawSource = Source.read[F](blocker, file.auth, file.input)
-        goodSink <- Sinks.goodSink[F](blocker, file.auth, file.good)
-        piiSink <- file.pii.map(f => Sinks.goodSink[F](blocker, file.auth, f)).sequence
-        badSink <- Sinks.badSink[F](blocker, file.auth, file.bad)
+        goodSink <- Sinks.sink[F](blocker, file.auth, file.good)
+        piiSink <- file.pii.map(f => Sinks.sink[F](blocker, file.auth, f)).sequence
+        badSink <- Sinks.sink[F](blocker, file.auth, file.bad)
         assets = parsedConfigs.enrichmentConfigs.flatMap(_.filesToCache)
         pauseEnrich <- makePause[F]
         assets <- Assets.State.make[F](blocker, pauseEnrich, assets)

--- a/modules/fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/fs2/Output.scala
+++ b/modules/fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/fs2/Output.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.enrich.fs2
+
+import cats.effect.Concurrent
+import fs2.Pipe
+
+import com.snowplowanalytics.snowplow.badrows.BadRow
+import com.snowplowanalytics.snowplow.enrich.common.outputs.EnrichedEvent
+
+/** Represents the three different outputs of enrichment that should be delivered to three different sinks */
+sealed trait Output
+
+object Output {
+
+  case class Bad(badRow: BadRow) extends Output
+  case class Good(event: EnrichedEvent) extends Output
+  case class Pii(event: EnrichedEvent) extends Output
+
+  /** A variant of fs2's observeEither, sinking three output types into three Pipe's */
+  def sink[F[_]: Concurrent](
+    bad: Pipe[F, BadRow, Unit],
+    good: Pipe[F, EnrichedEvent, Unit],
+    pii: Pipe[F, EnrichedEvent, Unit]
+  ): Pipe[F, Output, Unit] =
+    _.observe(_.collect { case Bad(br) => br }.through(bad))
+      .observe(_.collect { case Good(event) => event }.through(good))
+      .observe(_.collect { case Pii(event) => event }.through(pii))
+      .drain
+
+}

--- a/modules/fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/fs2/config/ConfigFile.scala
+++ b/modules/fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/fs2/config/ConfigFile.scala
@@ -35,6 +35,7 @@ import pureconfig.module.circe._
  * @param auth authentication details, such as credentials
  * @param input input (PubSub, Kinesis etc)
  * @param good good enriched output (PubSub, Kinesis, FS etc)
+ * @param pii pii enriched output (PubSub, Kinesis, FS etc)
  * @param bad bad rows output (PubSub, Kinesis, FS etc)
  * @param assetsUpdatePeriod time after which assets should be updated, in minutes
  */
@@ -42,6 +43,7 @@ final case class ConfigFile(
   auth: Authentication,
   input: Input,
   good: Output,
+  pii: Option[Output],
   bad: Output,
   assetsUpdatePeriod: Option[FiniteDuration],
   sentry: Option[Sentry],
@@ -56,9 +58,9 @@ object ConfigFile {
 
   implicit val configFileDecoder: Decoder[ConfigFile] =
     deriveConfiguredDecoder[ConfigFile].emap {
-      case ConfigFile(_, _, _, _, Some(aup), _, _) if aup._1 <= 0L =>
+      case ConfigFile(_, _, _, _, _, Some(aup), _, _) if aup._1 <= 0L =>
         "assetsUpdatePeriod in config file cannot be less than 0".asLeft // TODO: use newtype
-      case ConfigFile(_, _, _, _, _, _, Some(mrp)) if mrp._1 <= 0L =>
+      case ConfigFile(_, _, _, _, _, _, _, Some(mrp)) if mrp._1 <= 0L =>
         "metricsReportPeriod in config file cannot be less than 0".asLeft
       case other => other.asRight
     }

--- a/modules/fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/fs2/io/package.scala
+++ b/modules/fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/fs2/io/package.scala
@@ -5,22 +5,12 @@ import cats.syntax.either._
 import com.permutive.pubsub.consumer.decoder.MessageDecoder
 import com.permutive.pubsub.producer.encoder.MessageEncoder
 
-import com.snowplowanalytics.snowplow.badrows.BadRow
-
-import com.snowplowanalytics.snowplow.enrich.common.outputs.EnrichedEvent
-
 package object io {
 
-  implicit val badRowEncoder: MessageEncoder[BadRow] =
-    new MessageEncoder[BadRow] {
-      def encode(a: BadRow): Either[Throwable, Array[Byte]] =
-        a.compact.getBytes.asRight
-    }
-
-  implicit val enrichedEventEncoder: MessageEncoder[EnrichedEvent] =
-    new MessageEncoder[EnrichedEvent] {
-      def encode(enrichedEvent: EnrichedEvent): Either[Throwable, Array[Byte]] =
-        Enrich.encodeEvent(enrichedEvent).getBytes.asRight
+  implicit val byteArrayEncoder: MessageEncoder[Array[Byte]] =
+    new MessageEncoder[Array[Byte]] {
+      def encode(a: Array[Byte]): Either[Throwable, Array[Byte]] =
+        a.asRight
     }
 
   implicit val byteArrayMessageDecoder: MessageDecoder[Array[Byte]] =

--- a/modules/fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/fs2/package.scala
+++ b/modules/fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/fs2/package.scala
@@ -25,8 +25,7 @@ package object fs2 {
   /** Raw Thrift payloads coming from a collector */
   type RawSource[F[_]] = Stream[F, Payload[F, Array[Byte]]]
 
-  type BadSink[F[_]] = Pipe[F, BadRow, Unit]
-  type GoodSink[F[_]] = Pipe[F, EnrichedEvent, Unit]
+  type ByteSink[F[_]] = Pipe[F, Array[Byte], Unit]
 
   /** Enrichment result, containing list of (valid and invalid) results */
   type Result[F[_]] = Payload[F, List[Validated[BadRow, EnrichedEvent]]]

--- a/modules/fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/fs2/package.scala
+++ b/modules/fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/fs2/package.scala
@@ -25,8 +25,8 @@ package object fs2 {
   /** Raw Thrift payloads coming from a collector */
   type RawSource[F[_]] = Stream[F, Payload[F, Array[Byte]]]
 
-  type BadSink[F[_]] = Pipe[F, Payload[F, BadRow], Unit]
-  type GoodSink[F[_]] = Pipe[F, Payload[F, EnrichedEvent], Unit]
+  type BadSink[F[_]] = Pipe[F, BadRow, Unit]
+  type GoodSink[F[_]] = Pipe[F, EnrichedEvent, Unit]
 
   /** Enrichment result, containing list of (valid and invalid) results */
   type Result[F[_]] = Payload[F, List[Validated[BadRow, EnrichedEvent]]]

--- a/modules/fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/fs2/PayloadSpec.scala
+++ b/modules/fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/fs2/PayloadSpec.scala
@@ -12,77 +12,35 @@
  */
 package com.snowplowanalytics.snowplow.enrich.fs2
 
-import cats.implicits._
-
 import cats.effect.IO
+import cats.implicits._
 import cats.effect.concurrent.Ref
 import cats.effect.testing.specs2.CatsIO
+import fs2.Stream
 
 import org.specs2.ScalaCheck
 import org.specs2.mutable.Specification
 
 class PayloadSpec extends Specification with CatsIO with ScalaCheck {
-  "mapWithLast" should {
-    "always apply a lastF function to the last element" in {
-      prop { (list: List[String]) =>
-        val lastF: String => String = _ => "unique"
-        val result = Payload.mapWithLast(identity[String], lastF)(list).toList
-        result.lastOption must (beSome("unique") or beNone)
-      }
-    }
 
-    "always apply an f function to all elements except last" in {
-      prop { (list: List[String]) =>
-        val f: String => String = _ => "unique"
-        val result = Payload.mapWithLast(f, identity[String])(list).toList
-        list match {
-          case Nil => ok
-          case _ =>
-            val init = List.fill(list.length - 1)("unique")
-            result.mkString("-") must startWith(init.mkString("-"))
-        }
-      }
-    }
-  }
-
-  "decompose" should {
-    "preserve the order" in {
-      val input = List("error-1".invalid, 42.valid, "error-2".invalid)
-      val payload = Payload(input, IO.unit)
-      payload.decompose[String, Int].compile.toList.map {
-        case List(error1, valid, error2) =>
-          error1 must beLeft.like {
-            case Payload(data, _) => data must be("error-1")
-          }
-          valid must beRight.like {
-            case Payload(data, _) => data must beEqualTo(42)
-          }
-          error2 must beLeft.like {
-            case Payload(data, _) => data must be("error-2")
-          }
-        case other =>
-          ko(s"Expected list of 3, got $other")
-      }
-    }
-
+  "sink" should {
     "execute finalize action only once" in {
-      val input = List("error-1".invalid, 42.valid, "error-2".invalid)
+      val input = List(1, 2, 3)
+      val pipe = { (s: Stream[IO, List[Int]]) => s.flatMap(Stream.emits(_)).drain }
       for {
         ref <- Ref.of[IO, Int](0)
         payload = Payload(input, ref.update(_ + 1))
-        parsed <- payload.decompose[String, Int].compile.toList
-        _ <- parsed.traverse_(_.fold(_.finalise, _.finalise))
+        _ <- Stream.emit(payload).through(Payload.sink(pipe)).compile.drain
         result <- ref.get
       } yield result must beEqualTo(1)
     }
 
-    "not execute finalize action until last element" in {
-      val input = List("error-1".invalid, 42.valid, "error-2".invalid)
+    "not execute finalize action when an error occurs" in {
+      val pipe = { (s: Stream[IO, Int]) => s.evalMap(_ => IO.raiseError(new RuntimeException("boom!"))) }
       for {
         ref <- Ref.of[IO, Int](0)
-        payload = Payload(input, ref.update(_ + 1))
-        parsed <- payload.decompose[String, Int].compile.toList
-        _ <- parsed.init.traverse_(_.fold(_.finalise, _.finalise))
+        payload = Payload(1, ref.update(_ + 1))
+        _ <- Stream.emit(payload).through(Payload.sink(pipe)).compile.drain.handleError(_ => ())
         result <- ref.get
       } yield result must beEqualTo(0)
     }

--- a/modules/fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/fs2/config/CliConfigSpec.scala
+++ b/modules/fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/fs2/config/CliConfigSpec.scala
@@ -48,6 +48,10 @@ class CliConfigSpec extends Specification with CatsIO {
              type = "PubSub"
              topic = "projects/test-project/topics/good-topic"
            }
+           pii = {
+             type = "PubSub"
+             topic = "projects/test-project/topics/pii-topic"
+           }
            bad = {
              type = "PubSub"
              topic = "projects/test-project/topics/bad-topic"
@@ -59,6 +63,7 @@ class CliConfigSpec extends Specification with CatsIO {
         io.Authentication.Gcp,
         io.Input.PubSub("projects/test-project/subscriptions/inputSub"),
         io.Output.PubSub("projects/test-project/topics/good-topic"),
+        Some(io.Output.PubSub("projects/test-project/topics/pii-topic")),
         io.Output.PubSub("projects/test-project/topics/bad-topic"),
         None,
         None,

--- a/modules/fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/fs2/config/ConfigFileSpec.scala
+++ b/modules/fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/fs2/config/ConfigFileSpec.scala
@@ -34,6 +34,7 @@ class ConfigFileSpec extends Specification with CatsIO {
         io.Authentication.Gcp,
         io.Input.PubSub("projects/test-project/subscriptions/inputSub"),
         io.Output.PubSub("projects/test-project/topics/good-topic"),
+        Some(io.Output.PubSub("projects/test-project/topics/pii-topic")),
         io.Output.PubSub("projects/test-project/topics/bad-topic"),
         Some(7.days),
         Some(Sentry(URI.create("http://sentry.acme.com"))),
@@ -55,6 +56,10 @@ class ConfigFileSpec extends Specification with CatsIO {
           "good": {
             "type": "PubSub",
             "topic": "projects/test-project/topics/good-topic"
+          },
+          "pii": {
+            "type": "PubSub",
+            "topic": "projects/test-project/topics/pii-topic"
           },
           "bad": {
             "type": "PubSub",

--- a/modules/fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/fs2/enrichments/ApiRequestEnrichmentSpec.scala
+++ b/modules/fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/fs2/enrichments/ApiRequestEnrichmentSpec.scala
@@ -39,11 +39,11 @@ import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.apirequ
   HttpApi,
   Input,
   JsonOutput,
-  Output
+  Output => RegistryOutput
 }
 
 import com.snowplowanalytics.snowplow.enrich.fs2.enrichments.ApiRequestEnrichmentSpec.unstructEvent
-import com.snowplowanalytics.snowplow.enrich.fs2.{EnrichSpec, Payload}
+import com.snowplowanalytics.snowplow.enrich.fs2.{EnrichSpec, Output, Payload}
 import com.snowplowanalytics.snowplow.enrich.fs2.test._
 
 import org.specs2.mutable.Specification
@@ -69,7 +69,7 @@ class ApiRequestEnrichmentSpec extends Specification with CatsIO {
         SchemaKey("com.acme", "enrichment", "jsonschema", SchemaVer.Full(1, 0, 0)),
         List(Input.Json("key1", "unstruct_event", SchemaCriterion("com.acme", "test", "jsonschema", 1), "$.path.id")),
         HttpApi("GET", "http://localhost:8080/enrichment/api/{{key1}}", 2000, Authentication(None)),
-        List(Output("iglu:com.acme/output/jsonschema/1-0-0", Some(JsonOutput("$")))),
+        List(RegistryOutput("iglu:com.acme/output/jsonschema/1-0-0", Some(JsonOutput("$")))),
         Cache(1, 1000)
       )
 
@@ -86,7 +86,7 @@ class ApiRequestEnrichmentSpec extends Specification with CatsIO {
       testWithHttp.use { test =>
         test.run().map { events =>
           events must beLike {
-            case List(Right(event)) =>
+            case List(Output.Good(event)) =>
               event.derived_contexts must beEqualTo(expected)
             case other => ko(s"Expected one enriched event, got $other")
           }

--- a/modules/fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/fs2/enrichments/IabEnrichmentSpec.scala
+++ b/modules/fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/fs2/enrichments/IabEnrichmentSpec.scala
@@ -17,7 +17,7 @@ import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer, SelfDescribingData
 
 import com.snowplowanalytics.snowplow.analytics.scalasdk.SnowplowEvent.Contexts
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf
-import com.snowplowanalytics.snowplow.enrich.fs2.{EnrichSpec, Payload}
+import com.snowplowanalytics.snowplow.enrich.fs2.{EnrichSpec, Output, Payload}
 import com.snowplowanalytics.snowplow.enrich.fs2.test.{HttpServer, TestEnvironment}
 
 import org.specs2.mutable.Specification
@@ -46,7 +46,7 @@ class IabEnrichmentSpec extends Specification with CatsIO {
       val testWithHttp = HttpServer.resource(6.seconds) *> TestEnvironment.make(input, List(IabEnrichmentSpec.enrichmentConf))
       testWithHttp.use { test =>
         test.run().map {
-          case List(Right(event)) =>
+          case List(Output.Good(event)) =>
             event.derived_contexts must beEqualTo(expected)
           case other =>
             ko(s"Expected one valid event, got $other")
@@ -82,7 +82,7 @@ class IabEnrichmentSpec extends Specification with CatsIO {
       val testWithHttp = HttpServer.resource(6.seconds) *> TestEnvironment.make(input, List(IabEnrichmentSpec.enrichmentConf))
       testWithHttp.use { test =>
         test.run(_.copy(assetsUpdatePeriod = Some(1800.millis))).map {
-          case List(Right(eventOne), Right(eventTwo)) =>
+          case List(Output.Good(eventOne), Output.Good(eventTwo)) =>
             List(eventOne.derived_contexts, eventTwo.derived_contexts) must containTheSameElementsAs(List(expectedOne, expectedTwo))
           case other =>
             ko(s"Expected two valid events, got $other")

--- a/modules/fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/fs2/enrichments/YauaaEnrichmentSpec.scala
+++ b/modules/fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/fs2/enrichments/YauaaEnrichmentSpec.scala
@@ -26,7 +26,7 @@ import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer, SelfDescribingData
 import com.snowplowanalytics.snowplow.analytics.scalasdk.SnowplowEvent.Contexts
 
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf.YauaaConf
-import com.snowplowanalytics.snowplow.enrich.fs2.{EnrichSpec, Payload}
+import com.snowplowanalytics.snowplow.enrich.fs2.{EnrichSpec, Output, Payload}
 import com.snowplowanalytics.snowplow.enrich.fs2.test._
 
 import org.specs2.mutable.Specification
@@ -87,7 +87,7 @@ class YauaaEnrichmentSpec extends Specification with CatsIO {
       TestEnvironment.make(input, List(enrichment)).use { test =>
         test.run().map { events =>
           events must beLike {
-            case List(Right(event)) =>
+            case List(Output.Good(event)) =>
               event.derived_contexts must beEqualTo(expected)
             case other => ko(s"Expected one enriched event, got $other")
           }

--- a/modules/fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/fs2/test/TestEnvironment.scala
+++ b/modules/fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/fs2/test/TestEnvironment.scala
@@ -33,7 +33,7 @@ import com.snowplowanalytics.snowplow.badrows.BadRow
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.EnrichmentRegistry
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf
 import com.snowplowanalytics.snowplow.enrich.common.outputs.EnrichedEvent
-import com.snowplowanalytics.snowplow.enrich.fs2.{Assets, Enrich, EnrichSpec, Environment, Payload, RawSource}
+import com.snowplowanalytics.snowplow.enrich.fs2.{Assets, Enrich, EnrichSpec, Environment, RawSource}
 import com.snowplowanalytics.snowplow.enrich.fs2.Environment.Enrichments
 import com.snowplowanalytics.snowplow.enrich.fs2.SpecHelpers.{filesResource, ioClock}
 import cats.effect.testing.specs2.CatsIO
@@ -46,8 +46,9 @@ import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 case class TestEnvironment(
   env: Environment[IO],
   counter: Ref[IO, Counter],
-  good: Queue[IO, Payload[IO, EnrichedEvent]],
-  bad: Queue[IO, Payload[IO, BadRow]]
+  good: Queue[IO, EnrichedEvent],
+  pii: Queue[IO, EnrichedEvent],
+  bad: Queue[IO, BadRow]
 ) {
 
   /**
@@ -77,7 +78,7 @@ case class TestEnvironment(
       .compile
       .toList
       .map { rows =>
-        rows.map(_.fold(_.data.asLeft, event => EnrichSpec.normalize(event).toEither))
+        rows.map(_.fold(_.asLeft, event => EnrichSpec.normalize(event).toEither))
       }
   }
 }
@@ -119,26 +120,29 @@ object TestEnvironment extends CatsIO {
       blocker <- ioBlocker
       _ <- filesResource(blocker, enrichments.flatMap(_.filesToCache).map(p => Paths.get(p._2)))
       counter <- Resource.liftF(Counter.make[IO])
-      goodQueue <- Resource.liftF(Queue.unbounded[IO, Payload[IO, EnrichedEvent]])
-      badQueue <- Resource.liftF(Queue.unbounded[IO, Payload[IO, BadRow]])
+      goodQueue <- Resource.liftF(Queue.unbounded[IO, EnrichedEvent])
+      piiQueue <- Resource.liftF(Queue.unbounded[IO, EnrichedEvent])
+      badQueue <- Resource.liftF(Queue.unbounded[IO, BadRow])
       metrics = Counter.mkCounterMetrics[IO](counter)(Monad[IO], ioClock)
       pauseEnrich <- Environment.makePause[IO]
       assets <- Assets.State.make(blocker, pauseEnrich, enrichments.flatMap(_.filesToCache))
       _ <- Resource.liftF(logger.info("AssetsState initialized"))
       enrichmentsRef <- Enrichments.make[IO](enrichments)
-      environment = Environment[IO](igluClient,
-                                    enrichmentsRef,
-                                    pauseEnrich,
-                                    assets,
-                                    blocker,
-                                    source,
-                                    goodQueue.enqueue,
-                                    badQueue.enqueue,
-                                    None,
-                                    metrics,
-                                    None,
-                                    None
+      environment = Environment[IO](
+                      igluClient,
+                      enrichmentsRef,
+                      pauseEnrich,
+                      assets,
+                      blocker,
+                      source,
+                      goodQueue.enqueue,
+                      piiQueue.enqueue,
+                      badQueue.enqueue,
+                      None,
+                      metrics,
+                      None,
+                      None
                     )
       _ <- Resource.liftF(pauseEnrich.set(false) *> logger.info("TestEnvironment initialized"))
-    } yield TestEnvironment(environment, counter, goodQueue, badQueue)
+    } yield TestEnvironment(environment, counter, goodQueue, piiQueue, badQueue)
 }

--- a/modules/kinesis/src/main/scala/com.snowplowanalytics.snowplow.enrich.stream/sources/KinesisSource.scala
+++ b/modules/kinesis/src/main/scala/com.snowplowanalytics.snowplow.enrich.stream/sources/KinesisSource.scala
@@ -19,7 +19,7 @@
 package com.snowplowanalytics.snowplow.enrich.stream
 package sources
 
-import java.net.InetAddress
+import java.net.{InetAddress, URI}
 import java.util.{List, UUID}
 
 import scala.util.control.Breaks._
@@ -28,14 +28,28 @@ import scala.util.control.NonFatal
 
 import cats.Id
 import cats.syntax.either._
-import com.amazonaws.auth.AWSCredentialsProvider
-import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
-import com.amazonaws.services.kinesis.AmazonKinesisClientBuilder
-import com.amazonaws.services.kinesis.clientlibrary.interfaces._
-import com.amazonaws.services.kinesis.clientlibrary.exceptions._
-import com.amazonaws.services.kinesis.clientlibrary.lib.worker._
-import com.amazonaws.services.kinesis.model.Record
-import com.amazonaws.services.kinesis.metrics.impl.NullMetricsFactory
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
+import software.amazon.kinesis.common.{InitialPositionInStream, InitialPositionInStreamExtended}
+import software.amazon.kinesis.exceptions.ThrottlingException
+import software.amazon.kinesis.metrics.NullMetricsFactory
+import software.amazon.kinesis.processor.{RecordProcessorCheckpointer, ShardRecordProcessorFactory}
+import software.amazon.kinesis.retrieval.KinesisClientRecord
+import software.amazon.kinesis.retrieval.polling.PollingConfig
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient
+import software.amazon.awssdk.services.kinesis.KinesisAsyncClient
+import software.amazon.awssdk.regions.Region
+import software.amazon.kinesis.common.ConfigsBuilder
+import software.amazon.kinesis.common.KinesisClientUtil
+import software.amazon.kinesis.coordinator.Scheduler
+import software.amazon.kinesis.exceptions.InvalidStateException
+import software.amazon.kinesis.exceptions.ShutdownException
+import software.amazon.kinesis.lifecycle.events.InitializationInput
+import software.amazon.kinesis.lifecycle.events.LeaseLostInput
+import software.amazon.kinesis.lifecycle.events.ProcessRecordsInput
+import software.amazon.kinesis.lifecycle.events.ShardEndedInput
+import software.amazon.kinesis.lifecycle.events.ShutdownRequestedInput
+import software.amazon.kinesis.processor.ShardRecordProcessor
 import com.snowplowanalytics.iglu.client.Client
 import com.snowplowanalytics.snowplow.badrows.Processor
 import com.snowplowanalytics.snowplow.enrich.common.adapters.AdapterRegistry
@@ -45,7 +59,7 @@ import io.circe.Json
 
 import model.{Kinesis, SentryConfig, StreamsConfig}
 import sinks._
-import utils.getAWSCredentialsProvider
+import utils.getAwsCredentialsProvider
 
 /** KinesisSource companion object with factory method */
 object KinesisSource {
@@ -64,12 +78,14 @@ object KinesisSource {
                          case _ => "Configured source/sink is not Kinesis".asLeft
                        }
       emitPii = utils.emitPii(enrichmentRegistry)
-      _ <- KinesisSink.validate(kinesisConfig, config.out.enriched)
+      credentialsProvider <- getAwsCredentialsProvider(kinesisConfig.aws)
+      kClient = kinesisClient(credentialsProvider, kinesisConfig)
+      _ <- KinesisSink.validate(kClient, config.out.enriched)
       _ <- utils.validatePii(emitPii, config.out.pii)
-      _ <- KinesisSink.validate(kinesisConfig, config.out.bad)
-      provider <- getAWSCredentialsProvider(kinesisConfig.aws)
+      _ <- KinesisSink.validate(kClient, config.out.bad)
     } yield new KinesisSource(
       client,
+      kClient,
       adapterRegistry,
       enrichmentRegistry,
       tracker,
@@ -77,13 +93,23 @@ object KinesisSource {
       config,
       kinesisConfig,
       sentryConfig,
-      provider
+      credentialsProvider
+    )
+
+  private def kinesisClient(credentialsProvider: AwsCredentialsProvider, kinesisConfig: Kinesis): KinesisAsyncClient =
+    KinesisClientUtil.createKinesisAsyncClient(
+      KinesisAsyncClient
+        .builder()
+        .credentialsProvider(credentialsProvider)
+        .endpointOverride(new URI(kinesisConfig.streamEndpoint))
+        .region(Region.of(kinesisConfig.region))
     )
 }
 
 /** Source to read events from a Kinesis stream */
 class KinesisSource private (
   client: Client[Id, Json],
+  kinesisClient: KinesisAsyncClient,
   adapterRegistry: AdapterRegistry,
   enrichmentRegistry: EnrichmentRegistry[Id],
   tracker: Option[Tracker[Id]],
@@ -91,25 +117,17 @@ class KinesisSource private (
   config: StreamsConfig,
   kinesisConfig: Kinesis,
   sentryConfig: Option[SentryConfig],
-  provider: AWSCredentialsProvider
+  credentialsProvider: AwsCredentialsProvider
 ) extends Source(client, adapterRegistry, enrichmentRegistry, processor, config.out.partitionKey, sentryConfig) {
 
   override val MaxRecordSize = Some(1000000)
-
-  private val kClient = {
-    val endpointConfiguration =
-      new EndpointConfiguration(kinesisConfig.streamEndpoint, kinesisConfig.region)
-    AmazonKinesisClientBuilder
-      .standard()
-      .withCredentials(provider)
-      .withEndpointConfiguration(endpointConfiguration)
-      .build()
-  }
+  private val DYNAMODB_DEFAULT_INITIAL_RCU = 10
+  private val DYNAMODB_DEFAULT_INITIAL_WCU = 10
 
   override val threadLocalGoodSink: ThreadLocal[Sink] = new ThreadLocal[Sink] {
     override def initialValue: Sink =
       new KinesisSink(
-        kClient,
+        kinesisClient,
         kinesisConfig.backoffPolicy,
         config.buffer,
         config.out.enriched,
@@ -126,7 +144,7 @@ class KinesisSource private (
           new ThreadLocal[Sink] {
             override def initialValue: Sink =
               new KinesisSink(
-                kClient,
+                kinesisClient,
                 kinesisConfig.backoffPolicy,
                 config.buffer,
                 piiStreamName,
@@ -139,7 +157,7 @@ class KinesisSource private (
 
   override val threadLocalBadSink: ThreadLocal[Sink] = new ThreadLocal[Sink] {
     override def initialValue: Sink =
-      new KinesisSink(kClient, kinesisConfig.backoffPolicy, config.buffer, config.out.bad, tracker)
+      new KinesisSink(kinesisClient, kinesisConfig.backoffPolicy, config.buffer, config.out.bad, tracker)
   }
 
   /** Never-ending processing loop over source stream. */
@@ -147,78 +165,106 @@ class KinesisSource private (
     val workerId = InetAddress.getLocalHost().getCanonicalHostName() + ":" + UUID.randomUUID()
     log.info("Using workerId: " + workerId)
 
-    val kinesisClientLibConfiguration = {
-      val kclc = new KinesisClientLibConfiguration(
-        config.appName,
-        config.in.raw,
-        provider,
-        workerId
-      ).withKinesisEndpoint(kinesisConfig.streamEndpoint)
-        .withMaxRecords(kinesisConfig.maxRecords)
-        .withRegionName(kinesisConfig.region)
-        // If the record list is empty, we still check whether it is time to flush the buffer
-        .withCallProcessRecordsEvenForEmptyRecordList(true)
-        .withDynamoDBEndpoint(kinesisConfig.dynamodbEndpoint)
-
-      val position = InitialPositionInStream.valueOf(kinesisConfig.initialPosition)
-      kinesisConfig.timestamp.right.toOption
-        .filter(_ => position == InitialPositionInStream.AT_TIMESTAMP)
-        .map(kclc.withTimestampAtInitialPositionInStream(_))
-        .getOrElse(kclc.withInitialPositionInStream(position))
-    }
+    val dynamoClient = DynamoDbAsyncClient.builder
+      .credentialsProvider(credentialsProvider)
+      .endpointOverride(new URI(kinesisConfig.dynamodbEndpoint))
+      .region(Region.of(kinesisConfig.region))
+      .build
+    val cloudWatchClient = CloudWatchAsyncClient.builder
+      .credentialsProvider(credentialsProvider)
+      .region(Region.of(kinesisConfig.region))
+      .build
 
     log.info(s"Running: ${config.appName}.")
     log.info(s"Processing raw input stream: ${config.in.raw}")
 
     val rawEventProcessorFactory = new RawEventProcessorFactory()
-    val worker = kinesisConfig.disableCloudWatch match {
-      case Some(true) =>
-        new Worker.Builder()
-          .recordProcessorFactory(rawEventProcessorFactory)
-          .config(kinesisClientLibConfiguration)
-          .metricsFactory(new NullMetricsFactory())
-          .build()
-      case _ =>
-        new Worker.Builder()
-          .recordProcessorFactory(rawEventProcessorFactory)
-          .config(kinesisClientLibConfiguration)
-          .build()
+
+    val configsBuilder = new ConfigsBuilder(
+      config.in.raw,
+      config.appName,
+      kinesisClient,
+      dynamoClient,
+      cloudWatchClient,
+      workerId,
+      rawEventProcessorFactory
+    )
+
+    val positionValue = InitialPositionInStream.valueOf(kinesisConfig.initialPosition)
+    val position = kinesisConfig.timestamp.right.toOption
+      .filter(_ => positionValue == InitialPositionInStream.AT_TIMESTAMP)
+      .map(InitialPositionInStreamExtended.newInitialPositionAtTimestamp(_))
+      .getOrElse(InitialPositionInStreamExtended.newInitialPosition(positionValue))
+
+    val metricFactory = kinesisConfig.disableCloudWatch match {
+      case Some(true) => new NullMetricsFactory()
+      case _ => null // KCL internally creates it.
     }
 
-    worker.run()
+    //Enhanced fan-out is the default retrieval behavior for KCL 2.x. We need to override it if we want to use polling mode.
+    val retrievalConfig = kinesisConfig.maxRecords match {
+      case Some(maxRecordsCount) =>
+        configsBuilder
+          .retrievalConfig()
+          .retrievalSpecificConfig(
+            new PollingConfig(config.in.raw, kinesisClient).maxRecords(maxRecordsCount)
+          )
+      case None => configsBuilder.retrievalConfig()
+    }
+
+    val scheduler = new Scheduler(
+      configsBuilder.checkpointConfig(),
+      configsBuilder.coordinatorConfig(),
+      configsBuilder
+        .leaseManagementConfig()
+        .initialLeaseTableReadCapacity(
+          kinesisConfig.dynamodbInitialRCU.getOrElse(DYNAMODB_DEFAULT_INITIAL_RCU)
+        )
+        .initialLeaseTableWriteCapacity(
+          kinesisConfig.dynamodbInitialWCU.getOrElse(DYNAMODB_DEFAULT_INITIAL_WCU)
+        )
+        .initialPositionInStream(position),
+      configsBuilder.lifecycleConfig(),
+      configsBuilder.metricsConfig().metricsFactory(metricFactory),
+      configsBuilder.processorConfig().callProcessRecordsEvenForEmptyRecordList(true),
+      retrievalConfig
+    )
+
+    scheduler.run()
   }
 
   // Factory needed by the Amazon Kinesis Consumer library to
   // create a processor.
-  class RawEventProcessorFactory extends IRecordProcessorFactory {
-    override def createProcessor: IRecordProcessor = new RawEventProcessor()
+  class RawEventProcessorFactory extends ShardRecordProcessorFactory {
+    override def shardRecordProcessor: ShardRecordProcessor = new RawEventProcessor()
   }
 
   // Process events from a Kinesis stream.
-  class RawEventProcessor extends IRecordProcessor {
+  class RawEventProcessor extends ShardRecordProcessor {
     private var kinesisShardId: String = _
 
     // Backoff and retry settings.
+    // make these configurations with default values.
     private val BACKOFF_TIME_IN_MILLIS = 3000L
     private val NUM_RETRIES = 10
 
-    override def initialize(shardId: String) = {
-      log.info("Initializing record processor for shard: " + shardId)
-      this.kinesisShardId = shardId
+    override def initialize(initializationInput: InitializationInput) = {
+      log.info(s"Initializing record processor for shard: ${initializationInput.shardId()}")
+      this.kinesisShardId = initializationInput.shardId()
     }
 
-    override def processRecords(records: List[Record], checkpointer: IRecordProcessorCheckpointer) = {
+    override def processRecords(processRecordsInput: ProcessRecordsInput) = {
 
-      if (!records.isEmpty)
-        log.info(s"Processing ${records.size} records from $kinesisShardId")
-      val shouldCheckpoint = processRecordsWithRetries(records)
+      if (!processRecordsInput.records().isEmpty)
+        log.info(s"Processing ${processRecordsInput.records().size()} records from $kinesisShardId")
+      val shouldCheckpoint = processRecordsWithRetries(processRecordsInput.records())
 
       if (shouldCheckpoint)
-        checkpoint(checkpointer)
+        checkpoint(processRecordsInput.checkpointer())
     }
 
-    private def processRecordsWithRetries(records: List[Record]): Boolean =
-      try enrichAndStoreEvents(records.asScala.map(_.getData.array).toList)
+    private def processRecordsWithRetries(records: List[KinesisClientRecord]): Boolean =
+      try enrichAndStoreEvents(records.asScala.map(_.data().array).toList)
       catch {
         case NonFatal(e) =>
           // TODO: send an event when something goes wrong here
@@ -226,13 +272,33 @@ class KinesisSource private (
           false
       }
 
-    override def shutdown(checkpointer: IRecordProcessorCheckpointer, reason: ShutdownReason) = {
-      log.info(s"Shutting down record processor for shard: $kinesisShardId")
-      if (reason == ShutdownReason.TERMINATE)
-        checkpoint(checkpointer)
-    }
+    def leaseLost(leaseLostInput: LeaseLostInput) =
+      // do nothing, the new shard processor will take care of it.
+      log.info(s"Lease lost  ${leaseLostInput}")
 
-    private def checkpoint(checkpointer: IRecordProcessorCheckpointer) = {
+    def shardEnded(shardEndedInput: ShardEndedInput) =
+      try {
+        log.info(s"Shard ended for shard: $kinesisShardId")
+        shardEndedInput.checkpointer().checkpoint()
+      } catch {
+        case e: ShutdownException =>
+          log.error(s"Caught ShutdownException for endedShard ", e)
+        case e: InvalidStateException =>
+          log.error(s"Caught InvalidStateException for endedShard ", e)
+      }
+
+    def shutdownRequested(shutdownRequestedInput: ShutdownRequestedInput) =
+      try {
+        log.info(s"Shutting down record processor for shard: $kinesisShardId")
+        shutdownRequestedInput.checkpointer().checkpoint()
+      } catch {
+        case e: ShutdownException =>
+          log.error(s"Caught ShutdownException for shutdownRequestedInput", e)
+        case e: InvalidStateException =>
+          log.error(s"Caught InvalidStateException for shutdownRequestedInput", e)
+      }
+
+    private def checkpoint(checkpointer: RecordProcessorCheckpointer) = {
       log.info(s"Checkpointing shard $kinesisShardId")
       breakable {
         for (i <- 0 to NUM_RETRIES - 1) {

--- a/modules/stream/src/main/scala/com.snowplowanalytics.snowplow.enrich.stream/model.scala
+++ b/modules/stream/src/main/scala/com.snowplowanalytics.snowplow.enrich.stream/model.scala
@@ -96,12 +96,14 @@ object model {
     aws: AWSCredentials,
     gcp: Option[GCPCredentials],
     region: String,
-    maxRecords: Int,
+    maxRecords: Option[Int],
     initialPosition: String,
     initialTimestamp: Option[String],
     backoffPolicy: KinesisBackoffPolicyConfig,
     customEndpoint: Option[String],
     dynamodbCustomEndpoint: Option[String],
+    dynamodbInitialRCU: Option[Int],
+    dynamodbInitialWCU: Option[Int],
     disableCloudWatch: Option[Boolean]
   ) extends AWSNativePlatformConfig {
     val timestamp = initialTimestamp

--- a/modules/stream/src/main/scala/com.snowplowanalytics.snowplow.enrich.stream/sources/Source.scala
+++ b/modules/stream/src/main/scala/com.snowplowanalytics.snowplow.enrich.stream/sources/Source.scala
@@ -37,29 +37,20 @@ import com.snowplowanalytics.snowplow.enrich.common.adapters.AdapterRegistry
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.EnrichmentRegistry
 import com.snowplowanalytics.snowplow.enrich.common.loaders.{CollectorPayload, ThriftLoader}
 import com.snowplowanalytics.snowplow.enrich.common.outputs.EnrichedEvent
+import com.snowplowanalytics.snowplow.enrich.common.utils.ConversionUtils
 import com.snowplowanalytics.snowplow.enrich.stream.model.SentryConfig
 import io.circe.Json
-import io.circe.syntax._
 import org.joda.time.DateTime
 import org.slf4j.LoggerFactory
 import io.sentry.Sentry
 import io.sentry.SentryClient
-import org.joda.time.{DateTime, DateTimeZone}
-import org.joda.time.format.DateTimeFormat
+import org.joda.time.DateTime
 
 import sinks._
 import utils._
 
 object Source {
   val processor = Processor(generated.BuildInfo.name, generated.BuildInfo.version)
-
-  val PiiEventName = "pii_transformation"
-  val PiiEventVendor = "com.snowplowanalytics.snowplow"
-  val PiiEventFormat = "jsonschema"
-  val PiiEventVersion = "1-0-0"
-  val PiiEventPlatform = "srv"
-  val ContextsSchema = "iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-0"
-  val ParentEventSchema = "iglu:com.snowplowanalytics.snowplow/parent_event/jsonschema/1-0-0"
 
   /**
    * If a bad row JSON is too big, reduce it's size
@@ -131,42 +122,6 @@ abstract class Source(
   /** Never-ending processing loop over source stream. */
   def run(): Unit
 
-  private val formatter = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSS")
-
-  def getPiiEvent(event: EnrichedEvent): Option[EnrichedEvent] =
-    Option(event.pii)
-      .filter(_.nonEmpty)
-      .map { _ =>
-        val ee = new EnrichedEvent
-        ee.unstruct_event = event.pii
-        ee.app_id = event.app_id
-        ee.platform = Source.PiiEventPlatform
-        ee.etl_tstamp = event.etl_tstamp
-        ee.collector_tstamp = event.collector_tstamp
-        ee.event = Source.PiiEventName
-        ee.event_id = UUID.randomUUID().toString
-        ee.derived_tstamp = formatter.print(DateTime.now(DateTimeZone.UTC))
-        ee.true_tstamp = ee.derived_tstamp
-        ee.event_vendor = Source.PiiEventVendor
-        ee.event_format = Source.PiiEventFormat
-        ee.event_name = Source.PiiEventName
-        ee.event_version = Source.PiiEventVersion
-        ee.contexts = getContextParentEvent(event.event_id).noSpaces
-        ee.v_etl = s"stream-enrich-${generated.BuildInfo.version}-common-${generated.BuildInfo.commonEnrichVersion}"
-        ee
-      }
-
-  def getContextParentEvent(eventId: String): Json =
-    Json.obj(
-      "schema" := Json.fromString(Source.ContextsSchema),
-      "data" := Json.arr(
-        Json.obj(
-          "schema" -> Json.fromString(Source.ParentEventSchema),
-          "data" -> Json.obj("parentEventId" -> Json.fromString(eventId))
-        )
-      )
-    )
-
   val threadLocalGoodSink: ThreadLocal[Sink]
   val threadLocalPiiSink: Option[ThreadLocal[Sink]]
   val threadLocalBadSink: ThreadLocal[Sink]
@@ -230,7 +185,7 @@ abstract class Source(
               (
                 tabSeparateEnrichedEvent(enriched),
                 getProprertyValue(enriched, partitionKey),
-                getPiiEvent(enriched).map(tabSeparateEnrichedEvent)
+                ConversionUtils.getPiiEvent(processor, enriched).map(tabSeparateEnrichedEvent)
               )
           )
         )

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -107,6 +107,11 @@ object BuildSettings {
       case x if x.endsWith("public-suffix-list.txt") => MergeStrategy.first
       case x if x.endsWith("ProjectSettings$.class") => MergeStrategy.first
       case x if x.endsWith("module-info.class") => MergeStrategy.first
+      // Below are AWS SDK v2 configuration files - can be discarded
+      case PathList(ps@_*) if Set("codegen.config" , "service-2.json" , "waiters-2.json" ,
+        "customization.config" , "examples-1.json" , "paginators-1.json", "mime.types", "io.netty.versions.properties")
+        .contains(ps.last) =>
+        MergeStrategy.discard
       case x =>
         val oldStrategy = (assemblyMergeStrategy in assembly).value
         oldStrategy(x)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -38,7 +38,7 @@ object Dependencies {
     val mysqlConnector   = "8.0.16"
     val jaywayJsonpath   = "2.4.0"
     val iabClient        = "0.2.0"
-    val yauaa            = "5.19"
+    val yauaa            = "5.23"
     val guava            = "28.1-jre"
     val slf4j            = "1.7.26"
     val log4j            = "2.13.3"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -60,9 +60,9 @@ object Dependencies {
     val collectorPayload = "0.0.0"
     val schemaSniffer    = "0.0.0"
 
-    val awsSdk           = "1.11.728"
+    val awsSdk           = "2.16.21"
     val gcpSdk           = "1.106.0"
-    val kinesisClient    = "1.13.3"
+    val kinesisClient    = "2.3.4"
     val kafka            = "2.2.1"
     val nsqClient        = "1.2.0"
     val jackson          = "2.10.5"
@@ -149,10 +149,10 @@ object Dependencies {
     val scalaTest        = "org.scalatest"              %% "scalatest"                                % V.scalaTest       % Test
 
     // Stream
-    val kinesisSdk       = "com.amazonaws"                    %  "aws-java-sdk-kinesis"              % V.awsSdk
-    val dynamodbSdk      = "com.amazonaws"                    %  "aws-java-sdk-dynamodb"             % V.awsSdk
-    val s3Sdk            = "com.amazonaws"                    %  "aws-java-sdk-s3"                   % V.awsSdk
-    val kinesisClient    = "com.amazonaws"                    %  "amazon-kinesis-client"             % V.kinesisClient
+    val authSdk          = "software.amazon.awssdk"           %  "auth"                              % V.awsSdk
+    val dynamodbSdk      = "software.amazon.awssdk"           %  "dynamodb"                          % V.awsSdk
+    val s3Sdk            = "software.amazon.awssdk"           %  "s3"                                % V.awsSdk
+    val kinesisClient    = "software.amazon.kinesis"          %  "amazon-kinesis-client"             % V.kinesisClient
     val gsSdk            = "com.google.cloud"                 %  "google-cloud-storage"              % V.gcpSdk
     val kafkaClients     = "org.apache.kafka"                 %  "kafka-clients"                     % V.kafka
     val jacksonCbor      = "com.fasterxml.jackson.dataformat" %  "jackson-dataformat-cbor"           % V.jackson


### PR DESCRIPTION
The primary purpose of this PR is:
* sink PII events into the dedicated PII topic.
* sink overly large messages into the bad topic

This PR includes refactoring some shared code into common, rather than have it implemented three times separately in beam, stream and fs2 modules.

I made a significant change to the `Payload` class - which needs some careful review.  Previously we were decomposing a list of events into a stream, replacing the "ack" with `F[Unit]` for all but the last event in the list.  I changed this to instead send the list through a pipe, and call the `finalise` only after all events are processed ([link](https://github.com/snowplow/enrich/pull/418/files#diff-7c8458a5ab1e0d1898535fbdcb94645e2824a1c1d76e7d928c71be6d2b2e5f40R30-R32))

```scala
  def sink[F[_]: Concurrent, A](inner: Pipe[F, A, Unit]): Pipe[F, Payload[F, A], Unit] =
    _.observeAsync(Enrich.ConcurrencyLevel)(_.map(_.data).through(inner))
      .evalMap(_.finalise)
```