### PR TITLE
Kinesis: verifyCertificates option to skip SSL cert verification for custom endpoints (fixes #631)

### DIFF
--- a/config/config.kinesis.extended.hocon
+++ b/config/config.kinesis.extended.hocon
@@ -143,6 +143,10 @@
       # Needs to be specified along with customEndpoint
       # "customPort": 4566
 
+      # Optional, should Kinesis KPL producer validate SSL certificate of the endpoint
+      # Can be used with custom localstack endpoints
+      # "verifyCertificates": false
+
       # Optional. Use a custom Cloudwatch endpoint.
       # Note this does not accept protocols or paths, only host names or ip addresses.
       # There is no way to disable TLS
@@ -229,6 +233,10 @@
       # Needs to be specified along with customEndpoint
       # "customPort": 4566
 
+      # Optional, should Kinesis KPL producer validate SSL certificate of the endpoint
+      # Can be used with custom localstack endpoints
+      # "verifyCertificates": false
+
       # Optional. Use a custom Cloudwatch endpoint.
       # Note this does not accept protocols or paths, only host names or ip addresses.
       # There is no way to disable TLS
@@ -306,6 +314,10 @@
       # Optional. Server port to connect to for Kinesis.
       # Needs to be specified along with customEndpoint
       # "customPort": 4566
+
+      # Optional, should Kinesis KPL producer validate SSL certificate of the endpoint
+      # Can be used with custom localstack endpoints
+      # "verifyCertificates": false
 
       # Optional. Use a custom Cloudwatch endpoint.
       # Note this does not accept protocols or paths, only host names or ip addresses.

--- a/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/config/ParsedConfigs.scala
+++ b/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/config/ParsedConfigs.scala
@@ -109,7 +109,7 @@ object ParsedConfigs {
             if (invalidAttributes.nonEmpty) NonEmptyList(invalidAttributes.head, invalidAttributes.tail.toList).invalid
             else output.valid
           }
-      case OutputConfig.Kinesis(_, _, Some(key), _, _, _, _, _, _, _, _, _, _, _) if !enrichedFieldsMap.contains(key) =>
+      case OutputConfig.Kinesis(_, _, Some(key), _, _, _, _, _, _, _, _, _, _, _, _) if !enrichedFieldsMap.contains(key) =>
         NonEmptyList.one(s"Partition key $key not valid").invalid
       case _ =>
         output.valid
@@ -123,7 +123,7 @@ object ParsedConfigs {
             attributes.contains(s)
         }
         attributesFromFields(fields)
-      case OutputConfig.Kinesis(_, _, Some(key), _, _, _, _, _, _, _, _, _, _, _) =>
+      case OutputConfig.Kinesis(_, _, Some(key), _, _, _, _, _, _, _, _, _, _, _, _) =>
         val fields = ParsedConfigs.enrichedFieldsMap.filter {
           case (s, _) =>
             s == key

--- a/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/config/io.scala
+++ b/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/config/io.scala
@@ -232,7 +232,8 @@ object io {
       customEndpoint: Option[URI],
       customPort: Option[Long],
       cloudwatchEndpoint: Option[URI],
-      cloudwatchPort: Option[Long]
+      cloudwatchPort: Option[Long],
+      verifyCertificates: Option[Boolean]
     ) extends Output
 
     case class BackoffPolicy(

--- a/modules/common-fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/config/ConfigFileSpec.scala
+++ b/modules/common-fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/config/ConfigFileSpec.scala
@@ -113,6 +113,7 @@ class ConfigFileSpec extends Specification with CatsIO {
             None,
             None,
             None,
+            None,
             None
           ),
           Some(
@@ -130,6 +131,7 @@ class ConfigFileSpec extends Specification with CatsIO {
               None,
               None,
               None,
+              None,
               None
             )
           ),
@@ -144,6 +146,7 @@ class ConfigFileSpec extends Specification with CatsIO {
             None,
             24,
             "warning",
+            None,
             None,
             None,
             None,

--- a/modules/kinesis/src/main/scala/com/snowplowanalytics/snowplow/enrich/kinesis/Sink.scala
+++ b/modules/kinesis/src/main/scala/com/snowplowanalytics/snowplow/enrich/kinesis/Sink.scala
@@ -106,9 +106,12 @@ object Sink {
     }
 
     val withKinesisEndpoint =
-      (config.customEndpoint, config.customPort)
-        .mapN { case (host, port) => withAggregation.setKinesisEndpoint(host.toString).setKinesisPort(port) }
-        .getOrElse(producerConfig)
+      (config.customEndpoint, config.customPort, config.verifyCertificates) match {
+        case (Some(host), Some(port), Some(verify)) =>
+          withAggregation.setKinesisEndpoint(host.toString).setKinesisPort(port).setVerifyCertificate(verify)
+        case (Some(host), Some(port), None) => withAggregation.setKinesisEndpoint(host.toString).setKinesisPort(port)
+        case _ => producerConfig
+      }
 
     val withCloudwatchEndpoint =
       (config.cloudwatchEndpoint, config.cloudwatchPort)


### PR DESCRIPTION
This PR adds an optional `verifyCertificates` parameter to the kinesis output config block to skip SSL verification completely for custom endpoints.

I've also considered being "smart" and not adding a separate option, and just disable the SSL in a case if custom endpoint is set, but then:
* How to distinguish between custom AWS-managed per-region per-az endpoints, which should still have valid SSL and local ones?
* If using docker-compose, the localstack endpoint may have non `127.0.0.1` address, and not a `localhost` one

So that's why custom option.

