### PR TITLE
Common: api_request_enrichment_config schema version 1-0-1 support

### DIFF
--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/apirequest/ApiRequestEnrichment.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/apirequest/ApiRequestEnrichment.scala
@@ -40,7 +40,6 @@ object ApiRequestEnrichment extends ParseableEnrichment {
       "api_request_enrichment_config",
       "jsonschema",
       1,
-      0,
       0
     )
 


### PR DESCRIPTION
See: https://github.com/snowplow/enrich/issues/669


### check 1 - api request enrichment with schema version 1-0-0 works on a pipeline
this change is in 3.2.4-rc2
1. I brought up a GCP pipeline and ensured enrichment version was set to 3.2.4-rc2
2. I set up a minimal api_request_enrichment_config.json which configures an api, one input and one output which is valid for schema version 1-0-0 (has a non-zero value for cache size)
3. I added a schema to the dev sandbox iglu server to configure the output in api_request_enrichment_config.json
4. I added a subscription to the good event topic so that I'd be able to pull and look at good events
5. I sent a test event to the collector of my GCP pipeline
6. I was able to see the good event coming through, enriched with the output field I had defined in api_request_enrichment_config.json and matching the schema I added to the iglu server.

### check 2 - api request enrichment with schema version 1-0-1 works on a pipeline
same as above, except for 2:
I set up a minimal api_request_enrichment_config.json which configures an api, one input and one output which is valid for schema version 1-0-1 (where cache size is 0) and then re-ran `terraform apply`
