### PR TITLE
Bump postgresql to 42.2.26

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,7 +34,7 @@ object Dependencies {
     val jodaTime         = "2.10.1"
     val useragent        = "1.21"
     val uaParser         = "1.4.3"
-    val postgresDriver   = "42.2.25"
+    val postgresDriver   = "42.2.26"
     val mysqlConnector   = "8.0.29"
     val hikariCP         = "5.0.1"
     val jaywayJsonpath   = "2.7.0"


### PR DESCRIPTION
Before bump:

```
snyk test
```

>  ✗ SQL Injection [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGPOSTGRESQL-2970521] in org.postgresql:postgresql@42.2.25
    introduced by com.snowplowanalytics:snowplow-common-enrich_2.12@3.2.3 > org.postgresql:postgresql@42.2.25 and 8 other path(s)
>  This issue was fixed in versions: 42.2.26, 42.4.1

After bump:

```
snyk test
```

> [No high-severity vulnerabilities]

