### PR TITLE
Common: bump log4j to 2.15.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,7 +39,7 @@ object Dependencies {
     val yauaa            = "5.23"
     val guava            = "28.1-jre"
     val slf4j            = "1.7.26"
-    val log4j            = "2.13.3"
+    val log4j            = "2.15.0"
 
     val refererParser    = "1.1.0"
     val maxmindIplookups = "0.7.1"


### PR DESCRIPTION
This release mitigates CVE-2021-44228.

See:
- https://github.com/advisories/GHSA-jfh8-c2jp-5v3q
- https://github.com/apache/logging-log4j2/compare/rel/2.13.3...rel/2.15.0

