### PR TITLE
fix: add mskAuth to kafka depedencies

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -359,7 +359,8 @@ object Dependencies {
 
     val kafkaDependencies = Seq(
       fs2Kafka,
-      kafkaClients // override kafka-clients 2.8.1 from fs2Kafka to address https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHEKAFKA-3027430
+      kafkaClients, // override kafka-clients 2.8.1 from fs2Kafka to address https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHEKAFKA-3027430
+      mskAuth
     )
 
     // exclusions


### PR DESCRIPTION
kafka-enrich is throwing Class software.amazon.msk.auth.iam.IAMClientCallbackHandler could not be found.

<!--
Thank you for contributing to Snowplow Enrich!

You'll find a small checklist below which should help speed up the review process:

- [X] Have you signed the [contributor license agreement](https://github.com/snowplow/snowplow/wiki/CLA)?
- [ ] Have you read the [contributing guide](https://github.com/snowplow/enrich/blob/master/CONTRIBUTING.md)?
- [ ] Have you added the appropriate unit tests?
- [ ] Have you run the tests through `sbt test`?
- [X] Is your pull request against the `master` branch?
-->

