### PR TITLE
common-fs2: Add experimental metadata aggregation sink

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - master
       - develop
+      - 'snapshot/**'
   pull_request:
 
 jobs:
@@ -102,7 +103,7 @@ jobs:
 
   publish_docker:
     needs: test
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/snapshot')
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -114,6 +115,12 @@ jobs:
           - kinesis
     steps:
     - uses: actions/checkout@v2
+      if: startsWith(github.ref, 'refs/tags/')
+    - name: Checkout with history for version info
+      uses: actions/checkout@v2
+      if: startsWith(github.ref, 'refs/heads/snapshot')
+      with:
+        fetch-depth: 0
     - uses: coursier/cache-action@v6
     - name: Set up JDK 11
       uses: actions/setup-java@v1
@@ -125,8 +132,15 @@ jobs:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
     - name: Get current version
+      if: startsWith(github.ref, 'refs/tags/')
       id: ver
       run: echo "::set-output name=tag::${GITHUB_REF#refs/tags/}"
+    - name: Get current version (snapshot)
+      if: startsWith(github.ref, 'refs/heads/snapshot')
+      id: ver-snapshot
+      run: |
+        export SNAPSHOT_VERSION=$(sbt common/version -Dsbt.log.noformat=true | grep 'SNAPSHOT' | awk '{ print $2 }')
+        echo "::set-output name=tag::$SNAPSHOT_VERSION"
     - name: Get app package name
       id: packageName
       run: |
@@ -145,8 +159,9 @@ jobs:
       with:
         images: ${{ steps.packageName.outputs.package_name }}
         tags: |
-          type=raw,value=latest,enable=${{ !contains(steps.ver.outputs.tag, 'rc') }}
-          type=raw,value=${{ steps.ver.outputs.tag }}
+          type=raw,value=latest,enable=${{ !contains(steps.ver.outputs.tag, 'rc') && !contains(steps.ver-snapshot.outputs.tag, 'SNAPSHOT' )}}
+          type=raw,value=${{ steps.ver.outputs.tag }},enable=${{ contains(steps.ver.outputs.tag, 'rc') }}
+          type=raw,value=${{ steps.ver-snapshot.outputs.tag }},enable=${{ contains(steps.ver-snapshot.outputs.tag, 'SNAPSHOT') }}
         flavor: |
           latest=false
     - name: Set up QEMU

--- a/config/config.kinesis.extended.hocon
+++ b/config/config.kinesis.extended.hocon
@@ -405,4 +405,16 @@
     # More details: https://github.com/snowplow/enrich/issues/517#issuecomment-1033910690
     "acceptInvalid": false
   }
+
+  # Optional. Configuration for experimental/preview features
+  "experimental": {
+    # Whether to export metadata using a webhook URL.
+    # Follows iglu-webhook protocol.
+    "metadata": {
+      "endpoint": "https://my_pipeline.my_domain.com/iglu"
+      "interval": 5 minutes
+      "organizationId": "c5f3a09f-75f8-4309-bec5-fea560f78455"
+      "pipelineId": "75a13583-5c99-40e3-81fc-541084dfc784"
+    }
+  }
 }

--- a/config/config.pubsub.extended.hocon
+++ b/config/config.pubsub.extended.hocon
@@ -204,4 +204,16 @@
     # More details: https://github.com/snowplow/enrich/issues/517#issuecomment-1033910690
     "acceptInvalid": false
   }
+
+  # Optional. Configuration for experimental/preview features
+  "experimental": {
+    # Whether to export metadata using a webhook URL.
+    # Follows iglu-webhook protocol.
+    "metadata": {
+      "endpoint": "https://my_pipeline.my_domain.com/iglu"
+      "interval": 5 minutes
+      "organizationId": "c5f3a09f-75f8-4309-bec5-fea560f78455"
+      "pipelineId": "75a13583-5c99-40e3-81fc-541084dfc784"
+    }
+  }
 }

