### PR TITLE
enrich-kinesis: add STS v2 to runtime dependencies (close #643)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -69,9 +69,9 @@ object Dependencies {
     val awsSdk           = "1.12.129"
     val gcpSdk           = "2.7.2"
     val kinesisClient    = "1.14.5"
-    val kinesisClient2   = "2.4.1" // Override version from fs2-aws
+    val awsSdk2          = "2.17.287"
     val kafka            = "2.8.1"
-    val mskAuth          = "1.1.1"
+    val mskAuth          = "1.1.4"
     val nsqClient        = "1.3.0"
     val jackson          = "2.13.3"
     val config           = "1.3.4"
@@ -191,7 +191,11 @@ object Dependencies {
     val fs2Aws           = "io.laserdisc"                     %% "fs2-aws"                               % V.fs2Aws
     val fs2              = "co.fs2"                           %% "fs2-core"                              % V.fs2
     val fs2Io            = "co.fs2"                           %% "fs2-io"                                % V.fs2
-    val kinesisClient2   = "software.amazon.kinesis"          %  "amazon-kinesis-client"                 % V.kinesisClient2
+    val kinesisSdk2      = "software.amazon.awssdk"           %  "kinesis"                               % V.awsSdk2
+    val dynamoDbSdk2     = "software.amazon.awssdk"           %  "dynamodb"                              % V.awsSdk2
+    val s3Sdk2           = "software.amazon.awssdk"           %  "s3"                                    % V.awsSdk2
+    val cloudwatchSdk2   = "software.amazon.awssdk"           %  "cloudwatch"                            % V.awsSdk2
+    val stsSdk2          = "software.amazon.awssdk"           %  "sts"                                   % V.awsSdk2         % Runtime
     val http4sClient     = "org.http4s"                       %% "http4s-blaze-client"                   % V.http4s
     val http4sCirce      = "org.http4s"                       %% "http4s-circe"                          % V.http4s
     val log4cats         = "org.typelevel"                    %% "log4cats-slf4j"                        % V.log4cats
@@ -327,7 +331,11 @@ object Dependencies {
       kinesisSdk,
       fs2BlobS3,
       fs2Aws,
-      kinesisClient2,
+      kinesisSdk2,
+      dynamoDbSdk2,
+      s3Sdk2,
+      cloudwatchSdk2,
+      stsSdk2,
       sts,
       specs2
     )


### PR DESCRIPTION
I took the opportunity to set the versions of all the AWS SDK v2 that we use in `enrich-kinesis` (kinesis, dynamoDb, s3, sts, cloudwatch) to the same version.