### PR TITLE
Set fixed termination period for pre-shutdown hook

### DIFF
--- a/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/Enrich.scala
+++ b/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/Enrich.scala
@@ -90,7 +90,7 @@ object Enrich {
       _.parEvalMap(env.streamsSettings.concurrency.sink)(sinkChunk(_, sinkOne(env), env.metrics.enrichLatency))
         .evalMap(env.checkpoint)
 
-    Stream.eval(runWithShutdown(enriched, sinkAndCheckpoint, env.preShutdown.getOrElse(() => Sync[F].unit)))
+    Stream.eval(runWithShutdown(enriched, sinkAndCheckpoint)).onComplete(env.preShutdown)
   }
 
   /**
@@ -262,8 +262,7 @@ object Enrich {
    */
   private def runWithShutdown[F[_]: Concurrent: Sync: Timer, A](
     enriched: Stream[F, List[(A, Result)]],
-    sinkAndCheckpoint: Pipe[F, List[(A, Result)], Unit],
-    preShutdown: () => F[Unit]
+    sinkAndCheckpoint: Pipe[F, List[(A, Result)], Unit]
   ): F[Unit] =
     Queue.synchronousNoneTerminated[F, List[(A, Result)]].flatMap { queue =>
       queue.dequeue
@@ -275,18 +274,18 @@ object Enrich {
         .bracketCase(_.join) {
           case (_, ExitCase.Completed) =>
             // The source has completed "naturally", e.g. processed all input files in the directory
-            preShutdown()
+            Sync[F].unit
           case (fiber, ExitCase.Canceled) =>
             // SIGINT received. We wait for the enriched events already in the queue to get sunk and checkpointed
-            preShutdown() *> terminateStream(queue, fiber)
+            terminateStream(queue, fiber)
           case (fiber, ExitCase.Error(e)) =>
             // Runtime exception in the stream of enriched events.
             // We wait for the enriched events already in the queue to get sunk and checkpointed.
             // We then raise the original exception
             Logger[F].error(e)("Unexpected error in enrich") *>
-              preShutdown() *> terminateStream(queue, fiber).handleErrorWith { e2 =>
-              Logger[F].error(e2)("Error when terminating the stream")
-            } *> Sync[F].raiseError(e)
+              terminateStream(queue, fiber).handleErrorWith { e2 =>
+                Logger[F].error(e2)("Error when terminating the stream")
+              } *> Sync[F].raiseError(e)
         }
     }
 

--- a/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/Environment.scala
+++ b/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/Environment.scala
@@ -12,7 +12,7 @@
  */
 package com.snowplowanalytics.snowplow.enrich.common.fs2
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
 
 import cats.Show
 import cats.data.EitherT
@@ -113,7 +113,7 @@ final case class Environment[F[_], A](
   region: Option[String],
   cloud: Option[Telemetry.Cloud],
   acceptInvalid: Boolean,
-  preShutdown: Option[() => F[Unit]]
+  preShutdown: Stream[F, Unit]
 )
 
 object Environment {
@@ -204,7 +204,7 @@ object Environment {
       getRegionFromConfig(file).orElse(getRegion),
       cloud,
       acceptInvalid,
-      Some(() => metadata.submit.compile.drain)
+      metadata.submit.interruptAfter(1.minute)
     )
   }
 

--- a/modules/common-fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/test/TestEnvironment.scala
+++ b/modules/common-fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/test/TestEnvironment.scala
@@ -160,7 +160,7 @@ object TestEnvironment extends CatsIO {
                       None,
                       None,
                       true,
-                      None
+                      Stream.empty[IO]
                     )
       _ <- Resource.eval(logger.info("TestEnvironment initialized"))
     } yield TestEnvironment(environment, counter, goodRef.get, piiRef.get, badRef.get)


### PR DESCRIPTION
Previously it was possible for pre-shutdown hook to take longer than expected resulting in a slow shutdown.
This affected integration test for kinesis and may have extended graceful shutdown time if the metadata endpoint was very slow to respond.