--- a/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/Environment.scala
+++ b/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/Environment.scala
@@ -46,6 +46,7 @@ import com.snowplowanalytics.snowplow.enrich.common.fs2.config.{ConfigFile, Pars
 import com.snowplowanalytics.snowplow.enrich.common.fs2.config.io.{Concurrency, Telemetry => TelemetryConfig}
 import com.snowplowanalytics.snowplow.enrich.common.fs2.io.{Clients, Metrics}
 import com.snowplowanalytics.snowplow.enrich.common.fs2.io.Clients.Client
+import com.snowplowanalytics.snowplow.enrich.common.fs2.io.experimental.Metadata
 
 import scala.concurrent.ExecutionContext
 import com.snowplowanalytics.snowplow.enrich.common.fs2.config.io.Input.Kinesis
@@ -72,6 +73,7 @@ import com.snowplowanalytics.snowplow.enrich.common.fs2.config.io.Input.Kinesis
  * @param getPayload          function that extracts the collector payload bytes from a record
  * @param sentry              optional sentry client
  * @param metrics             common counters
+ * @param metadata            metadata aggregations
  * @param assetsUpdatePeriod  time after which enrich assets should be refresh
  * @param goodAttributes      fields from an enriched event to use as output message attributes
  * @param piiAttributes       fields from a PII event to use as output message attributes
@@ -101,6 +103,7 @@ final case class Environment[F[_], A](
   getPayload: A => Array[Byte],
   sentry: Option[SentryClient],
   metrics: Metrics[F],
+  metadata: Metadata[F],
   assetsUpdatePeriod: Option[FiniteDuration],
   goodAttributes: EnrichedEvent => Map[String, String],
   piiAttributes: EnrichedEvent => Map[String, String],
@@ -109,7 +112,8 @@ final case class Environment[F[_], A](
   streamsSettings: Environment.StreamsSettings,
   region: Option[String],
   cloud: Option[Telemetry.Cloud],
-  acceptInvalid: Boolean
+  acceptInvalid: Boolean,
+  preShutdown: Option[() => F[Unit]]
 )
 
 object Environment {
@@ -169,6 +173,7 @@ object Environment {
       clts <- clients.map(Clients.init(http, _))
       igluClient <- IgluClient.parseDefault[F](parsedConfigs.igluJson).resource
       metrics <- Resource.eval(metricsReporter[F](blocker, file))
+      metadata <- Resource.eval(metadataReporter[F](file, processor.artifact, http))
       assets = parsedConfigs.enrichmentConfigs.flatMap(_.filesToCache)
       sem <- Resource.eval(Semaphore(1L))
       assetsState <- Resource.eval(Assets.State.make[F](blocker, sem, clts, assets))
@@ -189,6 +194,7 @@ object Environment {
       getPayload,
       sentry,
       metrics,
+      metadata,
       file.assetsUpdatePeriod,
       parsedConfigs.goodAttributes,
       parsedConfigs.piiAttributes,
@@ -197,7 +203,8 @@ object Environment {
       StreamsSettings(file.concurrency, maxRecordSize),
       getRegionFromConfig(file).orElse(getRegion),
       cloud,
-      acceptInvalid
+      acceptInvalid,
+      Some(() => metadata.submit.compile.drain)
     )
   }
 
@@ -218,6 +225,16 @@ object Environment {
 
   private def metricsReporter[F[_]: ConcurrentEffect: ContextShift: Timer](blocker: Blocker, config: ConfigFile): F[Metrics[F]] =
     config.monitoring.flatMap(_.metrics).map(Metrics.build[F](blocker, _)).getOrElse(Metrics.noop[F].pure[F])
+
+  private def metadataReporter[F[_]: ConcurrentEffect: ContextShift: Timer](
+    config: ConfigFile,
+    appName: String,
+    httpClient: HttpClient[F]
+  ): F[Metadata[F]] =
+    config.experimental
+      .flatMap(_.metadata)
+      .map(metadataConfig => Metadata.build[F](metadataConfig, Metadata.HttpMetadataReporter[F](metadataConfig, appName, httpClient)))
+      .getOrElse(Metadata.noop[F].pure[F])
 
   private implicit class EitherTOps[F[_], E: Show, A](eitherT: EitherT[F, E, A]) {
     def resource(implicit F: Sync[F]): Resource[F, A] = {

--- a/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/Run.scala
+++ b/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/Run.scala
@@ -151,7 +151,8 @@ object Run {
       val updates = Assets.run[F, A](env.blocker, env.semaphore, env.assetsUpdatePeriod, env.assetsState, env.enrichments)
       val telemetry = Telemetry.run[F, A](env)
       val reporting = env.metrics.report
-      val flow = enrich.merge(updates).merge(reporting).merge(telemetry)
+      val metadata = env.metadata.report
+      val flow = enrich.merge(updates).merge(reporting).merge(telemetry).merge(metadata)
       log >> flow.compile.drain.as(ExitCode.Success).recoverWith {
         case exception: Throwable =>
           Logger[F].error(s"The Enrich job has stopped") >>

--- a/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/io/experimental/Metadata.scala
+++ b/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/io/experimental/Metadata.scala
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.enrich.common.fs2.io.experimental
+
+import java.time.Instant
+import java.util.UUID
+
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+import cats.implicits._
+import cats.Applicative
+import cats.data.NonEmptyList
+import cats.effect.{Async, Clock, ConcurrentEffect, ContextShift, Resource, Sync, Timer}
+import cats.effect.concurrent.Ref
+import fs2.Stream
+import io.circe.Json
+import io.circe.parser._
+import io.circe.syntax._
+import org.http4s.Uri
+import org.http4s.client.Client
+
+import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer, SelfDescribingData}
+import com.snowplowanalytics.iglu.core.circe.implicits._
+import com.snowplowanalytics.snowplow.scalatracker.{Emitter, Tracker}
+import com.snowplowanalytics.snowplow.scalatracker.emitters.http4s.Http4sEmitter
+import com.snowplowanalytics.snowplow.enrich.common.fs2.config.io.{Metadata => MetadataConfig}
+import com.snowplowanalytics.snowplow.enrich.common.outputs.EnrichedEvent
+
+/**
+ * EXPERIMENTAL: This code is subject to change or being removed
+ *
+ * Aggregate relationships between events and entities
+ * observed over a given period of time.
+ */
+trait Metadata[F[_]] {
+  def report: Stream[F, Unit]
+  def submit: Stream[F, Unit]
+  def observe(event: EnrichedEvent): F[Unit]
+}
+
+object Metadata {
+  type EventsToEntities = Map[MetadataEvent, Set[SchemaKey]]
+
+  private implicit def unsafeLogger[F[_]: Sync]: Logger[F] =
+    Slf4jLogger.getLogger[F]
+
+  def build[F[_]: ContextShift: ConcurrentEffect: Timer](
+    config: MetadataConfig,
+    reporter: MetadataReporter[F]
+  ): F[Metadata[F]] =
+    MetadataEventsRef.init[F].map { observedRef =>
+      new Metadata[F] {
+        def report: Stream[F, Unit] =
+          for {
+            _ <- Stream.eval(Logger[F].info("Starting metadata repoter"))
+            _ <- Stream.fixedDelay[F](config.interval)
+            _ <- submit
+          } yield ()
+
+        def submit: Stream[F, Unit] =
+          for {
+            snapshot <- Stream.eval(MetadataEventsRef.snapshot(observedRef))
+            _ <- Stream
+                   .emits[F, MetadataEvent](snapshot.eventsToEntities.keySet.toSeq)
+                   .evalMap[F, Unit](reporter.report(snapshot.periodStart, snapshot.periodEnd)(_, snapshot.eventsToEntities))
+          } yield ()
+
+        def observe(event: EnrichedEvent): F[Unit] =
+          observedRef.eventsToEntities.update(recalculate(_, event))
+      }
+    }
+
+  def noop[F[_]: Async]: Metadata[F] =
+    new Metadata[F] {
+      def report: Stream[F, Unit] = Stream.never[F]
+      def submit: Stream[F, Unit] = Stream.never[F]
+      def observe(event: EnrichedEvent): F[Unit] = Applicative[F].unit
+    }
+
+  trait MetadataReporter[F[_]] {
+    def report(
+      periodStart: Instant,
+      periodEnd: Instant
+    )(
+      snapshot: MetadataEvent,
+      eventsToEntities: EventsToEntities
+    ): F[Unit]
+  }
+
+  case class HttpMetadataReporter[F[_]: ConcurrentEffect: Timer](
+    config: MetadataConfig,
+    appName: String,
+    client: Client[F]
+  ) extends MetadataReporter[F] {
+    def initTracker(
+      config: MetadataConfig,
+      appName: String,
+      client: Client[F]
+    ): Resource[F, Tracker[F]] =
+      for {
+        emitter <- Http4sEmitter.build(
+                     Emitter.EndpointParams(
+                       config.endpoint.host.map(_.toString()).getOrElse("localhost"),
+                       config.endpoint.port,
+                       https = config.endpoint.scheme.map(_ == Uri.Scheme.https).getOrElse(false)
+                     ),
+                     client,
+                     retryPolicy = Emitter.RetryPolicy.MaxAttempts(10),
+                     callback = Some(emitterCallback _)
+                   )
+      } yield new Tracker(NonEmptyList.of(emitter), "tracker-metadata", appName)
+
+    def report(
+      periodStart: Instant,
+      periodEnd: Instant
+    )(
+      event: MetadataEvent,
+      eventsToEntities: EventsToEntities
+    ): F[Unit] =
+      initTracker(config, appName, client).use { t =>
+        Logger[F].info(s"Tracking observed event ${event.schema.toSchemaUri}") >>
+          t.trackSelfDescribingEvent(
+            mkWebhookEvent(config.organizationId, config.pipelineId, periodStart, periodEnd, event),
+            eventsToEntities.find(_._1 == event).map(_._2).toSeq.flatMap(mkWebhookContexts)
+          ) >> t.flushEmitters()
+      }
+
+    private def emitterCallback(
+      params: Emitter.EndpointParams,
+      req: Emitter.Request,
+      res: Emitter.Result
+    ): F[Unit] =
+      res match {
+        case Emitter.Result.Success(_) =>
+          Logger[F].info(s"Metadata successfully sent to ${params.getGetUri}")
+        case Emitter.Result.Failure(code) =>
+          Logger[F].warn(s"Sending metadata got unexpected HTTP code $code from ${params.getUri}")
+        case Emitter.Result.TrackerFailure(exception) =>
+          Logger[F].warn(
+            s"Metadata failed to reach ${params.getUri} with following exception $exception after ${req.attempt} attempts"
+          )
+        case Emitter.Result.RetriesExceeded(failure) =>
+          Logger[F].error(s"Stopped trying to send metadata after following failure: $failure")
+      }
+  }
+
+  /**
+   * A metadata domain representation of an enriched event
+   *
+   * @param schema - schema key of given event
+   * @param source - `app_id` for given event
+   * @param tracker - `v_tracker` for given event
+   */
+  case class MetadataEvent(
+    schema: SchemaKey,
+    source: Option[String],
+    tracker: Option[String]
+  )
+  object MetadataEvent {
+    def apply(event: EnrichedEvent): MetadataEvent =
+      MetadataEvent(
+        SchemaKey(
+          Option(event.event_vendor).getOrElse("unknown-vendor"),
+          Option(event.event_name).getOrElse("unknown-name"),
+          Option(event.event_format).getOrElse("unknown-format"),
+          Option(event.event_version).toRight("unknown-version").flatMap(SchemaVer.parseFull).getOrElse(SchemaVer.Full(0, 0, 0))
+        ),
+        Option(event.app_id),
+        Option(event.v_tracker)
+      )
+  }
+
+  /**
+   * An representation of observed metadata events and entites attached to them over a period of time
+   *
+   * @param eventsToEntities - mappings of entities observed (since `periodStart`) for given `MetadataEvent`s
+   * @param periodStart - since when `eventsToEntities` are accumulated
+   * @param periodEnd - until when `eventsToEntities` are accumulated
+   */
+  case class MetadataSnapshot(
+    eventsToEntities: EventsToEntities,
+    periodStart: Instant,
+    periodEnd: Instant
+  )
+
+  /**
+   * Internal state representation for current metadata period
+   * @param eventsToEntities - mappings of entities observed (since `periodStart`) for given `MetadataEvent`s
+   * @param periodStart - since when `eventsToEntities` are accumulated
+   */
+  case class MetadataEventsRef[F[_]: Sync](
+    eventsToEntities: Ref[F, EventsToEntities],
+    periodStart: Ref[F, Instant]
+  )
+
+  object MetadataEventsRef {
+    def init[F[_]: Sync: Clock] =
+      for {
+        time <- Clock[F].instantNow
+        eventsToEntities <- Ref.of[F, EventsToEntities](Map.empty)
+        periodStart <- Ref.of[F, Instant](time)
+      } yield MetadataEventsRef(eventsToEntities, periodStart)
+    def snapshot[F[_]: Sync: Clock](ref: MetadataEventsRef[F]) =
+      for {
+        periodEnd <- Clock[F].instantNow
+        eventsToEntities <- ref.eventsToEntities.getAndSet(Map.empty)
+        periodStart <- ref.periodStart.getAndSet(periodEnd)
+      } yield MetadataSnapshot(eventsToEntities, periodStart, periodEnd)
+  }
+
+  def unwrapEntities(event: EnrichedEvent): Set[SchemaKey] = {
+    def unwrap(str: String) =
+      decode[SelfDescribingData[Json]](str)
+        .traverse(
+          _.data
+            .as[List[SelfDescribingData[Json]]]
+            .traverse(_.map(_.schema))
+            .flatMap(_.toList)
+        )
+        .flatMap(_.toList)
+        .toSet
+
+    unwrap(event.contexts) ++ unwrap(event.derived_contexts)
+  }
+
+  def schema(event: EnrichedEvent): SchemaKey =
+    SchemaKey(
+      Option(event.event_vendor).getOrElse("unknown-vendor"),
+      Option(event.event_name).getOrElse("unknown-name"),
+      Option(event.event_format).getOrElse("unknown-format"),
+      SchemaVer.parseFull(event.event_version).getOrElse(SchemaVer.Full(0, 0, 0))
+    )
+
+  def recalculate(previous: EventsToEntities, event: EnrichedEvent): EventsToEntities =
+    previous ++ Map(MetadataEvent(event) -> unwrapEntities(event))
+
+  def mkWebhookEvent(
+    organizationId: UUID,
+    pipelineId: UUID,
+    periodStart: Instant,
+    periodEnd: Instant,
+    event: MetadataEvent
+  ): SelfDescribingData[Json] =
+    SelfDescribingData(
+      SchemaKey("com.snowplowanalytics.console", "observed_event", "jsonschema", SchemaVer.Full(4, 0, 0)),
+      Json.obj(
+        "organizationId" -> organizationId.asJson,
+        "pipelineId" -> pipelineId.asJson,
+        "eventVendor" -> event.schema.vendor.asJson,
+        "eventName" -> event.schema.name.asJson,
+        "eventVersion" -> event.schema.version.asString.asJson,
+        "source" -> event.source.getOrElse("unknown-source").asJson,
+        "tracker" -> event.tracker.getOrElse("unknown-tracker").asJson,
+        "periodStart" -> periodStart.asJson,
+        "periodEnd" -> periodEnd.asJson
+      )
+    )
+
+  def mkWebhookContexts(entities: Set[SchemaKey]): Set[SelfDescribingData[Json]] =
+    entities.map(entity =>
+      SelfDescribingData[Json](
+        SchemaKey("com.snowplowanalytics.console", "observed_entity", "jsonschema", SchemaVer.Full(4, 0, 0)),
+        Json.obj("entityVendor" -> entity.vendor.asJson,
+                 "entityName" -> entity.name.asJson,
+                 "entityVersion" -> entity.version.asString.asJson
+        )
+      )
+    )
+}

--- a/modules/common-fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/config/ConfigFileSpec.scala
+++ b/modules/common-fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/config/ConfigFileSpec.scala
@@ -13,6 +13,7 @@
 package com.snowplowanalytics.snowplow.enrich.common.fs2.config
 
 import java.net.URI
+import java.util.UUID
 import java.nio.file.Paths
 
 import scala.concurrent.duration._
@@ -24,6 +25,8 @@ import cats.effect.IO
 import cats.effect.testing.specs2.CatsIO
 
 import _root_.io.circe.literal._
+
+import org.http4s.Uri
 
 import org.specs2.mutable.Specification
 
@@ -67,6 +70,18 @@ class ConfigFileSpec extends Specification with CatsIO {
         ),
         io.FeatureFlags(
           false
+        ),
+        Some(
+          io.Experimental(
+            Some(
+              io.Metadata(
+                Uri.uri("https://my_pipeline.my_domain.com/iglu"),
+                5.minutes,
+                UUID.fromString("c5f3a09f-75f8-4309-bec5-fea560f78455"),
+                UUID.fromString("75a13583-5c99-40e3-81fc-541084dfc784")
+              )
+            )
+          )
         )
       )
       ConfigFile.parse[IO](configPath.asRight).value.map(result => result must beRight(expected))
@@ -164,6 +179,18 @@ class ConfigFileSpec extends Specification with CatsIO {
         ),
         io.FeatureFlags(
           false
+        ),
+        Some(
+          io.Experimental(
+            Some(
+              io.Metadata(
+                Uri.uri("https://my_pipeline.my_domain.com/iglu"),
+                5.minutes,
+                UUID.fromString("c5f3a09f-75f8-4309-bec5-fea560f78455"),
+                UUID.fromString("75a13583-5c99-40e3-81fc-541084dfc784")
+              )
+            )
+          )
         )
       )
       ConfigFile.parse[IO](configPath.asRight).value.map(result => result must beRight(expected))
@@ -217,6 +244,14 @@ class ConfigFileSpec extends Specification with CatsIO {
           },
           "featureFlags" : {
             "acceptInvalid": false
+          },
+          "experimental": {
+            "metadata": {
+               "endpoint": "https://my_pipeline.my_domain.com/iglu",
+               "interval": "15 minutes",
+               "organizationId": "c5f3a09f-75f8-4309-bec5-fea560f78455",
+               "pipelineId": "75a13583-5c99-40e3-81fc-541084dfc784"
+            }
           }
         }"""
 

--- a/modules/common-fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/config/ParsedConfigsSpec.scala
+++ b/modules/common-fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/config/ParsedConfigsSpec.scala
@@ -13,11 +13,14 @@
 package com.snowplowanalytics.snowplow.enrich.common.fs2.config
 
 import java.net.URI
+import java.util.UUID
 import scala.concurrent.duration._
 
 import cats.effect.IO
 
 import cats.effect.testing.specs2.CatsIO
+
+import org.http4s.Uri
 
 import org.specs2.mutable.Specification
 
@@ -68,6 +71,18 @@ class ParsedConfigsSpec extends Specification with CatsIO {
         ),
         io.FeatureFlags(
           false
+        ),
+        Some(
+          io.Experimental(
+            Some(
+              io.Metadata(
+                Uri.uri("https://collector-g.snowplowanalytics.com"),
+                5.minutes,
+                UUID.fromString("c5f3a09f-75f8-4309-bec5-fea560f78455"),
+                UUID.fromString("75a13583-5c99-40e3-81fc-541084dfc784")
+              )
+            )
+          )
         )
       )
 

--- a/modules/common-fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/io/MetadataSpec.scala
+++ b/modules/common-fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/io/MetadataSpec.scala
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+
+package com.snowplowanalytics.snowplow.enrich.common.fs2.io.experimental
+
+import java.util.UUID
+import java.time.Instant
+import scala.concurrent.duration._
+
+import cats.effect.IO
+import cats.effect.concurrent.Ref
+import cats.effect.testing.specs2.CatsIO
+import org.http4s.Uri
+
+import org.specs2.mutable.Specification
+
+import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer}
+import com.snowplowanalytics.snowplow.enrich.common.outputs.EnrichedEvent
+import com.snowplowanalytics.snowplow.enrich.common.fs2.config.io.{Metadata => MetadataConfig}
+import Metadata.{MetadataEvent, MetadataReporter}
+
+class MetadataSpec extends Specification with CatsIO {
+  case class Report(
+    periodStart: Instant,
+    periodEnd: Instant,
+    event: SchemaKey,
+    entities: Set[SchemaKey]
+  )
+  case class TestReporter[F[_]](state: Ref[F, List[Report]]) extends MetadataReporter[F] {
+    def report(periodStart: Instant, periodEnd: Instant)(event: MetadataEvent, mappings: Map[MetadataEvent, Set[SchemaKey]]): F[Unit] =
+      state.update(
+        _ :+ Report(periodStart, periodEnd, event.schema, mappings.find(_._1 == event).map(_._2).toSet.flatten)
+      )
+  }
+
+  "Metadata" should {
+    "report observed events and entities" in {
+      val event = new EnrichedEvent()
+      event.contexts =
+        """{"schema":"iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-0","data":[{"schema":"iglu:com.snowplowanalytics.snowplow/web_page/jsonschema/1-0-0","data":{"id":"39a9934a-ddd3-4581-a4ea-d0ba20e63b92"}},{"schema":"iglu:org.w3/PerformanceTiming/jsonschema/1-0-0","data":{"navigationStart":1581931694397,"unloadEventStart":1581931696046,"unloadEventEnd":1581931694764,"redirectStart":0,"redirectEnd":0,"fetchStart":1581931694397,"domainLookupStart":1581931694440,"domainLookupEnd":1581931694513,"connectStart":1581931694513,"connectEnd":1581931694665,"secureConnectionStart":1581931694572,"requestStart":1581931694665,"responseStart":1581931694750,"responseEnd":1581931694750,"domLoading":1581931694762,"domInteractive":1581931695963,"domContentLoadedEventStart":1581931696039,"domContentLoadedEventEnd":1581931696039,"domComplete":0,"loadEventStart":0,"loadEventEnd":0}}]}"""
+      val config = MetadataConfig(
+        Uri.uri("https://localhost:443"),
+        50.millis,
+        UUID.fromString("dfc1aef8-2656-492b-b5ba-c77702f850bc"),
+        UUID.fromString("8c121fdd-dc8c-4cdc-bad1-3cefbe2b01ff")
+      )
+      for {
+        state <- Ref.of[IO, List[Report]](List.empty)
+        system <- Metadata.build[IO](config, TestReporter(state))
+        _ <- system.observe(event)
+        _ <- system.report.take(1).compile.drain
+        res <- state.get
+      } yield {
+        res.map(_.event) should containTheSameElementsAs(
+          List(SchemaKey("unknown-vendor", "unknown-name", "unknown-format", SchemaVer.Full(0, 0, 0)))
+        )
+        res.flatMap(_.entities) should containTheSameElementsAs(
+          Seq(
+            SchemaKey("com.snowplowanalytics.snowplow", "web_page", "jsonschema", SchemaVer.Full(1, 0, 0)),
+            SchemaKey("org.w3", "PerformanceTiming", "jsonschema", SchemaVer.Full(1, 0, 0))
+          )
+        )
+      }
+    }
+    "parse schemas for event's entities" in {
+      val event = new EnrichedEvent()
+      event.contexts =
+        """{"schema":"iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-0","data":[{"schema":"iglu:com.snowplowanalytics.snowplow/web_page/jsonschema/1-0-0","data":{"id":"39a9934a-ddd3-4581-a4ea-d0ba20e63b92"}},{"schema":"iglu:org.w3/PerformanceTiming/jsonschema/1-0-0","data":{"navigationStart":1581931694397,"unloadEventStart":1581931696046,"unloadEventEnd":1581931694764,"redirectStart":0,"redirectEnd":0,"fetchStart":1581931694397,"domainLookupStart":1581931694440,"domainLookupEnd":1581931694513,"connectStart":1581931694513,"connectEnd":1581931694665,"secureConnectionStart":1581931694572,"requestStart":1581931694665,"responseStart":1581931694750,"responseEnd":1581931694750,"domLoading":1581931694762,"domInteractive":1581931695963,"domContentLoadedEventStart":1581931696039,"domContentLoadedEventEnd":1581931696039,"domComplete":0,"loadEventStart":0,"loadEventEnd":0}}]}"""
+      val expected =
+        Seq(
+          SchemaKey("com.snowplowanalytics.snowplow", "web_page", "jsonschema", SchemaVer.Full(1, 0, 0)),
+          SchemaKey("org.w3", "PerformanceTiming", "jsonschema", SchemaVer.Full(1, 0, 0))
+        )
+
+      Metadata.unwrapEntities(event) should containTheSameElementsAs(expected)
+    }
+    "recalculate event aggregates" should {
+      "add new event type" in {
+        val eventVendor = "org.w3"
+        val eventName = "PerformanceTiming"
+        val eventVersion = SchemaVer.Full(1, 0, 0)
+        val eventFormat = "jsonschema"
+        val event = new EnrichedEvent()
+        event.event_name = eventName
+        event.event_vendor = eventVendor
+        event.event_version = eventVersion.asString
+        event.event_format = eventFormat
+        val source = "app123"
+        val tracker = "js-tracker-3.0.0"
+        event.v_tracker = tracker
+        event.app_id = source
+        Metadata.recalculate(Map.empty, event) should containTheSameElementsAs(
+          Seq((MetadataEvent(event) -> Set.empty))
+        )
+      }
+      "add new entities for a known event type" in {
+        val eventVendor = "org.w3"
+        val eventName = "PerformanceTiming"
+        val eventFormat = "jsonschema"
+        val eventVersion = SchemaVer.Full(1, 0, 0)
+        val tracker = "js-tracker-3.0.0"
+        val source = "app123"
+        val event = new EnrichedEvent()
+        event.event_name = eventName
+        event.event_vendor = eventVendor
+        event.event_format = eventFormat
+        event.event_version = eventVersion.asString
+        event.v_tracker = tracker
+        event.app_id = source
+        event.contexts =
+          """{"schema":"iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-0","data":[{"schema":"iglu:com.snowplowanalytics.snowplow/web_page/jsonschema/1-0-0","data":{"id":"39a9934a-ddd3-4581-a4ea-d0ba20e63b92"}},{"schema":"iglu:org.w3/PerformanceTiming/jsonschema/1-0-0","data":{"navigationStart":1581931694397,"unloadEventStart":1581931696046,"unloadEventEnd":1581931694764,"redirectStart":0,"redirectEnd":0,"fetchStart":1581931694397,"domainLookupStart":1581931694440,"domainLookupEnd":1581931694513,"connectStart":1581931694513,"connectEnd":1581931694665,"secureConnectionStart":1581931694572,"requestStart":1581931694665,"responseStart":1581931694750,"responseEnd":1581931694750,"domLoading":1581931694762,"domInteractive":1581931695963,"domContentLoadedEventStart":1581931696039,"domContentLoadedEventEnd":1581931696039,"domComplete":0,"loadEventStart":0,"loadEventEnd":0}}]}"""
+        val schema = SchemaKey(eventVendor, eventName, eventFormat, eventVersion)
+        val schemas = Set(
+          SchemaKey("com.snowplowanalytics.snowplow", "web_page", eventFormat, SchemaVer.Full(1, 0, 0)),
+          SchemaKey("org.w3", "PerformanceTiming", eventFormat, SchemaVer.Full(1, 0, 0))
+        )
+
+        Metadata.recalculate(Map(MetadataEvent(event) -> Set(schema)), event) should containTheSameElementsAs(
+          Seq((MetadataEvent(event) -> schemas))
+        )
+      }
+    }
+  }
+}

--- a/modules/common-fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/test/Aggregates.scala
+++ b/modules/common-fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/test/Aggregates.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.enrich.common.fs2.test
+
+import cats.effect.Sync
+import cats.effect.concurrent.Ref
+import fs2.Stream
+import com.snowplowanalytics.iglu.core.SchemaKey
+import com.snowplowanalytics.snowplow.enrich.common.outputs.EnrichedEvent
+import com.snowplowanalytics.snowplow.enrich.common.fs2.io.experimental.Metadata
+import com.snowplowanalytics.snowplow.enrich.common.fs2.io.experimental.Metadata.MetadataEvent
+
+object Aggregates {
+  def init[F[_]: Sync] = Ref.of[F, Map[MetadataEvent, Set[SchemaKey]]](Map.empty)
+
+  def metadata[F[_]](ref: Ref[F, Map[MetadataEvent, Set[SchemaKey]]]): Metadata[F] =
+    new Metadata[F] {
+      def report: Stream[F, Unit] = Stream.empty.covary[F]
+      def submit: Stream[F, Unit] = Stream.empty.covary[F]
+      def observe(event: EnrichedEvent): F[Unit] =
+        ref.update(Metadata.recalculate(_, event))
+    }
+}


### PR DESCRIPTION
This adds experimental metadata aggregation that allows exporting event-entity clusters for modelling purposes. Each predefined period of time we are sending the observed clusters to an iglu-compatible webhook.

We used to use `rc` tags to release code for testing purposes. As we now use docker images for that we only need to push these. With this change it is possible to push an image by creating a special `snapshot/` branch that will get the images pushed.