### PR TITLE
Common: Explicitly set Accept header

### DIFF
--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/utils/HttpClient.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/utils/HttpClient.scala
@@ -38,10 +38,10 @@ object HttpClient {
   def apply[F[_]](implicit ev: HttpClient[F]): HttpClient[F] = ev
 
   private[utils] def getHeaders(authUser: Option[String], authPassword: Option[String]): Headers = {
-    val contentTypeHeader = Header("content-type", "application/json")
+    val alwaysIncludedHeaders = List(Header("content-type", "application/json"), Header("accept", "*/*"))
     if (authUser.isDefined || authPassword.isDefined)
-      Headers(Authorization(BasicCredentials(authUser.getOrElse(""), authPassword.getOrElse(""))), contentTypeHeader)
-    else Headers(contentTypeHeader)
+      Headers(Authorization(BasicCredentials(authUser.getOrElse(""), authPassword.getOrElse(""))) :: alwaysIncludedHeaders)
+    else Headers(alwaysIncludedHeaders)
   }
 
   implicit def syncHttpClient[F[_]: Sync](implicit http4sClient: Http4sClient[F]): HttpClient[F] =
@@ -168,7 +168,7 @@ object HttpClient {
 
     def maybePostData(body: Option[String]): HttpRequest =
       body
-        .map(data => request.postData(data).header("content-type", "application/json"))
+        .map(data => request.postData(data).header("content-type", "application/json").header("accept", "*/*"))
         .getOrElse(request)
   }
 }

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/apirequest/HttpClientSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/apirequest/HttpClientSpec.scala
@@ -20,20 +20,23 @@ import org.specs2.mock.Mockito
 
 class HttpClientSpec extends Specification with ValidatedMatchers with Mockito {
   def is = s2"""
-  getHeaders returns an Authorization header and a content-type header if authUser or authPassword is defined $e1
+  getHeaders returns Authorization, accept header and content-type headers if authUser or authPassword is defined $e1
   getHeaders does not return an Authorization header if authUser and authPassword are not defined  $e2
   """
 
   def e1 = {
     val headers = HttpClient.getHeaders(None, Some("2778e1d8-500b-4f9f-a14e-f68b6b4e7b9f"))
     val expected =
-      Headers(Authorization(BasicCredentials("", "2778e1d8-500b-4f9f-a14e-f68b6b4e7b9f")), Header("content-type", "application/json"))
+      Headers(Authorization(BasicCredentials("", "2778e1d8-500b-4f9f-a14e-f68b6b4e7b9f")),
+              Header("content-type", "application/json"),
+              Header("accept", "*/*")
+      )
     headers must beEqualTo(expected)
   }
 
   def e2 = {
     val headers = HttpClient.getHeaders(None, None)
-    val expected = Headers(Header("content-type", "application/json"))
+    val expected = Headers(Header("content-type", "application/json"), Header("accept", "*/*"))
     headers must beEqualTo(expected)
   }
 }


### PR DESCRIPTION
See https://github.com/snowplow/enrich/issues/667


Notes on additional checks
### 1 - api request enrichment works on a pipeline - this will make http requests via syncHttpClient 
1. this change is in [3.2.4-rc1](https://github.com/snowplow/enrich/actions/runs/2819071351)
2. I brought up a GCP pipeline and ensured enrichment version was set to 3.2.4-rc1
3. I set up a minimal `api_request_enrichment_config.json` which configures an api, one input and one output
4. I added a schema to the dev sandbox iglu server to configure the output in `api_request_enrichment_config.json`
5. I added a subscription to the good event topic so that I'd be able to pull and look at good events
6. I sent a test event to the collector of my GCP pipeline
7. I was able to see the good event coming through, enriched with the output field I had defined in `api_request_enrichment_config.json` and matching the schema I added to the iglu server. 

### 2 - api request enrichment works on a mini - this will make requests via idHttpClient
1. made a [branch](https://github.com/snowplow/snowplow-mini/compare/master...test-enrich-3.2.4-rc1) of mini that uses enrich 3.2.4-rc1 (and also has a fix that is needed for cutting a snowplow mini rc) to create mini version 0.14.2-rc2
2. I brought up an instance of mini in the aws sandbox that used the ami corresponding to 0.14.2-rc2
3. I configured a [simple api request enrichment](https://gist.github.com/lmath/b64e2bdbbcd74d74e8dca40b12270573) with one input and one output 
4. I added a schema that was listed in my config's output
```
curl -v POST http://<mini address>/schemas -d '{"$schema":"http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#","self":{"vendor":"com.leighan","name":"geo_location","format":"jsonschema","version":"1-0-0"},"description":"geo location","properties":{"country":{"type":"string","maxLength":255,"description":"Mandatory field to describe the country"}},"additionalProperties":true,"type":"object","required":["country"]}' --header 'apikey: <apikey for my mini>'
```
5. I sent this test event 
```
curl -i -X POST http://<mini address>/com.snowplowanalytics.snowplow/tp2 -H 'Content-Type: application/json' -d '{"schema":"iglu:com.snowplowanalytics.snowplow/payload_data/jsonschema/1-0-4","data":[{"p":"web","e":"pv","tv":"js-2.16.1","aid":"snowplow-support-test","ip":"18.194.133.57","ua":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36"}]}'
```
5. and saw the event come through as a good event with the context 🎉 
![image](https://user-images.githubusercontent.com/3072877/183685667-f3ea01b7-6e09-44a0-b531-7eb5e0ecfd5e.png)
