### PR TITLE
Stream FS2: StatsD reporter for metrics (close #421)

### DIFF
--- a/config/config.fs2.hocon.sample
+++ b/config/config.fs2.hocon.sample
@@ -52,6 +52,30 @@ sentry = {
 // no assets will be updated if the key is absent
 assetsUpdatePeriod = "7 days"
 
-// Optional, period after Dropwizard will print out its metrics
-// no metrics will be printed if the key is absent
-metricsReportPeriod = "10 seconds"
+// Optional, configure how metrics are reported
+metrics = {
+
+  // Send metrics to a StatsD server on localhost
+  type = "StatsD"
+  hostname = "localhost"
+  port = 8125
+
+  // Alternatively, log to stdout using Slf4j
+  // type = "Stdout"
+
+  // Required, how frequently to report metrics
+  period = "10 seconds"
+
+  // Any key-value pairs to be tagged on every metric
+  tags = {
+    app = enrich
+
+    // Environment variables can be resolved to tags
+    // host = ${HOSTNAME}
+  }
+
+  // Optional, override the default metric prefix
+  // prefix = "snowplow.enrich."
+
+
+}

--- a/modules/fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/fs2/Main.scala
+++ b/modules/fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/fs2/Main.scala
@@ -20,8 +20,6 @@ import _root_.io.sentry.SentryClient
 import _root_.io.chrisdavenport.log4cats.Logger
 import _root_.io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 
-import com.snowplowanalytics.snowplow.enrich.fs2.io.Metrics
-
 object Main extends IOApp {
 
   private implicit val logger: Logger[IO] =
@@ -39,7 +37,7 @@ object Main extends IOApp {
                         val log = logger.info("Running enrichment stream")
                         val enrich = Enrich.run[IO](env)
                         val updates = Assets.run[IO](env)
-                        val reporting = Metrics.run[IO](env)
+                        val reporting = env.metrics.report
                         val flow = enrich.merge(updates).merge(reporting)
                         log >> flow.compile.drain.attempt.flatMap {
                           case Left(exception) =>

--- a/modules/fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/fs2/config/ConfigFile.scala
+++ b/modules/fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/fs2/config/ConfigFile.scala
@@ -23,7 +23,7 @@ import _root_.io.circe.{Decoder, Encoder, Json}
 import _root_.io.circe.config.syntax._
 import _root_.io.circe.generic.extras.semiauto.{deriveConfiguredDecoder, deriveConfiguredEncoder}
 
-import com.snowplowanalytics.snowplow.enrich.fs2.config.io.{Authentication, Input, Output}
+import com.snowplowanalytics.snowplow.enrich.fs2.config.io.{Authentication, Input, MetricsReporter, Output}
 
 import pureconfig.ConfigSource
 import pureconfig.module.catseffect.syntax._
@@ -47,7 +47,7 @@ final case class ConfigFile(
   bad: Output,
   assetsUpdatePeriod: Option[FiniteDuration],
   sentry: Option[Sentry],
-  metricsReportPeriod: Option[FiniteDuration]
+  metrics: Option[MetricsReporter]
 )
 
 object ConfigFile {
@@ -60,8 +60,6 @@ object ConfigFile {
     deriveConfiguredDecoder[ConfigFile].emap {
       case ConfigFile(_, _, _, _, _, Some(aup), _, _) if aup._1 <= 0L =>
         "assetsUpdatePeriod in config file cannot be less than 0".asLeft // TODO: use newtype
-      case ConfigFile(_, _, _, _, _, _, _, Some(mrp)) if mrp._1 <= 0L =>
-        "metricsReportPeriod in config file cannot be less than 0".asLeft
       case other => other.asRight
     }
   implicit val configFileEncoder: Encoder[ConfigFile] =

--- a/modules/fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/fs2/config/io.scala
+++ b/modules/fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/fs2/config/io.scala
@@ -15,9 +15,11 @@ package com.snowplowanalytics.snowplow.enrich.fs2.config
 import java.nio.file.{InvalidPathException, Path, Paths}
 
 import cats.syntax.either._
+import scala.concurrent.duration.{Duration, FiniteDuration}
 
 import _root_.io.circe.{Decoder, Encoder}
 import _root_.io.circe.generic.extras.semiauto._
+import _root_.io.circe.config.syntax._
 
 object io {
 
@@ -97,5 +99,35 @@ object io {
       }
     implicit val outputEncoder: Encoder[Output] =
       deriveConfiguredEncoder[Output]
+  }
+
+  sealed trait MetricsReporter {
+    def period: FiniteDuration
+    def prefix: Option[String]
+  }
+
+  object MetricsReporter {
+    final case class Stdout(period: FiniteDuration, prefix: Option[String]) extends MetricsReporter
+    final case class StatsD(
+      hostname: String,
+      port: Int,
+      tags: Map[String, String],
+      period: FiniteDuration,
+      prefix: Option[String]
+    ) extends MetricsReporter
+
+    import ConfigFile.finiteDurationEncoder
+
+    implicit val metricsReporterDecoder: Decoder[MetricsReporter] =
+      deriveConfiguredDecoder[MetricsReporter].emap { mr =>
+        if (mr.period <= Duration.Zero)
+          "metrics report period in config file cannot be less than 0".asLeft
+        else mr.asRight
+      }
+
+    implicit val metricsReporterEncoder: Encoder[MetricsReporter] =
+      deriveConfiguredEncoder[MetricsReporter]
+
+    val DefaultPrefix = "snowplow.enrich."
   }
 }

--- a/modules/fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/fs2/io/StatsDReporter.scala
+++ b/modules/fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/fs2/io/StatsDReporter.scala
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2021 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.enrich.fs2.io
+
+import cats.syntax.show._
+
+import java.net.{DatagramPacket, DatagramSocket, InetAddress}
+import java.nio.charset.StandardCharsets.UTF_8
+
+import cats.effect.{Blocker, ContextShift, Resource, Sync, Timer => CatsTimer}
+import fs2.{Pure, Stream}
+import com.codahale.metrics._
+import scala.jdk.CollectionConverters._
+
+import _root_.io.chrisdavenport.log4cats.Logger
+import _root_.io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+
+import com.snowplowanalytics.snowplow.enrich.fs2.config.io.MetricsReporter
+
+/**
+ * Reports metrics to a StatsD server over UDP
+ *
+ * We use the DogStatsD extension to the StatsD protocol, which adds arbitrary key-value tags to the metric, e.g:
+ * `snowplow.enrich.good.count:20000|g|#app_id:12345,env:prod`
+ */
+object StatsDReporter {
+
+  /**
+   * A stream which periodically sends metrics from the registry to the StatsD server.
+   *
+   * The stream calls `InetAddress.getByName` each time there is a new batch of metrics. This allows
+   * the run-time to resolve the address to a new IP address, in case DNS records change.  This is
+   * necessary in dynamic container environments (Kubernetes) where the statsd server could get
+   * restarted at a new IP address.
+   *
+   * Note, InetAddress caches name resolutions, (see https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/net/InetAddress.html)
+   * so there could be a delay in following a DNS record change.  For the Docker image we release
+   * the cache time is 30 seconds.
+   */
+  def stream[F[_]: Sync: ContextShift: CatsTimer](
+    blocker: Blocker,
+    config: MetricsReporter.StatsD,
+    registry: MetricRegistry
+  ): Stream[F, Unit] =
+    for {
+      logger <- Stream.eval(Slf4jLogger.create[F])
+      socket <- Stream.resource(Resource.fromAutoCloseableBlocking(blocker)(Sync[F].delay(new DatagramSocket)))
+      _ <- Stream.fixedDelay(config.period)
+      inetAddr <- Stream.eval(blocker.delay(InetAddress.getByName(config.hostname))).handleErrorWith(logAndAbort(logger))
+      _ <- serializedStream(registry, config)
+             .covary[F]
+             .evalMap(sendMetric[F](blocker, socket, inetAddr, config.port))
+             .handleErrorWith(logAndAbort(logger))
+    } yield ()
+
+  def logAndAbort[F[_]: Sync](logger: Logger[F])(t: Throwable): Stream[F, Nothing] =
+    Stream.eval(Sync[F].delay(logger.error(t)("Caught exception sending metrics"))).drain
+
+  def serializedStream(registry: MetricRegistry, config: MetricsReporter.StatsD): Stream[Pure, String] =
+    kvMetrics(registry).map(statsDFormat(config))
+
+  def sendMetric[F[_]: ContextShift: Sync](
+    blocker: Blocker,
+    socket: DatagramSocket,
+    addr: InetAddress,
+    port: Int
+  )(
+    m: String
+  ): F[Unit] = {
+    val bytes = m.getBytes(UTF_8)
+    val packet = new DatagramPacket(bytes, bytes.length, addr, port)
+    blocker.delay(socket.send(packet))
+  }
+
+  final case class KVMetric(key: String, value: String)
+
+  def kvMetrics(registry: MetricRegistry): Stream[Pure, KVMetric] =
+    kvGauges(registry.getGauges.asScala.toSeq) ++
+      kvCounters(registry.getCounters.asScala.toSeq) ++
+      kvHistograms(registry.getHistograms.asScala.toSeq) ++
+      kvMeters(registry.getMeters.asScala.toSeq) ++
+      kvTimers(registry.getTimers.asScala.toSeq)
+
+  /* Handlers for the five DropWizard metric classes */
+
+  def kvGauges(gauges: Seq[(String, Gauge[_])]): Stream[Pure, KVMetric] =
+    Stream
+      .emits(gauges)
+      .map { case (k, v) => k -> v.getValue }
+      .collect {
+        case (k, v: Int) => KVMetric(k, v.toLong.show)
+        case (k, v: Long) => KVMetric(k, v.show)
+        case (k, v: Double) => KVMetric(k, v.show)
+        case (k, v: String) => KVMetric(k, v)
+      }
+
+  // Counters implement the `Counting` interface
+  def kvCounters(counters: Seq[(String, Counter)]): Stream[Pure, KVMetric] =
+    Stream.emits(counters).flatMap {
+      case (k, v) =>
+        kvCounting(k, v)
+    }
+
+  // Counters implement the `Counting` and `Sampling` interfaces
+  def kvHistograms(histograms: Seq[(String, Histogram)]): Stream[Pure, KVMetric] =
+    Stream.emits(histograms).flatMap {
+      case (k, v) =>
+        kvCounting(k, v) ++ kvSampling(k, v)
+    }
+
+  // Meters implement the `Counting` and `Metered` interfaces
+  def kvMeters(meters: Seq[(String, Meter)]): Stream[Pure, KVMetric] =
+    Stream.emits(meters).flatMap {
+      case (k, v) =>
+        kvCounting(k, v) ++ kvMetered(k, v)
+    }
+
+  // Timers implement the `Counting`, `Metered` and `Sampling` interfaces
+  def kvTimers(timers: Seq[(String, Timer)]): Stream[Pure, KVMetric] =
+    Stream.emits(timers).flatMap {
+      case (k, v) =>
+        kvCounting(k, v) ++ kvMetered(k, v) ++ kvSampling(k, v)
+    }
+
+  /* Handlers for the traits implemented by the Metric classes */
+
+  def kvCounting(key: String, counting: Counting): Stream[Pure, KVMetric] =
+    Stream.emit(KVMetric(s"$key.count", counting.getCount.show))
+
+  def kvMetered(key: String, metered: Metered): Stream[Pure, KVMetric] =
+    Stream(
+      KVMetric(s"$key.fifteenMinuteRate", metered.getFifteenMinuteRate.show),
+      KVMetric(s"$key.fiveMinuteRate", metered.getFiveMinuteRate.show),
+      KVMetric(s"$key.oneMinuteRate", metered.getOneMinuteRate.show),
+      KVMetric(s"$key.meanRate", metered.getMeanRate.show)
+    )
+
+  def kvSampling(key: String, sampling: Sampling): Stream[Pure, KVMetric] = {
+    val snapshot = sampling.getSnapshot
+    Stream(
+      KVMetric(s"$key.min", snapshot.getMin.show),
+      KVMetric(s"$key.max", snapshot.getMax.show),
+      KVMetric(s"$key.mean", snapshot.getMean.show),
+      KVMetric(s"$key.median", snapshot.getMedian.show),
+      KVMetric(s"$key.stdDev", snapshot.getStdDev.show),
+      KVMetric(s"$key.size", snapshot.size.toLong.show),
+      KVMetric(s"$key.75thPercentile", snapshot.get75thPercentile.show),
+      KVMetric(s"$key.95thPercentile", snapshot.get95thPercentile.show),
+      KVMetric(s"$key.98thPercentile", snapshot.get98thPercentile.show),
+      KVMetric(s"$key.99thPercentile", snapshot.get99thPercentile.show),
+      KVMetric(s"$key.999thPercentile", snapshot.get999thPercentile.show)
+    )
+  }
+
+  private def statsDFormat(config: MetricsReporter.StatsD): KVMetric => String = {
+    val tagStr = config.tags.map { case (k, v) => s"$k:$v" }.mkString(",")
+    val prefix = config.prefix.getOrElse(MetricsReporter.DefaultPrefix)
+    kv => s"${prefix}${kv.key}:${kv.value}|g|#$tagStr"
+  }
+
+}

--- a/modules/fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/fs2/config/ConfigFileSpec.scala
+++ b/modules/fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/fs2/config/ConfigFileSpec.scala
@@ -38,7 +38,7 @@ class ConfigFileSpec extends Specification with CatsIO {
         io.Output.PubSub("projects/test-project/topics/bad-topic"),
         Some(7.days),
         Some(Sentry(URI.create("http://sentry.acme.com"))),
-        Some(10.seconds)
+        Some(io.MetricsReporter.StatsD("localhost", 8125, Map("app" -> "enrich"), 10.seconds, None))
       )
       ConfigFile.parse[IO](configPath.asRight).value.map(result => result must beRight(expected))
     }

--- a/modules/fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/fs2/io/StatsDReporterSpec.scala
+++ b/modules/fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/fs2/io/StatsDReporterSpec.scala
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2021 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.enrich.fs2.io
+
+import com.codahale.metrics._
+
+import com.snowplowanalytics.snowplow.enrich.fs2.config.io.MetricsReporter
+import scala.concurrent.duration.DurationLong
+
+import org.specs2.mutable.Specification
+
+class StatsDReporterSpec extends Specification {
+  import StatsDReporterSpec._
+
+  "StatsDeporter" should {
+    "report dropwizard gauges" in {
+      val registry = new MetricRegistry()
+
+      registry.register("gauge1", fixedGauge(42))
+
+      val result = StatsDReporter.serializedStream(registry, TestConfig).toList
+
+      result must contain(exactly("snowplow.test.gauge1:42|g|#tag1:abc"))
+    }
+
+    "report dropwizard counters" in {
+      val registry = new MetricRegistry()
+
+      val counter = registry.counter("counter1")
+      (1 to 42).foreach(_ => counter.inc())
+
+      val result = StatsDReporter.serializedStream(registry, TestConfig).toList
+
+      result must contain(exactly("snowplow.test.counter1.count:42|g|#tag1:abc"))
+    }
+
+    "report dropwizard histograms" in {
+      val registry = new MetricRegistry()
+
+      val histogram = registry.histogram("hist1")
+      histogram.update(10)
+      histogram.update(20)
+
+      val result = StatsDReporter.serializedStream(registry, TestConfig).toList
+
+      result must contain(
+        exactly(
+          "snowplow.test.hist1.count:2|g|#tag1:abc",
+          "snowplow.test.hist1.min:10|g|#tag1:abc",
+          "snowplow.test.hist1.max:20|g|#tag1:abc",
+          "snowplow.test.hist1.mean:15.0|g|#tag1:abc",
+          "snowplow.test.hist1.median:20.0|g|#tag1:abc",
+          "snowplow.test.hist1.stdDev:5.0|g|#tag1:abc",
+          "snowplow.test.hist1.size:2|g|#tag1:abc",
+          beMatching("snowplow\\.test\\.hist1\\.75thPercentile:.*|g|#tag1:abc"),
+          beMatching("snowplow\\.test\\.hist1\\.95thPercentile:.*|g|#tag1:abc"),
+          beMatching("snowplow\\.test\\.hist1\\.98thPercentile:.*|g|#tag1:abc"),
+          beMatching("snowplow\\.test\\.hist1\\.99thPercentile:.*|g|#tag1:abc"),
+          beMatching("snowplow\\.test\\.hist1\\.999thPercentile:.*|g|#tag1:abc")
+        )
+      )
+    }
+
+    "report dropwizard meters" in {
+      val registry = new MetricRegistry()
+
+      val meter = registry.meter("meter1")
+      meter.mark()
+      meter.mark()
+
+      val result = StatsDReporter.serializedStream(registry, TestConfig).toList
+
+      result must contain(
+        exactly(
+          "snowplow.test.meter1.count:2|g|#tag1:abc",
+          beMatching("snowplow\\.test\\.meter1\\.fifteenMinuteRate:.*|g|#tag1:abc"),
+          beMatching("snowplow\\.test\\.meter1\\.fiveMinuteRate:.*|g|#tag1:abc"),
+          beMatching("snowplow\\.test\\.meter1\\.oneMinuteRate:.*|g|#tag1:abc"),
+          beMatching("snowplow\\.test\\.meter1\\.meanRate:.*|g|#tag1:abc")
+        )
+      )
+    }
+
+    "report dropwizard timers" in {
+      val registry = new MetricRegistry()
+
+      val timer = registry.timer("timer1")
+      timer.time({ () => () }: java.util.concurrent.Callable[Unit])
+
+      val result = StatsDReporter.serializedStream(registry, TestConfig).toList
+
+      result must contain(
+        allOf(
+          "snowplow.test.timer1.count:1|g|#tag1:abc",
+          beMatching("snowplow\\.test\\.timer1\\.fifteenMinuteRate:.*|g|#tag1:abc"),
+          beMatching("snowplow\\.test\\.timer1\\.fiveMinuteRate:.*|g|#tag1:abc"),
+          beMatching("snowplow\\.test\\.timer1\\.oneMinuteRate:.*|g|#tag1:abc"),
+          beMatching("snowplow\\.test\\.timer1\\.meanRate:.*|g|#tag1:abc"),
+          beMatching("snowplow\\.test\\.timer1\\.min:.*|g|#tag1:abc"),
+          beMatching("snowplow\\.test\\.timer1\\.max:.*|g|#tag1:abc"),
+          beMatching("snowplow\\.test\\.timer1\\.mean:.*|g|#tag1:abc"),
+          beMatching("snowplow\\.test\\.timer1\\.median:.*|g|#tag1:abc"),
+          "snowplow.test.timer1.stdDev:0.0|g|#tag1:abc",
+          "snowplow.test.timer1.size:1|g|#tag1:abc",
+          beMatching("snowplow\\.test\\.timer1\\.75thPercentile:.*|g|#tag1:abc"),
+          beMatching("snowplow\\.test\\.timer1\\.95thPercentile:.*|g|#tag1:abc"),
+          beMatching("snowplow\\.test\\.timer1\\.98thPercentile:.*|g|#tag1:abc"),
+          beMatching("snowplow\\.test\\.timer1\\.99thPercentile:.*|g|#tag1:abc"),
+          beMatching("snowplow\\.test\\.timer1\\.999thPercentile:.*|g|#tag1:abc")
+        )
+      )
+    }
+  }
+
+}
+
+object StatsDReporterSpec {
+
+  val TestConfig = MetricsReporter.StatsD("localhost", 8125, Map("tag1" -> "abc"), 1.second, Some("snowplow.test."))
+
+  def fixedGauge[T](v: T): Gauge[T] =
+    new Gauge[T] {
+      def getValue: T = v
+    }
+
+}

--- a/modules/fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/fs2/test/Counter.scala
+++ b/modules/fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/fs2/test/Counter.scala
@@ -16,9 +16,9 @@ import java.util.concurrent.TimeUnit
 
 import cats.Monad
 import cats.syntax.flatMap._
-
 import cats.effect.concurrent.Ref
 import cats.effect.{Clock, Sync}
+import fs2.Stream
 
 import com.snowplowanalytics.snowplow.enrich.fs2.io.Metrics
 
@@ -39,8 +39,7 @@ object Counter {
   /** Create a pure metrics with mutable state */
   def mkCounterMetrics[F[_]: Monad: Clock](ref: Ref[F, Counter]): Metrics[F] =
     new Metrics[F] {
-      def report: F[Unit] =
-        Monad[F].unit
+      def report: Stream[F, Unit] = Stream.empty.covary[F]
 
       def enrichLatency(collectorTstamp: Option[Long]): F[Unit] =
         Clock[F].realTime(TimeUnit.MILLISECONDS).flatMap { now =>

--- a/modules/fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/fs2/test/TestEnvironment.scala
+++ b/modules/fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/fs2/test/TestEnvironment.scala
@@ -150,7 +150,6 @@ object TestEnvironment extends CatsIO {
                       _.map(Some(_)).through(badQueue.enqueue),
                       None,
                       metrics,
-                      None,
                       None
                     )
       _ <- Resource.liftF(pauseEnrich.set(false) *> logger.info("TestEnvironment initialized"))


### PR DESCRIPTION
This the re-worked version.  We no longer use a 3rd party statsd client, but rather implement the statsd protocol ourselves.  This is because I could not find a 3rd party client that respected DNS changes during a long-running process.

Here, I call `InetAddress.getByName()` every time I want to send metrics.  This gives the JVM opportunity to re-query the DNS server.  The JVM will respect the ttl on DNS records, but otherwise will cache the result of a DNS lookup.