### PR TITLE
Enforce maximum field lengths (close #517)

### DIFF
--- a/modules/bench/src/test/scala/com.snowplowanalytics.snowplow.enrich.bench/EtlPipelineBench.scala
+++ b/modules/bench/src/test/scala/com.snowplowanalytics.snowplow.enrich.bench/EtlPipelineBench.scala
@@ -49,13 +49,13 @@ class EtlPipelineBench {
 
   @Benchmark
   def measureProcessEventsIO(state: EtlPipelineBench.BenchState) = {
-    val payload = EnrichSpec.colllectorPayload
+    val payload = EnrichSpec.collectorPayload
     EtlPipeline.processEvents[IO](state.adapterRegistry, state.enrichmentRegistryIo, Client.IgluCentral, Enrich.processor, state.dateTime, Validated.Valid(Some(payload))).unsafeRunSync()
   }
 
   @Benchmark
   def measureProcessEventsId(state: EtlPipelineBench.BenchState) = {
-    val payload = EnrichSpec.colllectorPayload
+    val payload = EnrichSpec.collectorPayload
     EtlPipeline.processEvents[Id](state.adapterRegistry, state.enrichmentRegistryId, state.clientId, Enrich.processor, state.dateTime, Validated.Valid(Some(payload)))
   }
 }

--- a/modules/bench/src/test/scala/com.snowplowanalytics.snowplow.enrich.bench/ThriftLoaderBench.scala
+++ b/modules/bench/src/test/scala/com.snowplowanalytics.snowplow.enrich.bench/ThriftLoaderBench.scala
@@ -30,7 +30,7 @@ class ThriftLoaderBench {
 
   @Benchmark
   def measureNormalize(state: ThriftLoaderBench.BenchState) = {
-    Enrich.encodeEvent(state.event)
+    Enrich.serializeEnriched(state.event)
   }
 }
 
@@ -42,7 +42,7 @@ object ThriftLoaderBench {
 
     @Setup(Level.Trial)
     def setup(): Unit = {
-      data = EnrichSpec.colllectorPayload.toRaw
+      data = EnrichSpec.collectorPayload.toRaw
 
       event = new EnrichedEvent()
       event.setApp_id("foo")

--- a/modules/common/src/test/resources/iglu-schemas/schemas/com.snowplowanalytics.snowplow/atomic/jsonschema/1-0-0
+++ b/modules/common/src/test/resources/iglu-schemas/schemas/com.snowplowanalytics.snowplow/atomic/jsonschema/1-0-0
@@ -1,0 +1,489 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for an atomic canonical Snowplow event",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow",
+    "name": "atomic",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "app_id": {
+      "type": ["string", "null"],
+      "maxLength": 255
+    },
+    "platform": {
+      "type": ["string", "null"],
+      "maxLength": 255
+    },
+    "etl_tstamp": {
+      "type": ["string", "null"],
+      "format": "date-time"
+    },
+    "collector_tstamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "dvce_created_tstamp": {
+      "type": ["string", "null"],
+      "format": "date-time"
+    },
+    "event": {
+      "type": ["string", "null"],
+      "maxLength": 128
+    },
+    "event_id": {
+      "type": "string",
+      "maxLength": 36
+    },
+    "txn_id": {
+      "type": ["integer", "null"]
+    },
+    "name_tracker": {
+      "type": ["string", "null"],
+      "maxLength": 128
+    },
+    "v_tracker": {
+      "type": ["string", "null"],
+      "maxLength": 100
+    },
+    "v_collector": {
+      "type": "string",
+      "maxLength": 100
+    },
+    "v_etl": {
+      "type": "string",
+      "maxLength": 100
+    },
+    "user_id": {
+      "type": ["string", "null"],
+      "maxLength": 255
+    },
+    "user_ipaddress": {
+      "type": ["string", "null"],
+      "maxLength": 128
+    },
+    "user_fingerprint": {
+      "type": ["string", "null"],
+      "maxLength": 128
+    },
+    "domain_userid": {
+      "type": ["string", "null"],
+      "maxLength": 128
+    },
+    "domain_sessionidx": {
+      "type": ["integer", "null"]
+    },
+    "network_userid": {
+      "type": ["string", "null"],
+      "maxLength": 128
+    },
+    "geo_country": {
+      "type": ["string", "null"],
+      "maxLength": 2
+    },
+    "geo_region": {
+      "type": ["string", "null"],
+      "maxLength": 3
+    },
+    "geo_city": {
+      "type": ["string", "null"],
+      "maxLength": 75
+    },
+    "geo_zipcode": {
+      "type": ["string", "null"],
+      "maxLength": 15
+    },
+    "geo_latitude": {
+      "type": ["number", "null"]
+    },
+    "geo_longitude": {
+      "type": ["number", "null"]
+    },
+    "geo_region_name": {
+      "type": ["string", "null"],
+      "maxLength": 100
+    },
+    "ip_isp": {
+      "type": ["string", "null"],
+      "maxLength": 100
+    },
+    "ip_organization": {
+      "type": ["string", "null"],
+      "maxLength": 128
+    },
+    "ip_domain": {
+      "type": ["string", "null"],
+      "maxLength": 128
+    },
+    "ip_netspeed": {
+      "type": ["string", "null"],
+      "maxLength": 100
+    },
+    "page_url": {
+      "type": ["string", "null"],
+      "maxLength": 4096
+    },
+    "page_title": {
+      "type": ["string", "null"],
+      "maxLength": 2000
+    },
+    "page_referrer": {
+      "type": ["string", "null"],
+      "maxLength": 4096
+    },
+    "page_urlscheme": {
+      "type": ["string", "null"],
+      "maxLength": 16
+    },
+    "page_urlhost": {
+      "type": ["string", "null"],
+      "maxLength": 255
+    },
+    "page_urlport": {
+      "type": ["integer", "null"]
+    },
+    "page_urlpath": {
+      "type": ["string", "null"],
+      "maxLength": 3000
+    },
+    "page_urlquery": {
+      "type": ["string", "null"],
+      "maxLength": 6000
+    },
+    "page_urlfragment": {
+      "type": ["string", "null"],
+      "maxLength": 3000
+    },
+    "refr_urlscheme": {
+      "type": ["string", "null"],
+      "maxLength": 16
+    },
+    "refr_urlhost": {
+      "type": ["string", "null"],
+      "maxLength": 255
+    },
+    "refr_urlport": {
+      "type": ["integer", "null"]
+    },
+    "refr_urlpath": {
+      "type": ["string", "null"],
+      "maxLength": 6000
+    },
+    "refr_urlquery": {
+      "type": ["string", "null"],
+      "maxLength": 6000
+    },
+    "refr_urlfragment": {
+      "type": ["string", "null"],
+      "maxLength": 3000
+    },
+    "refr_medium": {
+      "type": ["string", "null"],
+      "maxLength": 25
+    },
+    "refr_source": {
+      "type": ["string", "null"],
+      "maxLength": 50
+    },
+    "refr_term": {
+      "type": ["string", "null"],
+      "maxLength": 255
+    },
+    "mkt_medium": {
+      "type": ["string", "null"],
+      "maxLength": 255
+    },
+    "mkt_source": {
+      "type": ["string", "null"],
+      "maxLength": 255
+    },
+    "mkt_term": {
+      "type": ["string", "null"],
+      "maxLength": 255
+    },
+    "mkt_content": {
+      "type": ["string", "null"],
+      "maxLength": 500
+    },
+    "mkt_campaign": {
+      "type": ["string", "null"],
+      "maxLength": 255
+    },
+    "se_category": {
+      "type": ["string", "null"],
+      "maxLength": 1000
+    },
+    "se_action": {
+      "type": ["string", "null"],
+      "maxLength": 1000
+    },
+    "se_label": {
+      "type": ["string", "null"],
+      "maxLength": 4096
+    },
+    "se_property": {
+      "type": ["string", "null"],
+      "maxLength": 1000
+    },
+    "se_value": {
+      "type": ["number", "null"]
+    },
+    "tr_orderid": {
+      "type": ["string", "null"],
+      "maxLength": 255
+    },
+    "tr_affiliation": {
+      "type": ["string", "null"],
+      "maxLength": 255
+    },
+    "tr_total": {
+      "type": ["number", "null"]
+    },
+    "tr_tax": {
+      "type": ["number", "null"]
+    },
+    "tr_shipping": {
+      "type": ["number", "null"]
+    },
+    "tr_city": {
+      "type": ["string", "null"],
+      "maxLength": 255
+    },
+    "tr_state": {
+      "type": ["string", "null"],
+      "maxLength": 255
+    },
+    "tr_country": {
+      "type": ["string", "null"],
+      "maxLength": 255
+    },
+    "ti_orderid": {
+      "type": ["string", "null"],
+      "maxLength": 255
+    },
+    "ti_sku": {
+      "type": ["string", "null"],
+      "maxLength": 255
+    },
+    "ti_name": {
+      "type": ["string", "null"],
+      "maxLength": 255
+    },
+    "ti_category": {
+      "type": ["string", "null"],
+      "maxLength": 255
+    },
+    "ti_price": {
+      "type": ["number", "null"]
+    },
+    "ti_quantity": {
+      "type": ["integer", "null"]
+    },
+    "pp_xoffset_min": {
+      "type": ["integer", "null"]
+    },
+    "pp_xoffset_max": {
+      "type": ["integer", "null"]
+    },
+    "pp_yoffset_min": {
+      "type": ["integer", "null"]
+    },
+    "pp_yoffset_max": {
+      "type": ["integer", "null"]
+    },
+    "useragent": {
+      "type": ["string", "null"],
+      "maxLength": 1000
+    },
+    "br_name": {
+      "type": ["string", "null"],
+      "maxLength": 50
+    },
+    "br_family": {
+      "type": ["string", "null"],
+      "maxLength": 50
+    },
+    "br_version": {
+      "type": ["string", "null"],
+      "maxLength": 50
+    },
+    "br_type": {
+      "type": ["string", "null"],
+      "maxLength": 50
+    },
+    "br_renderengine": {
+      "type": ["string", "null"],
+      "maxLength": 50
+    },
+    "br_lang": {
+      "type": ["string", "null"],
+      "maxLength": 255
+    },
+    "br_features_pdf": {
+      "type": ["boolean", "null"]
+    },
+    "br_features_flash": {
+      "type": ["boolean", "null"]
+    },
+    "br_features_java": {
+      "type": ["boolean", "null"]
+    },
+    "br_features_director": {
+      "type": ["boolean", "null"]
+    },
+    "br_features_quicktime": {
+      "type": ["boolean", "null"]
+    },
+    "br_features_realplayer": {
+      "type": ["boolean", "null"]
+    },
+    "br_features_windowsmedia": {
+      "type": ["boolean", "null"]
+    },
+    "br_features_gears": {
+      "type": ["boolean", "null"]
+    },
+    "br_features_silverlight": {
+      "type": ["boolean", "null"]
+    },
+    "br_cookies": {
+      "type": ["boolean", "null"]
+    },
+    "br_colordepth": {
+      "type": ["string", "null"],
+      "maxLength": 12
+    },
+    "br_viewwidth": {
+      "type": ["integer", "null"]
+    },
+    "br_viewheight": {
+      "type": ["integer", "null"]
+    },
+    "os_name": {
+      "type": ["string", "null"],
+      "maxLength": 50
+    },
+    "os_family": {
+      "type": ["string", "null"],
+      "maxLength": 50
+    },
+    "os_manufacturer": {
+      "type": ["string", "null"],
+      "maxLength": 50
+    },
+    "os_timezone": {
+      "type": ["string", "null"],
+      "maxLength": 255
+    },
+    "dvce_type": {
+      "type": ["string", "null"],
+      "maxLength": 50
+    },
+    "dvce_ismobile": {
+      "type": ["boolean", "null"]
+    },
+    "dvce_screenwidth": {
+      "type": ["integer", "null"]
+    },
+    "dvce_screenheight": {
+      "type": ["integer", "null"]
+    },
+    "doc_charset": {
+      "type": ["string", "null"],
+      "maxLength": 128
+    },
+    "doc_width": {
+      "type": ["integer", "null"]
+    },
+    "doc_height": {
+      "type": ["integer", "null"]
+    },
+    "tr_currency": {
+      "type": ["string", "null"],
+      "maxLength": 3
+    },
+    "tr_total_base": {
+      "type": ["number", "null"]
+    },
+    "tr_tax_base": {
+      "type": ["number", "null"]
+    },
+    "tr_shipping_base": {
+      "type": ["number", "null"]
+    },
+    "ti_currency": {
+      "type": ["string", "null"],
+      "maxLength": 3
+    },
+    "ti_price_base": {
+      "type": ["number", "null"]
+    },
+    "base_currency": {
+      "type": ["string", "null"],
+      "maxLength": 3
+    },
+    "geo_timezone": {
+      "type": ["string", "null"],
+      "maxLength": 64
+    },
+    "mkt_clickid": {
+      "type": ["string", "null"],
+      "maxLength": 128
+    },
+    "mkt_network": {
+      "type": ["string", "null"],
+      "maxLength": 64
+    },
+    "etl_tags": {
+      "type": ["string", "null"],
+      "maxLength": 500
+    },
+    "dvce_sent_tstamp": {
+      "type": ["string", "null"],
+      "format": "date-time"
+    },
+    "refr_domain_userid": {
+      "type": ["string", "null"],
+      "maxLength": 128
+    },
+    "refr_dvce_tstamp": {
+      "type": ["string", "null"],
+      "format": "date-time"
+    },
+    "domain_sessionid": {
+      "type": ["string", "null"],
+      "maxLength": 128
+    },
+    "derived_tstamp": {
+      "type": ["string", "null"],
+      "format": "date-time"
+    },
+    "event_vendor": {
+      "type": ["string", "null"],
+      "maxLength": 1000
+    },
+    "event_name": {
+      "type": ["string", "null"],
+      "maxLength": 1000
+    },
+    "event_format": {
+      "type": ["string", "null"],
+      "maxLength": 128
+    },
+    "event_version": {
+      "type": ["string", "null"],
+      "maxLength": 128
+    },
+    "event_fingerprint": {
+      "type": ["string", "null"],
+      "maxLength": 128
+    },
+    "true_tstamp": {
+      "type": ["string", "null"],
+      "format": "date-time"
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
Enrichment uses the atomic event [schema](https://raw.githubusercontent.com/snowplow/iglu-central/master/schemas/com.snowplowanalytics.snowplow/atomic/jsonschema/1-0-0) for shredded data to validate the pipeline output.
*This enrichment is enabled by default.* And has to be explicitly disabled to allow shredding of events that won't match with the atomic event schema.

Config has a single parameter `disable`. Which was left for backward compatibility with the old behaviour. 

Config schema: https://github.com/snowplow/iglu-central/pull/1194

Events that failed by this enrichment could return: 
- `EnrichmentFailure` with identifier `shredded_validator`, in case of error converting `EnrichedEvent` to the shredded format. 
- `SchemaViolation.IgluError` refering to `iglu:com.snowplowanalytics.snowplow/atomic/jsonschema/1.0.0`.

If no errors were raised - events are sent downstream, as they did before this change.

Benchmarks (10 sec run/ 10 iteration / 1 thread):

Validation *enabled*:

```
[info] # Warmup Iteration   1: 120.519 us/op
[info] Iteration   1: 108.637 us/op
[info] Iteration   2: 99.207 us/op
[info] Iteration   3: 99.795 us/op
[info] Iteration   4: 100.925 us/op
[info] Iteration   5: 103.841 us/op
[info] Iteration   6: 111.455 us/op
[info] Iteration   7: 289.276 us/op
[info] Iteration   8: 352.504 us/op
[info] Iteration   9: 125.896 us/op
[info] Iteration  10: 99.814 us/op
[info] Result "com.snowplowanalytics.snowplow.enrich.bench.EtlPipelineBench.measureProcessEventsIO":
[info]   149.135 ±(99.9%) 139.235 us/op [Average]
[info]   (min, avg, max) = (99.207, 149.135, 352.504), stdev = 92.095
```


Validation *disabled*:

```
[info] # Warmup Iteration   1: 125.246 us/op
[info] Iteration   1: 99.984 us/op
[info] Iteration   2: 100.672 us/op
[info] Iteration   3: 99.633 us/op
[info] Iteration   4: 99.737 us/op
[info] Iteration   5: 98.294 us/op
[info] Iteration   6: 97.941 us/op
[info] Iteration   7: 97.828 us/op
[info] Iteration   8: 97.971 us/op
[info] Iteration   9: 103.606 us/op
[info] Iteration  10: 152.935 us/op
[info] Result "com.snowplowanalytics.snowplow.enrich.bench.EtlPipelineBench.measureProcessEventsIO":
[info]   104.860 ±(99.9%) 25.675 us/op [Average]
[info]   (min, avg, max) = (97.828, 104.860, 152.935), stdev = 16.982
```

Evidently, the results are not stable and a little counterintuitive. Based on my measurement this is a performance increase, which can't be right. So there are probably issues either with test settings, test cleanups, or just a noise introduced by something completely unrelated like GC. But solving this mystery is outside of the scope for this issue.

