### PR TITLE
enrich-kinesis: add retry mechanism for the checkpointing (close #591)

### DIFF
--- a/config/config.kinesis.extended.hocon
+++ b/config/config.kinesis.extended.hocon
@@ -46,6 +46,14 @@
     # each buffer holding up to maxRecords from above
     "bufferSize": 3
 
+    # Optional. Settings for backoff policy for checkpointing.
+    # Records are checkpointed after all the records of the same chunk have been enriched
+    "checkpointBackoff": {
+      "minBackoff": 100 milliseconds
+      "maxBackoff": 10 seconds
+      "maxRetries": 10
+    }
+
     # Optional, endpoint url configuration to override aws kinesis endpoints
     # Can be used to specify local endpoint when using localstack
     # "customEndpoint": "http://localhost:4566"

--- a/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/Environment.scala
+++ b/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/Environment.scala
@@ -247,8 +247,8 @@ object Environment {
 
   private def getRegionFromConfig(file: ConfigFile): Option[String] =
     file.input match {
-      case Kinesis(_, _, region, _, _, _, _, _, _) =>
-        region
+      case k: Kinesis =>
+        k.region
       case _ =>
         None
     }

--- a/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/config/io.scala
+++ b/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/config/io.scala
@@ -54,6 +54,18 @@ object io {
 
   import ConfigFile.finiteDurationEncoder
 
+  case class CheckpointBackoff(
+    minBackoff: FiniteDuration,
+    maxBackoff: FiniteDuration,
+    maxRetries: Int
+  )
+  implicit val checkpointBackoffDecoder: Decoder[CheckpointBackoff] = deriveConfiguredDecoder[CheckpointBackoff]
+  implicit val checkpointBackoffEncoder: Encoder[CheckpointBackoff] = deriveConfiguredEncoder[CheckpointBackoff]
+
+  sealed trait RetryCheckpointing {
+    val checkpointBackoff: CheckpointBackoff
+  }
+
   /** Source of raw collector data (only PubSub supported atm) */
   sealed trait Input
 
@@ -80,10 +92,12 @@ object io {
       initialPosition: Kinesis.InitPosition,
       retrievalMode: Kinesis.Retrieval,
       bufferSize: Int,
+      checkpointBackoff: CheckpointBackoff,
       customEndpoint: Option[URI],
       dynamodbCustomEndpoint: Option[URI],
       cloudwatchCustomEndpoint: Option[URI]
     ) extends Input
+        with RetryCheckpointing
 
     object Kinesis {
       sealed trait InitPosition

--- a/modules/common-fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/config/ConfigFileSpec.scala
+++ b/modules/common-fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/config/ConfigFileSpec.scala
@@ -93,6 +93,7 @@ class ConfigFileSpec extends Specification with CatsIO {
           io.Input.Kinesis.InitPosition.TrimHorizon,
           io.Input.Kinesis.Retrieval.Polling(10000),
           3,
+          io.CheckpointBackoff(100.milli, 10.second, 10),
           None,
           None,
           None

--- a/modules/kinesis/src/main/resources/application.conf
+++ b/modules/kinesis/src/main/resources/application.conf
@@ -10,6 +10,11 @@
       "maxRecords": 10000
     }
     "bufferSize": 3
+    "checkpointBackoff": {
+      "minBackoff": 100 milliseconds
+      "maxBackoff": 10 seconds
+      "maxRetries": 10
+    }
   }
 
   "output": {

--- a/modules/kinesis/src/main/scala/com/snowplowanalytics/snowplow/enrich/kinesis/KinesisRun.scala
+++ b/modules/kinesis/src/main/scala/com/snowplowanalytics/snowplow/enrich/kinesis/KinesisRun.scala
@@ -61,7 +61,7 @@ object KinesisRun {
   }
 
   /** For each shard, the record with the biggest sequence number is found, and checkpointed. */
-  private def checkpoint[F[_]: Parallel: Sync](records: List[CommittableRecord]): F[Unit] =
+  private def checkpoint[F[_]: Parallel: Sync: Timer](records: List[CommittableRecord]): F[Unit] =
     records
       .groupBy(_.shardId)
       .foldLeft(List.empty[CommittableRecord]) { (acc, shardRecords) =>


### PR DESCRIPTION
I know that we like everything to be configurable, but I wonder if this is worth it for [these ones](https://github.com/snowplow/enrich/pull/592/files#diff-a4a13945ab9a250994b2e255a44ad844eb06dd339220a02d37ff65a46a29d3f7R91-R93), as this is only for checkpointing failures.