### PR TITLE
Make schemas configurable in adapters (close #791)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ lazy val streamCommon = project
   .settings(streamCommonBuildSettings)
   .settings(libraryDependencies ++= streamCommonDependencies)
   .settings(excludeDependencies ++= exclusions)
-  .dependsOn(common)
+  .dependsOn(common % "test->test;compile->compile")
 
 lazy val streamKinesis = project
   .in(file("modules/stream/kinesis"))
@@ -105,7 +105,7 @@ lazy val commonFs2 = project
   .settings(Defaults.itSettings)
   .configs(IntegrationTest)
   .settings(addCompilerPlugin(betterMonadicFor))
-  .dependsOn(common)
+  .dependsOn(common % "test->test;compile->compile")
 
 
 lazy val pubsub = project

--- a/modules/bench/src/test/scala/com.snowplowanalytics.snowplow.enrich.bench/EtlPipelineBench.scala
+++ b/modules/bench/src/test/scala/com.snowplowanalytics.snowplow.enrich.bench/EtlPipelineBench.scala
@@ -28,8 +28,7 @@ import com.snowplowanalytics.iglu.client.{Resolver, Client, CirceValidator}
 import com.snowplowanalytics.snowplow.enrich.common.EtlPipeline
 import com.snowplowanalytics.snowplow.enrich.common.adapters.AdapterRegistry
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.EnrichmentRegistry
-
-import com.snowplowanalytics.snowplow.enrich.pubsub.{Enrich, EnrichSpec}
+import com.snowplowanalytics.snowplow.enrich.common.SpecHelpers.adaptersSchemas
 
 import org.joda.time.DateTime
 
@@ -75,7 +74,7 @@ object EtlPipelineBench {
     @Setup(Level.Trial)
     def setup(): Unit = {
       dateTime = DateTime.parse("2010-06-30T01:20+02:00")
-      adapterRegistry = new AdapterRegistry()
+      adapterRegistry = new AdapterRegistry(adaptersSchemas = adaptersSchemas)
       enrichmentRegistryId = EnrichmentRegistry[Id]()
       enrichmentRegistryIo = EnrichmentRegistry[IO]()
       clientId = Client[Id, Json](Resolver(List(), None), CirceValidator)

--- a/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/Environment.scala
+++ b/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/Environment.scala
@@ -198,7 +198,7 @@ object Environment {
       metadata <- Resource.eval(metadataReporter[F](file, processor.artifact, http))
       assets = parsedConfigs.enrichmentConfigs.flatMap(_.filesToCache)
       (remoteAdaptersHttpClient, remoteAdapters) <- prepareRemoteAdapters[F](file.remoteAdapters, ec, metrics)
-      adapterRegistry = new AdapterRegistry(remoteAdapters)
+      adapterRegistry = new AdapterRegistry(remoteAdapters, file.adaptersSchemas)
       sem <- Resource.eval(Semaphore(1L))
       assetsState <- Resource.eval(Assets.State.make[F](blocker, sem, clts, assets))
       shifter <- ShiftExecution.ofSingleThread[F]

--- a/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/config/io.scala
+++ b/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/config/io.scala
@@ -25,11 +25,11 @@ import scala.concurrent.duration.{Duration, FiniteDuration}
 import _root_.io.circe.{Decoder, DecodingFailure, Encoder}
 import _root_.io.circe.generic.extras.semiauto._
 import _root_.io.circe.config.syntax._
-import _root_.io.circe.DecodingFailure
 
 import org.http4s.{ParseFailure, Uri}
 
 import com.snowplowanalytics.snowplow.enrich.common.EtlPipeline.{FeatureFlags => CommonFeatureFlags}
+import com.snowplowanalytics.snowplow.enrich.common.adapters._
 
 object io {
 
@@ -511,5 +511,76 @@ object io {
         acceptInvalid = ff.acceptInvalid,
         legacyEnrichmentOrder = ff.legacyEnrichmentOrder
       )
+  }
+
+  object AdaptersSchemasEncoderDecoders {
+    implicit val adaptersSchemasDecoder: Decoder[AdaptersSchemas] =
+      deriveConfiguredDecoder[AdaptersSchemas]
+    implicit val adaptersSchemasEncoder: Encoder[AdaptersSchemas] =
+      deriveConfiguredEncoder[AdaptersSchemas]
+    implicit val callrailSchemasDecoder: Decoder[CallrailSchemas] =
+      deriveConfiguredDecoder[CallrailSchemas]
+    implicit val callrailSchemasEncoder: Encoder[CallrailSchemas] =
+      deriveConfiguredEncoder[CallrailSchemas]
+    implicit val cloudfrontAccessLogSchemasDecoder: Decoder[CloudfrontAccessLogSchemas] =
+      deriveConfiguredDecoder[CloudfrontAccessLogSchemas]
+    implicit val cloudfrontAccessLogSchemasEncoder: Encoder[CloudfrontAccessLogSchemas] =
+      deriveConfiguredEncoder[CloudfrontAccessLogSchemas]
+    implicit val googleAnalyticsSchemasDecoder: Decoder[GoogleAnalyticsSchemas] =
+      deriveConfiguredDecoder[GoogleAnalyticsSchemas]
+    implicit val googleAnalyticsSchemasEncoder: Encoder[GoogleAnalyticsSchemas] =
+      deriveConfiguredEncoder[GoogleAnalyticsSchemas]
+    implicit val hubspotSchemasDecoder: Decoder[HubspotSchemas] =
+      deriveConfiguredDecoder[HubspotSchemas]
+    implicit val hubspotSchemasEncoder: Encoder[HubspotSchemas] =
+      deriveConfiguredEncoder[HubspotSchemas]
+    implicit val mailchimpSchemasDecoder: Decoder[MailchimpSchemas] =
+      deriveConfiguredDecoder[MailchimpSchemas]
+    implicit val mailchimpSchemasEncoder: Encoder[MailchimpSchemas] =
+      deriveConfiguredEncoder[MailchimpSchemas]
+    implicit val mailgunSchemasDecoder: Decoder[MailgunSchemas] =
+      deriveConfiguredDecoder[MailgunSchemas]
+    implicit val mailgunSchemasEncoder: Encoder[MailgunSchemas] =
+      deriveConfiguredEncoder[MailgunSchemas]
+    implicit val mandrillSchemasDecoder: Decoder[MandrillSchemas] =
+      deriveConfiguredDecoder[MandrillSchemas]
+    implicit val mandrillSchemasEncoder: Encoder[MandrillSchemas] =
+      deriveConfiguredEncoder[MandrillSchemas]
+    implicit val marketoSchemasDecoder: Decoder[MarketoSchemas] =
+      deriveConfiguredDecoder[MarketoSchemas]
+    implicit val marketoSchemasEncoder: Encoder[MarketoSchemas] =
+      deriveConfiguredEncoder[MarketoSchemas]
+    implicit val olarkSchemasDecoder: Decoder[OlarkSchemas] =
+      deriveConfiguredDecoder[OlarkSchemas]
+    implicit val olarkSchemasEncoder: Encoder[OlarkSchemas] =
+      deriveConfiguredEncoder[OlarkSchemas]
+    implicit val pagerdutySchemasDecoder: Decoder[PagerdutySchemas] =
+      deriveConfiguredDecoder[PagerdutySchemas]
+    implicit val pagerdutySchemasEncoder: Encoder[PagerdutySchemas] =
+      deriveConfiguredEncoder[PagerdutySchemas]
+    implicit val pingdomSchemasDecoder: Decoder[PingdomSchemas] =
+      deriveConfiguredDecoder[PingdomSchemas]
+    implicit val pingdomSchemasEncoder: Encoder[PingdomSchemas] =
+      deriveConfiguredEncoder[PingdomSchemas]
+    implicit val sendgridSchemasDecoder: Decoder[SendgridSchemas] =
+      deriveConfiguredDecoder[SendgridSchemas]
+    implicit val sendgridSchemasEncoder: Encoder[SendgridSchemas] =
+      deriveConfiguredEncoder[SendgridSchemas]
+    implicit val statusgatorSchemasDecoder: Decoder[StatusGatorSchemas] =
+      deriveConfiguredDecoder[StatusGatorSchemas]
+    implicit val statusgatorSchemasEncoder: Encoder[StatusGatorSchemas] =
+      deriveConfiguredEncoder[StatusGatorSchemas]
+    implicit val unbounceSchemasDecoder: Decoder[UnbounceSchemas] =
+      deriveConfiguredDecoder[UnbounceSchemas]
+    implicit val unbounceSchemasEncoder: Encoder[UnbounceSchemas] =
+      deriveConfiguredEncoder[UnbounceSchemas]
+    implicit val urbanAirshipSchemasDecoder: Decoder[UrbanAirshipSchemas] =
+      deriveConfiguredDecoder[UrbanAirshipSchemas]
+    implicit val urbanAirshipSchemasEncoder: Encoder[UrbanAirshipSchemas] =
+      deriveConfiguredEncoder[UrbanAirshipSchemas]
+    implicit val veroSchemasDecoder: Decoder[VeroSchemas] =
+      deriveConfiguredDecoder[VeroSchemas]
+    implicit val veroSchemasEncoder: Encoder[VeroSchemas] =
+      deriveConfiguredEncoder[VeroSchemas]
   }
 }

--- a/modules/common-fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/EventGenEtlPipelineSpec.scala
+++ b/modules/common-fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/EventGenEtlPipelineSpec.scala
@@ -20,11 +20,13 @@ import com.snowplowanalytics.iglu.client.IgluCirceClient
 import com.snowplowanalytics.iglu.client.resolver.registries.Registry
 import com.snowplowanalytics.snowplow.badrows.{BadRow, Processor}
 import com.snowplowanalytics.snowplow.enrich.common.EtlPipeline
-import com.snowplowanalytics.snowplow.enrich.common.adapters.AdapterRegistry
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.EnrichmentRegistry
 import com.snowplowanalytics.snowplow.enrich.common.loaders._
 import com.snowplowanalytics.snowplow.enrich.common.outputs.EnrichedEvent
 import com.snowplowanalytics.snowplow.enrich.common.outputs.EnrichedEvent.toPartiallyEnrichedEvent
+import com.snowplowanalytics.snowplow.enrich.common.adapters.AdapterRegistry
+import com.snowplowanalytics.snowplow.enrich.common.SpecHelpers.adaptersSchemas
+import com.snowplowanalytics.snowplow.enrich.common.fs2.SpecHelpers._
 import com.snowplowanalytics.snowplow.eventgen.runGen
 import com.snowplowanalytics.snowplow.eventgen.enrich.{SdkEvent => GenSdkEvent}
 import org.specs2.matcher.MustMatchers.{left => _, right => _}
@@ -173,7 +175,7 @@ class EventGenEtlPipelineSpec extends Specification with CatsIO {
 
   val rng: Random = new scala.util.Random(1L)
 
-  val adapterRegistry = new AdapterRegistry()
+  val adapterRegistry = new AdapterRegistry(adaptersSchemas = adaptersSchemas)
   val enrichmentReg = EnrichmentRegistry[IO]()
   val igluCentral = Registry.IgluCentral
   val client = IgluCirceClient.parseDefault[IO](json"""

--- a/modules/common-fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/config/ConfigFileSpec.scala
+++ b/modules/common-fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/config/ConfigFileSpec.scala
@@ -31,6 +31,7 @@ import org.http4s.Uri
 import org.specs2.mutable.Specification
 
 import com.snowplowanalytics.snowplow.enrich.common.fs2.config.io.BackoffPolicy
+import com.snowplowanalytics.snowplow.enrich.common.SpecHelpers.adaptersSchemas
 
 class ConfigFileSpec extends Specification with CatsIO {
   "parse" should {
@@ -90,7 +91,8 @@ class ConfigFileSpec extends Specification with CatsIO {
               )
             )
           )
-        )
+        ),
+        adaptersSchemas
       )
       ConfigFile.parse[IO](configPath.asRight).value.map(result => result must beRight(expected))
     }
@@ -191,7 +193,8 @@ class ConfigFileSpec extends Specification with CatsIO {
               )
             )
           )
-        )
+        ),
+        adaptersSchemas
       )
       ConfigFile.parse[IO](configPath.asRight).value.map(result => result must beRight(expected))
     }
@@ -302,7 +305,8 @@ class ConfigFileSpec extends Specification with CatsIO {
               )
             )
           )
-        )
+        ),
+        adaptersSchemas
       )
       ConfigFile.parse[IO](configPath.asRight).value.map(result => result must beRight(expected))
     }
@@ -403,7 +407,8 @@ class ConfigFileSpec extends Specification with CatsIO {
               )
             )
           )
-        )
+        ),
+        adaptersSchemas
       )
       ConfigFile.parse[IO](configPath.asRight).value.map(result => result must beRight(expected))
     }

--- a/modules/common-fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/config/ParsedConfigsSpec.scala
+++ b/modules/common-fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/config/ParsedConfigsSpec.scala
@@ -27,6 +27,7 @@ import org.specs2.mutable.Specification
 import com.typesafe.config.ConfigFactory
 
 import com.snowplowanalytics.snowplow.enrich.common.outputs.EnrichedEvent
+import com.snowplowanalytics.snowplow.enrich.common.SpecHelpers.adaptersSchemas
 
 class ParsedConfigsSpec extends Specification with CatsIO {
   "validateConfig" should {
@@ -89,7 +90,8 @@ class ParsedConfigsSpec extends Specification with CatsIO {
               )
             )
           )
-        )
+        ),
+        adaptersSchemas
       )
 
       ParsedConfigs.validateConfig[IO](configFile).value.map(result => result must beLeft)

--- a/modules/common-fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/test/TestEnvironment.scala
+++ b/modules/common-fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/test/TestEnvironment.scala
@@ -37,6 +37,7 @@ import com.snowplowanalytics.snowplow.analytics.scalasdk.Event
 
 import com.snowplowanalytics.snowplow.badrows.BadRow
 
+import com.snowplowanalytics.snowplow.enrich.common.SpecHelpers.adaptersSchemas
 import com.snowplowanalytics.snowplow.enrich.common.adapters.AdapterRegistry
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.EnrichmentRegistry
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf
@@ -114,7 +115,7 @@ object TestEnvironment extends CatsIO {
 
   val embeddedRegistry = Registry.EmbeddedRegistry
 
-  val adapterRegistry = new AdapterRegistry()
+  val adapterRegistry = new AdapterRegistry(adaptersSchemas = adaptersSchemas)
 
   val http4sClient: Http4sClient[IO] = Http4sClient[IO] { _ =>
     val dsl = new Http4sDsl[IO] {}; import dsl._

--- a/modules/common/src/main/resources/reference.conf
+++ b/modules/common/src/main/resources/reference.conf
@@ -1,0 +1,151 @@
+{
+  "adaptersSchemas": {
+    "callrail": {
+        "call_complete": "iglu:com.callrail/call_complete/jsonschema/1-0-2"
+    },
+    "cloudfrontAccessLog": {
+      "with_12_fields": "iglu:com.amazon.aws.cloudfront/wd_access_log/jsonschema/1-0-0",
+      "with_15_fields": "iglu:com.amazon.aws.cloudfront/wd_access_log/jsonschema/1-0-1",
+      "with_18_fields": "iglu:com.amazon.aws.cloudfront/wd_access_log/jsonschema/1-0-2",
+      "with_19_fields": "iglu:com.amazon.aws.cloudfront/wd_access_log/jsonschema/1-0-3",
+      "with_23_fields": "iglu:com.amazon.aws.cloudfront/wd_access_log/jsonschema/1-0-4",
+      "with_24_fields": "iglu:com.amazon.aws.cloudfront/wd_access_log/jsonschema/1-0-5",
+      "with_26_fields": "iglu:com.amazon.aws.cloudfront/wd_access_log/jsonschema/1-0-6"
+    },
+    "googleAnalytics": {
+      "page_view": "iglu:com.google.analytics.measurement-protocol/page_view/jsonschema/1-0-0",
+      "screen_view": "iglu:com.google.analytics.measurement-protocol/screen_view/jsonschema/1-0-0",
+      "event": "iglu:com.google.analytics.measurement-protocol/event/jsonschema/1-0-0",
+      "transaction": "iglu:com.google.analytics.measurement-protocol/transaction/jsonschema/1-0-0",
+      "item": "iglu:com.google.analytics.measurement-protocol/item/jsonschema/1-0-0",
+      "social": "iglu:com.google.analytics.measurement-protocol/social/jsonschema/1-0-0",
+      "exception": "iglu:com.google.analytics.measurement-protocol/exception/jsonschema/1-0-0",
+      "timing": "iglu:com.google.analytics.measurement-protocol/timing/jsonschema/1-0-0",
+      "undocumented": "iglu:com.google.analytics/undocumented/jsonschema/1-0-0",
+      "private": "iglu:com.google.analytics/private/jsonschema/1-0-0",
+      "general": "iglu:com.google.analytics.measurement-protocol/general/jsonschema/1-0-0",
+      "user": "iglu:com.google.analytics.measurement-protocol/user/jsonschema/1-0-0",
+      "session": "iglu:com.google.analytics.measurement-protocol/session/jsonschema/1-0-0",
+      "traffic_source": "iglu:com.google.analytics.measurement-protocol/traffic_source/jsonschema/1-0-0",
+      "system_info": "iglu:com.google.analytics.measurement-protocol/system_info/jsonschema/1-0-0",
+      "link": "iglu:com.google.analytics.measurement-protocol/link/jsonschema/1-0-0",
+      "app": "iglu:com.google.analytics.measurement-protocol/app/jsonschema/1-0-0",
+      "product_action": "iglu:com.google.analytics.measurement-protocol/product_action/jsonschema/1-0-0",
+      "content_experiment": "iglu:com.google.analytics.measurement-protocol/content_experiment/jsonschema/1-0-0",
+      "hit": "iglu:com.google.analytics.measurement-protocol/hit/jsonschema/1-0-0",
+      "promotion_action": "iglu:com.google.analytics.measurement-protocol/promotion_action/jsonschema/1-0-0",
+      "product": "iglu:com.google.analytics.measurement-protocol/product/jsonschema/1-0-0",
+      "product_custom_dimension": "iglu:com.google.analytics.measurement-protocol/product_custom_dimension/jsonschema/1-0-0",
+      "product_custom_metric": "iglu:com.google.analytics.measurement-protocol/product_custom_metric/jsonschema/1-0-0",
+      "product_impression_list": "iglu:com.google.analytics.measurement-protocol/product_impression_list/jsonschema/1-0-0",
+      "product_impression": "iglu:com.google.analytics.measurement-protocol/product_impression/jsonschema/1-0-0",
+      "product_impression_custom_dimension": "iglu:com.google.analytics.measurement-protocol/product_impression_custom_dimension/jsonschema/1-0-0",
+      "product_impression_custom_metric": "iglu:com.google.analytics.measurement-protocol/product_impression_custom_metric/jsonschema/1-0-0",
+      "promotion": "iglu:com.google.analytics.measurement-protocol/promotion/jsonschema/1-0-0",
+      "custom_dimension": "iglu:com.google.analytics.measurement-protocol/custom_dimension/jsonschema/1-0-0",
+      "custom_metric": "iglu:com.google.analytics.measurement-protocol/custom_metric/jsonschema/1-0-0",
+      "content_group": "iglu:com.google.analytics.measurement-protocol/content_group/jsonschema/1-0-0"
+    },
+    "hubspot": {
+      "contact_creation": "iglu:com.hubspot/contact_creation/jsonschema/1-0-0",
+      "contact_deletion": "iglu:com.hubspot/contact_deletion/jsonschema/1-0-0",
+      "contact_change": "iglu:com.hubspot/contact_change/jsonschema/1-0-0",
+      "company_creation": "iglu:com.hubspot/company_creation/jsonschema/1-0-0",
+      "company_deletion": "iglu:com.hubspot/company_deletion/jsonschema/1-0-0",
+      "company_change": "iglu:com.hubspot/company_change/jsonschema/1-0-0",
+      "deal_creation": "iglu:com.hubspot/deal_creation/jsonschema/1-0-0",
+      "deal_deletion": "iglu:com.hubspot/deal_deletion/jsonschema/1-0-0",
+      "deal_change": "iglu:com.hubspot/deal_change/jsonschema/1-0-0"
+    },
+    "mailchimp": {
+      "subscribe": "iglu:com.mailchimp/subscribe/jsonschema/1-0-0",
+      "unsubscribe": "iglu:com.mailchimp/unsubscribe/jsonschema/1-0-0",
+      "campaign_sending_status": "iglu:com.mailchimp/campaign_sending_status/jsonschema/1-0-0",
+      "cleaned_email": "iglu:com.mailchimp/cleaned_email/jsonschema/1-0-0",
+      "email_address_change": "iglu:com.mailchimp/email_address_change/jsonschema/1-0-0",
+      "profile_update": "iglu:com.mailchimp/profile_update/jsonschema/1-0-0"
+    },
+    "mailgun": {
+      "message_bounced": "iglu:com.mailgun/message_bounced/jsonschema/1-0-0",
+      "message_clicked": "iglu:com.mailgun/message_clicked/jsonschema/1-0-0",
+      "message_complained": "iglu:com.mailgun/message_complained/jsonschema/1-0-0",
+      "message_delivered": "iglu:com.mailgun/message_delivered/jsonschema/1-0-0",
+      "message_dropped": "iglu:com.mailgun/message_dropped/jsonschema/1-0-0",
+      "message_opened": "iglu:com.mailgun/message_opened/jsonschema/1-0-0",
+      "recipient_unsubscribed": "iglu:com.mailgun/recipient_unsubscribed/jsonschema/1-0-0"
+    },
+    "mandrill": {
+      "message_bounced": "iglu:com.mandrill/message_bounced/jsonschema/1-0-1",
+      "message_clicked": "iglu:com.mandrill/message_clicked/jsonschema/1-0-1",
+      "message_delayed": "iglu:com.mandrill/message_delayed/jsonschema/1-0-1",
+      "message_marked_as_spam": "iglu:com.mandrill/message_marked_as_spam/jsonschema/1-0-1",
+      "message_opened": "iglu:com.mandrill/message_opened/jsonschema/1-0-1",
+      "message_rejected": "iglu:com.mandrill/message_rejected/jsonschema/1-0-0",
+      "message_sent": "iglu:com.mandrill/message_sent/jsonschema/1-0-0",
+      "message_soft_bounced": "iglu:com.mandrill/message_soft_bounced/jsonschema/1-0-1",
+      "recipient_unsubscribed": "iglu:com.mandrill/recipient_unsubscribed/jsonschema/1-0-1"
+    },
+    "marketo": {
+      "event": "iglu:com.marketo/event/jsonschema/2-0-0"
+    },
+    "olark": {
+      "transcript": "iglu:com.olark/transcript/jsonschema/1-0-0",
+      "offline_message": "iglu:com.olark/offline_message/jsonschema/1-0-0"
+    },
+    "pagerduty": {
+      "incident": "iglu:com.pagerduty/incident/jsonschema/1-0-0"
+    },
+    "pingdom": {
+      "incident_assign": "iglu:com.pingdom/incident_assign/jsonschema/1-0-0",
+      "incident_notify_user": "iglu:com.pingdom/incident_notify_user/jsonschema/1-0-0",
+      "incident_notify_of_close": "iglu:com.pingdom/incident_notify_of_close/jsonschema/1-0-0"
+    },
+    "sendgrid": {
+      "processed": "iglu:com.sendgrid/processed/jsonschema/2-0-0",
+      "dropped": "iglu:com.sendgrid/dropped/jsonschema/2-0-0",
+      "delivered": "iglu:com.sendgrid/delivered/jsonschema/2-0-0",
+      "deferred": "iglu:com.sendgrid/deferred/jsonschema/2-0-0",
+      "bounce": "iglu:com.sendgrid/bounce/jsonschema/2-0-0",
+      "open": "iglu:com.sendgrid/open/jsonschema/2-0-0",
+      "click": "iglu:com.sendgrid/click/jsonschema/2-0-0",
+      "spamreport": "iglu:com.sendgrid/spamreport/jsonschema/2-0-0",
+      "unsubscribe": "iglu:com.sendgrid/unsubscribe/jsonschema/2-0-0",
+      "group_unsubscribe": "iglu:com.sendgrid/group_unsubscribe/jsonschema/2-0-0",
+      "group_resubscribe": "iglu:com.sendgrid/group_resubscribe/jsonschema/2-0-0"
+    },
+    "statusgator": {
+      "status_change": "iglu:com.statusgator/status_change/jsonschema/1-0-0"
+    },
+    "unbounce": {
+      "form_post": "iglu:com.unbounce/form_post/jsonschema/1-0-0"
+    },
+    "urbanAirship": {
+      "close": "iglu:com.urbanairship.connect/CLOSE/jsonschema/1-0-0",
+      "custom": "iglu:com.urbanairship.connect/CUSTOM/jsonschema/1-0-0",
+      "first_open": "iglu:com.urbanairship.connect/FIRST_OPEN/jsonschema/1-0-0",
+      "in_app_message_display": "iglu:com.urbanairship.connect/IN_APP_MESSAGE_DISPLAY/jsonschema/1-0-0",
+      "in_app_message_expiration": "iglu:com.urbanairship.connect/IN_APP_MESSAGE_EXPIRATION/jsonschema/1-0-0",
+      "in_app_message_resolution": "iglu:com.urbanairship.connect/IN_APP_MESSAGE_RESOLUTION/jsonschema/1-0-0",
+      "location": "iglu:com.urbanairship.connect/LOCATION/jsonschema/1-0-0",
+      "open": "iglu:com.urbanairship.connect/OPEN/jsonschema/1-0-0",
+      "push_body": "iglu:com.urbanairship.connect/PUSH_BODY/jsonschema/1-0-0",
+      "region": "iglu:com.urbanairship.connect/REGION/jsonschema/1-0-0",
+      "rich_delete": "iglu:com.urbanairship.connect/RICH_DELETE/jsonschema/1-0-0",
+      "rich_delivery": "iglu:com.urbanairship.connect/RICH_DELIVERY/jsonschema/1-0-0",
+      "rich_head": "iglu:com.urbanairship.connect/RICH_HEAD/jsonschema/1-0-0",
+      "send": "iglu:com.urbanairship.connect/SEND/jsonschema/1-0-0",
+      "tag_change": "iglu:com.urbanairship.connect/TAG_CHANGE/jsonschema/1-0-0",
+      "uninstall": "iglu:com.urbanairship.connect/UNINSTALL/jsonschema/1-0-0"
+    },
+    "vero": {
+      "bounced": "iglu:com.getvero/bounced/jsonschema/1-0-0",
+      "clicked": "iglu:com.getvero/clicked/jsonschema/1-0-0",
+      "delivered": "iglu:com.getvero/delivered/jsonschema/1-0-0",
+      "opened": "iglu:com.getvero/opened/jsonschema/1-0-0",
+      "sent": "iglu:com.getvero/sent/jsonschema/1-0-0",
+      "unsubscribed": "iglu:com.getvero/unsubscribed/jsonschema/1-0-0",
+      "created": "iglu:com.getvero/created/jsonschema/1-0-0",
+      "updated": "iglu:com.getvero/updated/jsonschema/1-0-0"
+    }
+  }
+}

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/AdapterRegistry.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/AdapterRegistry.scala
@@ -34,29 +34,31 @@ import com.snowplowanalytics.snowplow.enrich.common.utils.HttpClient
  * The AdapterRegistry lets us convert a CollectorPayload into one or more RawEvents, using a given
  * adapter.
  */
-class AdapterRegistry(remoteAdapters: Map[(String, String), RemoteAdapter] = Map.empty) {
-
+class AdapterRegistry(
+  remoteAdapters: Map[(String, String), RemoteAdapter] = Map.empty,
+  adaptersSchemas: AdaptersSchemas
+) {
   val adapters: Map[(String, String), Adapter] = Map(
     (Vendor.Snowplow, "tp1") -> Tp1Adapter,
     (Vendor.Snowplow, "tp2") -> Tp2Adapter,
     (Vendor.Redirect, "tp2") -> RedirectAdapter,
     (Vendor.Iglu, "v1") -> IgluAdapter,
-    (Vendor.Callrail, "v1") -> CallrailAdapter,
-    (Vendor.Cloudfront, "wd_access_log") -> CloudfrontAccessLogAdapter,
-    (Vendor.Mailchimp, "v1") -> MailchimpAdapter,
-    (Vendor.Mailgun, "v1") -> MailgunAdapter,
-    (Vendor.GoogleAnalytics, "v1") -> GoogleAnalyticsAdapter,
-    (Vendor.Mandrill, "v1") -> MandrillAdapter,
-    (Vendor.Olark, "v1") -> OlarkAdapter,
-    (Vendor.Pagerduty, "v1") -> PagerdutyAdapter,
-    (Vendor.Pingdom, "v1") -> PingdomAdapter,
-    (Vendor.Sendgrid, "v3") -> SendgridAdapter,
-    (Vendor.StatusGator, "v1") -> StatusGatorAdapter,
-    (Vendor.Unbounce, "v1") -> UnbounceAdapter,
-    (Vendor.UrbanAirship, "v1") -> UrbanAirshipAdapter,
-    (Vendor.Marketo, "v1") -> MarketoAdapter,
-    (Vendor.Vero, "v1") -> VeroAdapter,
-    (Vendor.HubSpot, "v1") -> HubSpotAdapter
+    (Vendor.Callrail, "v1") -> CallrailAdapter(adaptersSchemas.callrail),
+    (Vendor.Cloudfront, "wd_access_log") -> CloudfrontAccessLogAdapter(adaptersSchemas.cloudfrontAccessLog),
+    (Vendor.Mailchimp, "v1") -> MailchimpAdapter(adaptersSchemas.mailchimp),
+    (Vendor.Mailgun, "v1") -> MailgunAdapter(adaptersSchemas.mailgun),
+    (Vendor.GoogleAnalytics, "v1") -> GoogleAnalyticsAdapter(adaptersSchemas.googleAnalytics),
+    (Vendor.Mandrill, "v1") -> MandrillAdapter(adaptersSchemas.mandrill),
+    (Vendor.Olark, "v1") -> OlarkAdapter(adaptersSchemas.olark),
+    (Vendor.Pagerduty, "v1") -> PagerdutyAdapter(adaptersSchemas.pagerduty),
+    (Vendor.Pingdom, "v1") -> PingdomAdapter(adaptersSchemas.pingdom),
+    (Vendor.Sendgrid, "v3") -> SendgridAdapter(adaptersSchemas.sendgrid),
+    (Vendor.StatusGator, "v1") -> StatusGatorAdapter(adaptersSchemas.statusgator),
+    (Vendor.Unbounce, "v1") -> UnbounceAdapter(adaptersSchemas.unbounce),
+    (Vendor.UrbanAirship, "v1") -> UrbanAirshipAdapter(adaptersSchemas.urbanAirship),
+    (Vendor.Marketo, "v1") -> MarketoAdapter(adaptersSchemas.marketo),
+    (Vendor.Vero, "v1") -> VeroAdapter(adaptersSchemas.vero),
+    (Vendor.HubSpot, "v1") -> HubSpotAdapter(adaptersSchemas.hubspot)
   ) ++ remoteAdapters
 
   private object Vendor {

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/AdaptersSchemas.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/AdaptersSchemas.scala
@@ -1,0 +1,341 @@
+/*
+ * Copyright (c) 2018-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+
+package com.snowplowanalytics.snowplow.enrich.common.adapters
+
+import com.snowplowanalytics.iglu.core.SchemaKey
+
+case class AdaptersSchemas(
+  callrail: CallrailSchemas,
+  cloudfrontAccessLog: CloudfrontAccessLogSchemas,
+  googleAnalytics: GoogleAnalyticsSchemas,
+  hubspot: HubspotSchemas,
+  mailchimp: MailchimpSchemas,
+  mailgun: MailgunSchemas,
+  mandrill: MandrillSchemas,
+  marketo: MarketoSchemas,
+  olark: OlarkSchemas,
+  pagerduty: PagerdutySchemas,
+  pingdom: PingdomSchemas,
+  sendgrid: SendgridSchemas,
+  statusgator: StatusGatorSchemas,
+  unbounce: UnbounceSchemas,
+  urbanAirship: UrbanAirshipSchemas,
+  vero: VeroSchemas
+)
+
+case class CallrailSchemas(call_complete: String) {
+  val callCompleteSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(call_complete, "call complete", "Callrail")
+}
+
+case class CloudfrontAccessLogSchemas(
+  with_12_fields: String,
+  with_15_fields: String,
+  with_18_fields: String,
+  with_19_fields: String,
+  with_23_fields: String,
+  with_24_fields: String,
+  with_26_fields: String
+) {
+  val with12FieldsSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(with_12_fields, "with 12 fields", "Cloudfront")
+  val with15FieldsSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(with_15_fields, "with 15 fields", "Cloudfront")
+  val with18FieldsSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(with_18_fields, "with 18 fields", "Cloudfront")
+  val with19FieldsSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(with_19_fields, "with 19 fields", "Cloudfront")
+  val with23FieldsSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(with_23_fields, "with 23 fields", "Cloudfront")
+  val with24FieldsSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(with_24_fields, "with 24 fields", "Cloudfront")
+  val with26FieldsSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(with_26_fields, "with 26 fields", "Cloudfront")
+}
+
+case class HubspotSchemas(
+  contact_creation: String,
+  contact_deletion: String,
+  contact_change: String,
+  company_creation: String,
+  company_deletion: String,
+  company_change: String,
+  deal_creation: String,
+  deal_deletion: String,
+  deal_change: String
+) {
+
+  val contactCreationSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(contact_creation, "contact_creation", "HubSpot")
+  val contactDeletionSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(contact_deletion, "contact_deletion", "HubSpot")
+  val contactChangeSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(contact_change, "contact_change", "HubSpot")
+  val companyCreationSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(company_creation, "company_creation", "HubSpot")
+  val companyDeletionSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(company_deletion, "company_deletion", "HubSpot")
+  val companyChangeSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(company_change, "company_change", "HubSpot")
+  val dealCreationSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(deal_creation, "deal_creation", "HubSpot")
+  val dealDeletionSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(deal_deletion, "deal_deletion", "HubSpot")
+  val dealChangeSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(deal_change, "deal_change", "HubSpot")
+}
+
+case class GoogleAnalyticsSchemas(
+  page_view: String,
+  screen_view: String,
+  event: String,
+  transaction: String,
+  item: String,
+  social: String,
+  exception: String,
+  timing: String,
+  undocumented: String,
+  `private`: String,
+  general: String,
+  user: String,
+  session: String,
+  traffic_source: String,
+  system_info: String,
+  link: String,
+  app: String,
+  product_action: String,
+  content_experiment: String,
+  hit: String,
+  promotion_action: String,
+  product: String,
+  product_custom_dimension: String,
+  product_custom_metric: String,
+  product_impression_list: String,
+  product_impression: String,
+  product_impression_custom_dimension: String,
+  product_impression_custom_metric: String,
+  promotion: String,
+  custom_dimension: String,
+  custom_metric: String,
+  content_group: String
+) {
+
+  val pageViewSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(page_view, "page_view", "Google Analytics")
+  val screenViewSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(screen_view, "screen_view", "Google Analytics")
+  val eventSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(event, "event", "Google Analytics")
+  val transactionSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(transaction, "transaction", "Google Analytics")
+  val itemSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(item, "item", "Google Analytics")
+  val socialSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(social, "social", "Google Analytics")
+  val exceptionSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(exception, "exception", "Google Analytics")
+  val timingSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(timing, "timing", "Google Analytics")
+  val undocumentedSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(undocumented, "undocumented", "Google Analytics")
+  val privateSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(`private`, "private", "Google Analytics")
+  val generalSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(general, "general", "Google Analytics")
+  val userSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(user, "user", "Google Analytics")
+  val sessionSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(session, "session", "Google Analytics")
+  val trafficSourceSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(traffic_source, "traffic_source", "Google Analytics")
+  val systemInfoSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(system_info, "system_info", "Google Analytics")
+  val linkSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(link, "link", "Google Analytics")
+  val appSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(app, "app", "Google Analytics")
+  val productActionSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(product_action, "product_action", "Google Analytics")
+  val contentExperimentSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(content_experiment, "content_experiment", "Google Analytics")
+  val hitSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(hit, "hit", "Google Analytics")
+  val promotionActionSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(promotion_action, "promotion_action", "Google Analytics")
+  val productSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(product, "product", "Google Analytics")
+  val productCustomDimensionSchemaKey: SchemaKey =
+    AdapterConfigHelper.toSchemaKey(product_custom_dimension, "product_custom_dimension", "Google Analytics")
+  val productCustomMetricSchemaKey: SchemaKey =
+    AdapterConfigHelper.toSchemaKey(product_custom_metric, "product_custom_metric", "Google Analytics")
+  val productImpressionListSchemaKey: SchemaKey =
+    AdapterConfigHelper.toSchemaKey(product_impression_list, "product_impression_list", "Google Analytics")
+  val productImpressionSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(product_impression, "product_impression", "Google Analytics")
+  val productImpressionCustomDimensionSchemaKey: SchemaKey =
+    AdapterConfigHelper.toSchemaKey(product_impression_custom_dimension, "product_impression_custom_dimension", "Google Analytics")
+  val productImpressionCustomMetricSchemaKey: SchemaKey =
+    AdapterConfigHelper.toSchemaKey(product_impression_custom_metric, "product_impression_custom_metric", "Google Analytics")
+  val promotionSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(promotion, "promotion", "Google Analytics")
+  val customDimensionSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(custom_dimension, "custom_dimension", "Google Analytics")
+  val customMetricSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(custom_metric, "custom_metric", "Google Analytics")
+  val contentGroupSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(content_group, "content_group", "Google Analytics")
+}
+
+case class MailchimpSchemas(
+  subscribe: String,
+  unsubscribe: String,
+  campaign_sending_status: String,
+  cleaned_email: String,
+  email_address_change: String,
+  profile_update: String
+) {
+  val subscribeSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(subscribe, "subscribe", "Mailchimp")
+  val unsubscribeSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(unsubscribe, "unsubscribe", "Mailchimp")
+  val campaignSendingStatusSchemaKey: SchemaKey =
+    AdapterConfigHelper.toSchemaKey(campaign_sending_status, "campaign_sending_status", "Mailchimp")
+  val cleanedEmailSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(cleaned_email, "cleaned_email", "Mailchimp")
+  val emailAddressChangeSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(email_address_change, "email_address_change", "Mailchimp")
+  val profileUpdateSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(profile_update, "profile_update", "Mailchimp")
+}
+
+case class MailgunSchemas(
+  message_bounced: String,
+  message_clicked: String,
+  message_complained: String,
+  message_delivered: String,
+  message_dropped: String,
+  message_opened: String,
+  recipient_unsubscribed: String
+) {
+  val messageBouncedSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(message_bounced, "message_bounced", "Mailgun")
+  val messageClickedSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(message_clicked, "message_clicked", "Mailgun")
+  val messageComplainedSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(message_complained, "message_complained", "Mailgun")
+  val messageDeliveredSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(message_delivered, "message_delivered", "Mailgun")
+  val messageDroppedSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(message_dropped, "message_dropped", "Mailgun")
+  val messageOpenedSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(message_opened, "message_opened", "Mailgun")
+  val recipientUnsubscribedSchemaKey: SchemaKey =
+    AdapterConfigHelper.toSchemaKey(recipient_unsubscribed, "recipient_unsubscribed", "Mailgun")
+}
+
+case class MandrillSchemas(
+  message_bounced: String,
+  message_clicked: String,
+  message_delayed: String,
+  message_marked_as_spam: String,
+  message_opened: String,
+  message_rejected: String,
+  message_sent: String,
+  message_soft_bounced: String,
+  recipient_unsubscribed: String
+) {
+
+  val messageBouncedSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(message_bounced, "message_bounced", "Mandrill")
+  val messageClickedSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(message_clicked, "message_clicked", "Mandrill")
+  val messageDelayedSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(message_delayed, "message_delayed", "Mandrill")
+  val messageMarkedAsSpamSchemaKey: SchemaKey =
+    AdapterConfigHelper.toSchemaKey(message_marked_as_spam, "message_marked_as_spam", "Mandrill")
+  val messageOpenedSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(message_opened, "message_opened", "Mandrill")
+  val messageRejectedSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(message_rejected, "message_rejected", "Mandrill")
+  val messageSentSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(message_sent, "message_sent", "Mandrill")
+  val messageSoftBouncedSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(message_soft_bounced, "message_soft_bounced", "Mandrill")
+  val recipientUnsubscribedSchemaKey: SchemaKey =
+    AdapterConfigHelper.toSchemaKey(recipient_unsubscribed, "recipient_unsubscribed", "Mandrill")
+}
+
+case class MarketoSchemas(event: String) {
+  val eventSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(event, "event", "Marketo")
+}
+
+case class OlarkSchemas(transcript: String, offline_message: String) {
+  val transcriptSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(transcript, "transcript", "Olark")
+  val offlineMessageSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(offline_message, "offline_message", "Olark")
+}
+
+case class PagerdutySchemas(incident: String) {
+  val incidentSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(incident, "incident", "Pagerduty")
+}
+
+case class PingdomSchemas(
+  incident_assign: String,
+  incident_notify_user: String,
+  incident_notify_of_close: String
+) {
+  val incidentAssignSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(incident_assign, "incident_assign", "Pingdom")
+  val incidentNotifyUserSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(incident_notify_user, "incident_notify_user", "Pingdom")
+  val incidentNotifyOfCloseSchemaKey: SchemaKey =
+    AdapterConfigHelper.toSchemaKey(incident_notify_of_close, "incident_notify_of_close", "Pingdom")
+}
+
+case class StatusGatorSchemas(status_change: String) {
+  val statusChangeSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(status_change, "status_change", "StatusGator")
+}
+
+case class SendgridSchemas(
+  processed: String,
+  dropped: String,
+  delivered: String,
+  deferred: String,
+  bounce: String,
+  open: String,
+  click: String,
+  spamreport: String,
+  unsubscribe: String,
+  group_unsubscribe: String,
+  group_resubscribe: String
+) {
+  val processedSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(processed, "processed", "Sendgrid")
+  val droppedSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(dropped, "dropped", "Sendgrid")
+  val deliveredSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(delivered, "delivered", "Sendgrid")
+  val deferredSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(deferred, "deferred", "Sendgrid")
+  val bounceSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(bounce, "bounce", "Sendgrid")
+  val openSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(open, "open", "Sendgrid")
+  val clickSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(click, "click", "Sendgrid")
+  val spamreportSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(spamreport, "spamreport", "Sendgrid")
+  val unsubscribeSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(unsubscribe, "unsubscribe", "Sendgrid")
+  val groupUnsubscribeSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(group_unsubscribe, "group_unsubscribe", "Sendgrid")
+  val groupResubscribeSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(group_resubscribe, "group_resubscribe", "Sendgrid")
+}
+
+case class UnbounceSchemas(form_post: String) {
+  val formPostSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(form_post, "form_post", "Unbounce")
+}
+
+case class UrbanAirshipSchemas(
+  close: String,
+  custom: String,
+  first_open: String,
+  in_app_message_display: String,
+  in_app_message_expiration: String,
+  in_app_message_resolution: String,
+  location: String,
+  open: String,
+  push_body: String,
+  region: String,
+  rich_delete: String,
+  rich_delivery: String,
+  rich_head: String,
+  send: String,
+  tag_change: String,
+  uninstall: String
+) {
+  val closeSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(close, "close", "UrbanAirship")
+  val customSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(custom, "custom", "UrbanAirship")
+  val firstOpenSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(first_open, "first_open", "UrbanAirship")
+  val inAppMessageDisplaySchemaKey: SchemaKey =
+    AdapterConfigHelper.toSchemaKey(in_app_message_display, "in_app_message_display", "UrbanAirship")
+  val inAppMessageExpirationSchemaKey: SchemaKey =
+    AdapterConfigHelper.toSchemaKey(in_app_message_expiration, "in_app_message_expiration", "UrbanAirship")
+  val inAppMessageResolutionSchemaKey: SchemaKey =
+    AdapterConfigHelper.toSchemaKey(in_app_message_resolution, "in_app_message_resolution", "UrbanAirship")
+  val locationSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(location, "location", "UrbanAirship")
+  val openSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(open, "open", "UrbanAirship")
+  val pushBodySchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(push_body, "push_body", "UrbanAirship")
+  val regionSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(region, "region", "UrbanAirship")
+  val richDeleteSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(rich_delete, "rich_delete", "UrbanAirship")
+  val richDeliverySchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(rich_delivery, "rich_delivery", "UrbanAirship")
+  val richHeadSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(rich_head, "rich_head", "UrbanAirship")
+  val sendSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(send, "send", "UrbanAirship")
+  val tagChangeSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(tag_change, "tag_change", "UrbanAirship")
+  val uninstallSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(uninstall, "uninstall", "UrbanAirship")
+}
+
+case class VeroSchemas(
+  bounced: String,
+  clicked: String,
+  delivered: String,
+  opened: String,
+  sent: String,
+  unsubscribed: String,
+  created: String,
+  updated: String
+) {
+  val bouncedSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(bounced, "bounced", "Vero")
+  val clickedSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(clicked, "clicked", "Vero")
+  val deliveredSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(delivered, "delivered", "Vero")
+  val openedSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(opened, "opened", "Vero")
+  val sentSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(sent, "sent", "Vero")
+  val unsubscribedSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(unsubscribed, "unsubscribed", "Vero")
+  val createdSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(created, "created", "Vero")
+  val updatedSchemaKey: SchemaKey = AdapterConfigHelper.toSchemaKey(updated, "updated", "Vero")
+}
+
+private object AdapterConfigHelper {
+  def toSchemaKey(
+    uri: String,
+    property: String,
+    adapter: String
+  ): SchemaKey =
+    SchemaKey.fromUri(uri).getOrElse(throw new RuntimeException(s"$adapter: Cannot parse schema $property: $uri"))
+}

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/CallrailAdapter.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/CallrailAdapter.scala
@@ -24,7 +24,6 @@ import org.joda.time.format.DateTimeFormat
 
 import com.snowplowanalytics.iglu.client.IgluCirceClient
 import com.snowplowanalytics.iglu.client.resolver.registries.RegistryLookup
-import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer}
 
 import com.snowplowanalytics.snowplow.badrows.FailureDetails
 
@@ -37,19 +36,14 @@ import Adapter.Adapted
  * a known version of the AD-X Tracking webhook
  * into raw events.
  */
-object CallrailAdapter extends Adapter {
+case class CallrailAdapter(schemas: CallrailSchemas) extends Adapter {
 
   // Tracker version for an AD-X Tracking webhook
   private val TrackerVersion = "com.callrail-v1"
 
   // Schemas for reverse-engineering a Snowplow unstructured event
   private object SchemaUris {
-    val CallComplete = SchemaKey(
-      "com.callrail",
-      "call_complete",
-      "jsonschema",
-      SchemaVer.Full(1, 0, 2)
-    )
+    val CallComplete = schemas.callCompleteSchemaKey
   }
 
   // Datetime format used by CallRail (as we will need to massage)

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/HubSpotAdapter.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/HubSpotAdapter.scala
@@ -27,7 +27,6 @@ import org.joda.time.DateTime
 
 import com.snowplowanalytics.iglu.client.IgluCirceClient
 import com.snowplowanalytics.iglu.client.resolver.registries.RegistryLookup
-import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer}
 import com.snowplowanalytics.snowplow.badrows._
 
 import io.circe._
@@ -40,37 +39,24 @@ import Adapter.Adapted
  * Transforms a collector payload which conforms to a known version of the HubSpot webhook
  * subscription into raw events.
  */
-object HubSpotAdapter extends Adapter {
+case class HubSpotAdapter(schemas: HubspotSchemas) extends Adapter {
   // Tracker version for a HubSpot webhook
   private val TrackerVersion = "com.hubspot-v1"
 
   // Expected content type for a request body
   private val ContentType = "application/json"
 
-  private val Vendor = "com.hubspot"
-  private val Format = "jsonschema"
-  private val SchemaVersion = SchemaVer.Full(1, 0, 0)
-
   // Event-Schema Map for reverse-engineering a Snowplow unstructured event
   private[registry] val EventSchemaMap = Map(
-    "contact.creation" ->
-      SchemaKey(Vendor, "contact_creation", Format, SchemaVersion),
-    "contact.deletion" ->
-      SchemaKey(Vendor, "contact_deletion", Format, SchemaVersion),
-    "contact.propertyChange" ->
-      SchemaKey(Vendor, "contact_change", Format, SchemaVersion),
-    "company.creation" ->
-      SchemaKey(Vendor, "company_creation", Format, SchemaVersion),
-    "company.deletion" ->
-      SchemaKey(Vendor, "company_deletion", Format, SchemaVersion),
-    "company.propertyChange" ->
-      SchemaKey(Vendor, "company_change", Format, SchemaVersion),
-    "deal.creation" ->
-      SchemaKey(Vendor, "deal_creation", Format, SchemaVersion),
-    "deal.deletion" ->
-      SchemaKey(Vendor, "deal_deletion", Format, SchemaVersion),
-    "deal.propertyChange" ->
-      SchemaKey(Vendor, "deal_change", Format, SchemaVersion)
+    "contact.creation" -> schemas.contactCreationSchemaKey,
+    "contact.deletion" -> schemas.contactDeletionSchemaKey,
+    "contact.propertyChange" -> schemas.contactChangeSchemaKey,
+    "company.creation" -> schemas.companyCreationSchemaKey,
+    "company.deletion" -> schemas.companyDeletionSchemaKey,
+    "company.propertyChange" -> schemas.companyChangeSchemaKey,
+    "deal.creation" -> schemas.dealCreationSchemaKey,
+    "deal.deletion" -> schemas.dealDeletionSchemaKey,
+    "deal.propertyChange" -> schemas.dealChangeSchemaKey
   )
 
   /**

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/MailchimpAdapter.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/MailchimpAdapter.scala
@@ -22,7 +22,6 @@ import cats.syntax.option._
 import cats.syntax.validated._
 import com.snowplowanalytics.iglu.client.IgluCirceClient
 import com.snowplowanalytics.iglu.client.resolver.registries.RegistryLookup
-import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer}
 import com.snowplowanalytics.snowplow.badrows._
 import io.circe._
 import org.joda.time.DateTimeZone
@@ -37,25 +36,21 @@ import Adapter.Adapted
  * Transforms a collector payload which conforms to a known version of the Mailchimp Tracking
  * webhook into raw events.
  */
-object MailchimpAdapter extends Adapter {
+case class MailchimpAdapter(schemas: MailchimpSchemas) extends Adapter {
   // Expected content type for a request body
   private val ContentType = "application/x-www-form-urlencoded"
 
   // Tracker version for a Mailchimp Tracking webhook
   private val TrackerVersion = "com.mailchimp-v1"
 
-  private val Vendor = "com.mailchimp"
-  private val Format = "jsonschema"
-  private val SchemaVersion = SchemaVer.Full(1, 0, 0)
-
   // Schemas for reverse-engineering a Snowplow unstructured event
   private[registry] val EventSchemaMap = Map(
-    "subscribe" -> SchemaKey(Vendor, "subscribe", Format, SchemaVersion),
-    "unsubscribe" -> SchemaKey(Vendor, "unsubscribe", Format, SchemaVersion),
-    "campaign" -> SchemaKey(Vendor, "campaign_sending_status", Format, SchemaVersion),
-    "cleaned" -> SchemaKey(Vendor, "cleaned_email", Format, SchemaVersion),
-    "upemail" -> SchemaKey(Vendor, "email_address_change", Format, SchemaVersion),
-    "profile" -> SchemaKey(Vendor, "profile_update", Format, SchemaVersion)
+    "subscribe" -> schemas.subscribeSchemaKey,
+    "unsubscribe" -> schemas.unsubscribeSchemaKey,
+    "campaign" -> schemas.campaignSendingStatusSchemaKey,
+    "cleaned" -> schemas.cleanedEmailSchemaKey,
+    "upemail" -> schemas.emailAddressChangeSchemaKey,
+    "profile" -> schemas.profileUpdateSchemaKey
   )
 
   // Datetime format used by MailChimp (as we will need to massage)

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/MailgunAdapter.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/MailgunAdapter.scala
@@ -22,7 +22,6 @@ import cats.syntax.option._
 import cats.syntax.validated._
 import com.snowplowanalytics.iglu.client.IgluCirceClient
 import com.snowplowanalytics.iglu.client.resolver.registries.RegistryLookup
-import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer}
 import com.snowplowanalytics.snowplow.badrows._
 import io.circe._
 import io.circe.parser._
@@ -36,26 +35,22 @@ import Adapter.Adapted
  * Transforms a collector payload which conforms to a known version of the StatusGator Tracking
  * webhook into raw events.
  */
-object MailgunAdapter extends Adapter {
+case class MailgunAdapter(schemas: MailgunSchemas) extends Adapter {
   // Tracker version for an Mailgun Tracking webhook
   private val TrackerVersion = "com.mailgun-v1"
 
   // Expected content type for a request body
   private val ContentType = "application/json"
 
-  private val Vendor = "com.mailgun"
-  private val Format = "jsonschema"
-  private val SchemaVersion = SchemaVer.Full(1, 0, 0)
-
   // Schemas for reverse-engineering a Snowplow unstructured event
   private[registry] val EventSchemaMap = Map(
-    "bounced" -> SchemaKey(Vendor, "message_bounced", Format, SchemaVersion),
-    "clicked" -> SchemaKey(Vendor, "message_clicked", Format, SchemaVersion),
-    "complained" -> SchemaKey(Vendor, "message_complained", Format, SchemaVersion),
-    "delivered" -> SchemaKey(Vendor, "message_delivered", Format, SchemaVersion),
-    "dropped" -> SchemaKey(Vendor, "message_dropped", Format, SchemaVersion),
-    "opened" -> SchemaKey(Vendor, "message_opened", Format, SchemaVersion),
-    "unsubscribed" -> SchemaKey(Vendor, "recipient_unsubscribed", Format, SchemaVersion)
+    "bounced" -> schemas.messageBouncedSchemaKey,
+    "clicked" -> schemas.messageClickedSchemaKey,
+    "complained" -> schemas.messageComplainedSchemaKey,
+    "delivered" -> schemas.messageDeliveredSchemaKey,
+    "dropped" -> schemas.messageDroppedSchemaKey,
+    "opened" -> schemas.messageOpenedSchemaKey,
+    "unsubscribed" -> schemas.recipientUnsubscribedSchemaKey
   )
 
   /**

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/MandrillAdapter.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/MandrillAdapter.scala
@@ -22,7 +22,6 @@ import cats.syntax.option._
 import cats.syntax.validated._
 import com.snowplowanalytics.iglu.client.IgluCirceClient
 import com.snowplowanalytics.iglu.client.resolver.registries.RegistryLookup
-import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer}
 import com.snowplowanalytics.snowplow.badrows._
 import io.circe._
 
@@ -35,28 +34,24 @@ import Adapter.Adapted
  * Transforms a collector payload which conforms to a known version of the Mandrill Tracking webhook
  * into raw events.
  */
-object MandrillAdapter extends Adapter {
+case class MandrillAdapter(schemas: MandrillSchemas) extends Adapter {
   // Tracker version for an Mandrill Tracking webhook
   private val TrackerVersion = "com.mandrill-v1"
 
   // Expected content type for a request body
   private val ContentType = "application/x-www-form-urlencoded"
 
-  private val Vendor = "com.mandrill"
-  private val Format = "jsonschema"
-  private val SchemaVersion = SchemaVer.Full(1, 0, 1)
-
   // Schemas for reverse-engineering a Snowplow unstructured event
   private[registry] val EventSchemaMap = Map(
-    "hard_bounce" -> SchemaKey(Vendor, "message_bounced", Format, SchemaVersion),
-    "click" -> SchemaKey(Vendor, "message_clicked", Format, SchemaVersion),
-    "deferral" -> SchemaKey(Vendor, "message_delayed", Format, SchemaVersion),
-    "spam" -> SchemaKey(Vendor, "message_marked_as_spam", Format, SchemaVersion),
-    "open" -> SchemaKey(Vendor, "message_opened", Format, SchemaVersion),
-    "reject" -> SchemaKey(Vendor, "message_rejected", Format, SchemaVer.Full(1, 0, 0)),
-    "send" -> SchemaKey(Vendor, "message_sent", Format, SchemaVer.Full(1, 0, 0)),
-    "soft_bounce" -> SchemaKey(Vendor, "message_soft_bounced", Format, SchemaVersion),
-    "unsub" -> SchemaKey(Vendor, "recipient_unsubscribed", Format, SchemaVersion)
+    "hard_bounce" -> schemas.messageBouncedSchemaKey,
+    "click" -> schemas.messageClickedSchemaKey,
+    "deferral" -> schemas.messageDelayedSchemaKey,
+    "spam" -> schemas.messageMarkedAsSpamSchemaKey,
+    "open" -> schemas.messageOpenedSchemaKey,
+    "reject" -> schemas.messageRejectedSchemaKey,
+    "send" -> schemas.messageSentSchemaKey,
+    "soft_bounce" -> schemas.messageSoftBouncedSchemaKey,
+    "unsub" -> schemas.recipientUnsubscribedSchemaKey
   )
 
   /**

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/MarketoAdapter.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/MarketoAdapter.scala
@@ -23,7 +23,6 @@ import cats.syntax.validated._
 
 import com.snowplowanalytics.iglu.client.IgluCirceClient
 import com.snowplowanalytics.iglu.client.resolver.registries.RegistryLookup
-import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer}
 import com.snowplowanalytics.snowplow.badrows._
 import io.circe._
 import org.joda.time.DateTimeZone
@@ -37,13 +36,13 @@ import Adapter.Adapted
  * Transforms a collector payload which conforms to a known version of the Marketo webhook into raw
  * events.
  */
-object MarketoAdapter extends Adapter {
+case class MarketoAdapter(schemas: MarketoSchemas) extends Adapter {
   // Tracker version for an Marketo webhook
   private val TrackerVersion = "com.marketo-v1"
 
   // Schemas for reverse-engineering a Snowplow unstructured event
   private val EventSchemaMap = Map(
-    "event" -> SchemaKey("com.marketo", "event", "jsonschema", SchemaVer.Full(2, 0, 0))
+    "event" -> schemas.eventSchemaKey
   )
 
   // Datetime format used by Marketo

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/OlarkAdapter.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/OlarkAdapter.scala
@@ -31,7 +31,6 @@ import cats.effect.Clock
 
 import com.snowplowanalytics.iglu.client.IgluCirceClient
 import com.snowplowanalytics.iglu.client.resolver.registries.RegistryLookup
-import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer}
 import com.snowplowanalytics.snowplow.badrows.FailureDetails
 
 import io.circe._
@@ -48,21 +47,17 @@ import Adapter.Adapted
  * Transforms a collector payload which conforms to a known version of the Olark Tracking webhook
  * into raw events.
  */
-object OlarkAdapter extends Adapter {
+case class OlarkAdapter(schemas: OlarkSchemas) extends Adapter {
   // Tracker version for an Olark Tracking webhook
   private val TrackerVersion = "com.olark-v1"
 
   // Expected content type for a request body
   private val ContentType = "application/x-www-form-urlencoded"
 
-  private val Vendor = "com.olark"
-  private val Format = "jsonschema"
-  private val SchemaVersion = SchemaVer.Full(1, 0, 0)
-
   // Schemas for reverse-engineering a Snowplow unstructured event
   private val EventSchemaMap = Map(
-    "transcript" -> SchemaKey(Vendor, "transcript", Format, SchemaVersion),
-    "offline_message" -> SchemaKey(Vendor, "offline_message", Format, SchemaVersion)
+    "transcript" -> schemas.transcriptSchemaKey,
+    "offline_message" -> schemas.offlineMessageSchemaKey
   )
 
   /**

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/PagerdutyAdapter.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/PagerdutyAdapter.scala
@@ -22,7 +22,6 @@ import cats.syntax.option._
 import cats.syntax.validated._
 import com.snowplowanalytics.iglu.client.IgluCirceClient
 import com.snowplowanalytics.iglu.client.resolver.registries.RegistryLookup
-import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer}
 import com.snowplowanalytics.snowplow.badrows._
 import io.circe._
 
@@ -34,7 +33,7 @@ import Adapter.Adapted
  * Transforms a collector payload which conforms to a known version of the PagerDuty Tracking
  * webhook into raw events.
  */
-object PagerdutyAdapter extends Adapter {
+case class PagerdutyAdapter(schemas: PagerdutySchemas) extends Adapter {
   // Tracker version for a PagerDuty webhook
   private val TrackerVersion = "com.pagerduty-v1"
 
@@ -42,8 +41,7 @@ object PagerdutyAdapter extends Adapter {
   private val ContentType = "application/json"
 
   // Event-Schema Map for reverse-engineering a Snowplow unstructured event
-  private val Incident =
-    SchemaKey("com.pagerduty", "incident", "jsonschema", SchemaVer.Full(1, 0, 0))
+  private val Incident = schemas.incidentSchemaKey
   private[registry] val EventSchemaMap = Map(
     "incident.trigger" -> Incident,
     "incident.acknowledge" -> Incident,

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/PingdomAdapter.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/PingdomAdapter.scala
@@ -22,7 +22,6 @@ import cats.syntax.option._
 import cats.syntax.validated._
 import com.snowplowanalytics.iglu.client.IgluCirceClient
 import com.snowplowanalytics.iglu.client.resolver.registries.RegistryLookup
-import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer}
 import com.snowplowanalytics.snowplow.badrows._
 import io.circe._
 import org.apache.http.NameValuePair
@@ -35,7 +34,7 @@ import Adapter.Adapted
  * Transforms a collector payload which conforms to a known version of the Pingdom Tracking webhook
  * into raw events.
  */
-object PingdomAdapter extends Adapter {
+case class PingdomAdapter(schemas: PingdomSchemas) extends Adapter {
   // Tracker version for an Pingdom Tracking webhook
   private val TrackerVersion = "com.pingdom-v1"
 
@@ -43,16 +42,11 @@ object PingdomAdapter extends Adapter {
   // believe are incorrectly handled Python unicode strings.
   private val PingdomValueRegex = """\(u'(.+)',\)""".r
 
-  private val Vendor = "com.pingdom"
-  private val Format = "jsonschema"
-  private val SchemaVersion = SchemaVer.Full(1, 0, 0)
-
   // Schemas for reverse-engineering a Snowplow unstructured event
   private val EventSchemaMap = Map(
-    "assign" -> SchemaKey(Vendor, "incident_assign", Format, SchemaVersion),
-    "notify_user" -> SchemaKey(Vendor, "incident_notify_user", Format, SchemaVersion),
-    "notify_of_close" ->
-      SchemaKey(Vendor, "incident_notify_of_close", Format, SchemaVersion)
+    "assign" -> schemas.incidentAssignSchemaKey,
+    "notify_user" -> schemas.incidentNotifyUserSchemaKey,
+    "notify_of_close" -> schemas.incidentNotifyOfCloseSchemaKey
   )
 
   /**

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/SendgridAdapter.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/SendgridAdapter.scala
@@ -22,7 +22,6 @@ import cats.syntax.option._
 import cats.syntax.validated._
 import com.snowplowanalytics.iglu.client.IgluCirceClient
 import com.snowplowanalytics.iglu.client.resolver.registries.RegistryLookup
-import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer}
 import com.snowplowanalytics.snowplow.badrows._
 
 import loaders.CollectorPayload
@@ -33,31 +32,26 @@ import Adapter.Adapted
  * Transforms a collector payload which conforms to a known version of the Sendgrid Tracking webhook
  * into raw events.
  */
-object SendgridAdapter extends Adapter {
+case class SendgridAdapter(schemas: SendgridSchemas) extends Adapter {
   // Expected content type for a request body
   private val ContentType = "application/json"
 
   // Tracker version for a Sendgrid Tracking webhook
   private val TrackerVersion = "com.sendgrid-v3"
 
-  private val Vendor = "com.sendgrid"
-  private val Format = "jsonschema"
-  private val SchemaVersion = SchemaVer.Full(2, 0, 0)
-
-  // Schemas for reverse-engineering a Snowplow unstructured event
+  // Schemas for reverse-engineering a Snowplow self-describing event
   private[registry] val EventSchemaMap = Map(
-    "processed" -> SchemaKey(Vendor, "processed", Format, SchemaVersion),
-    "dropped" -> SchemaKey(Vendor, "dropped", Format, SchemaVersion),
-    "delivered" -> SchemaKey(Vendor, "delivered", Format, SchemaVersion),
-    "deferred" -> SchemaKey(Vendor, "deferred", Format, SchemaVersion),
-    "bounce" -> SchemaKey(Vendor, "bounce", Format, SchemaVersion),
-    "open" -> SchemaKey(Vendor, "open", Format, SchemaVersion),
-    "click" -> SchemaKey(Vendor, "click", Format, SchemaVersion),
-    "spamreport" -> SchemaKey(Vendor, "spamreport", Format, SchemaVersion),
-    "unsubscribe" -> SchemaKey(Vendor, "unsubscribe", Format, SchemaVersion),
-    "group_unsubscribe" ->
-      SchemaKey(Vendor, "group_unsubscribe", Format, SchemaVersion),
-    "group_resubscribe" -> SchemaKey(Vendor, "group_resubscribe", Format, SchemaVersion)
+    "processed" -> schemas.processedSchemaKey,
+    "dropped" -> schemas.droppedSchemaKey,
+    "delivered" -> schemas.deliveredSchemaKey,
+    "deferred" -> schemas.deferredSchemaKey,
+    "bounce" -> schemas.bounceSchemaKey,
+    "open" -> schemas.openSchemaKey,
+    "click" -> schemas.clickSchemaKey,
+    "spamreport" -> schemas.spamreportSchemaKey,
+    "unsubscribe" -> schemas.unsubscribeSchemaKey,
+    "group_unsubscribe" -> schemas.groupUnsubscribeSchemaKey,
+    "group_resubscribe" -> schemas.groupResubscribeSchemaKey
   )
 
   /**

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/StatusGatorAdapter.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/StatusGatorAdapter.scala
@@ -27,7 +27,6 @@ import cats.syntax.option._
 import cats.syntax.validated._
 import com.snowplowanalytics.iglu.client.IgluCirceClient
 import com.snowplowanalytics.iglu.client.resolver.registries.RegistryLookup
-import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer}
 import com.snowplowanalytics.snowplow.badrows._
 import io.circe.syntax._
 import org.apache.http.client.utils.URLEncodedUtils
@@ -40,7 +39,7 @@ import Adapter.Adapted
  * Transforms a collector payload which conforms to a known version of the StatusGator Tracking
  * webhook into raw events.
  */
-object StatusGatorAdapter extends Adapter {
+case class StatusGatorAdapter(schemas: StatusGatorSchemas) extends Adapter {
   // Tracker version for an StatusGator Tracking webhook
   private val TrackerVersion = "com.statusgator-v1"
 
@@ -48,8 +47,7 @@ object StatusGatorAdapter extends Adapter {
   private val ContentType = "application/x-www-form-urlencoded"
 
   // Schemas for reverse-engineering a Snowplow unstructured event
-  private val EventSchema =
-    SchemaKey("com.statusgator", "status_change", "jsonschema", SchemaVer.Full(1, 0, 0))
+  private val EventSchema = schemas.statusChangeSchemaKey
 
   /**
    * Converts a CollectorPayload instance into raw events. A StatusGator Tracking payload contains

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/UnbounceAdapter.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/UnbounceAdapter.scala
@@ -29,7 +29,6 @@ import cats.syntax.option._
 import cats.syntax.validated._
 import com.snowplowanalytics.iglu.client.IgluCirceClient
 import com.snowplowanalytics.iglu.client.resolver.registries.RegistryLookup
-import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer}
 import com.snowplowanalytics.snowplow.badrows._
 import io.circe._
 import org.apache.http.client.utils.URLEncodedUtils
@@ -42,7 +41,7 @@ import Adapter.Adapted
  * Transforms a collector payload which conforms to a known version of the Unbounce Tracking webhook
  * into raw events.
  */
-object UnbounceAdapter extends Adapter {
+case class UnbounceAdapter(schemas: UnbounceSchemas) extends Adapter {
   // Tracker version for an Unbounce Tracking webhook
   private val TrackerVersion = "com.unbounce-v1"
 
@@ -51,7 +50,7 @@ object UnbounceAdapter extends Adapter {
 
   // Schema for Unbounce event context
   private val ContextSchema = Map(
-    "form_post" -> SchemaKey("com.unbounce", "form_post", "jsonschema", SchemaVer.Full(1, 0, 0))
+    "form_post" -> schemas.formPostSchemaKey
   )
 
   /**

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/UrbanAirshipAdapter.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/UrbanAirshipAdapter.scala
@@ -23,7 +23,6 @@ import cats.syntax.option._
 import cats.syntax.validated._
 import com.snowplowanalytics.iglu.client.IgluCirceClient
 import com.snowplowanalytics.iglu.client.resolver.registries.RegistryLookup
-import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer}
 import com.snowplowanalytics.snowplow.badrows._
 import io.circe.DecodingFailure
 import org.joda.time.{DateTime, DateTimeZone}
@@ -36,35 +35,28 @@ import Adapter.Adapted
  * Transforms a collector payload which conforms to a known version of the UrbanAirship Connect API
  * into raw events.
  */
-object UrbanAirshipAdapter extends Adapter {
+case class UrbanAirshipAdapter(schemas: UrbanAirshipSchemas) extends Adapter {
   // Tracker version for an UrbanAirship Connect API
   private val TrackerVersion = "com.urbanairship.connect-v1"
 
-  private val Vendor = "com.urbanairship.connect"
-  private val Format = "jsonschema"
-  private val SchemaVersion = SchemaVer.Full(1, 0, 0)
-
   // Schemas for reverse-engineering a Snowplow unstructured event
   private val EventSchemaMap = Map(
-    "CLOSE" -> SchemaKey(Vendor, "CLOSE", Format, SchemaVersion),
-    "CUSTOM" -> SchemaKey(Vendor, "CUSTOM", Format, SchemaVersion),
-    "FIRST_OPEN" -> SchemaKey(Vendor, "FIRST_OPEN", Format, SchemaVersion),
-    "IN_APP_MESSAGE_DISPLAY" ->
-      SchemaKey(Vendor, "IN_APP_MESSAGE_DISPLAY", Format, SchemaVersion),
-    "IN_APP_MESSAGE_EXPIRATION" ->
-      SchemaKey(Vendor, "IN_APP_MESSAGE_EXPIRATION", Format, SchemaVersion),
-    "IN_APP_MESSAGE_RESOLUTION" ->
-      SchemaKey(Vendor, "IN_APP_MESSAGE_RESOLUTION", Format, SchemaVersion),
-    "LOCATION" -> SchemaKey(Vendor, "LOCATION", Format, SchemaVersion),
-    "OPEN" -> SchemaKey(Vendor, "OPEN", Format, SchemaVersion),
-    "PUSH_BODY" -> SchemaKey(Vendor, "PUSH_BODY", Format, SchemaVersion),
-    "REGION" -> SchemaKey(Vendor, "REGION", Format, SchemaVersion),
-    "RICH_DELETE" -> SchemaKey(Vendor, "RICH_DELETE", Format, SchemaVersion),
-    "RICH_DELIVERY" -> SchemaKey(Vendor, "RICH_DELIVERY", Format, SchemaVersion),
-    "RICH_HEAD" -> SchemaKey(Vendor, "RICH_HEAD", Format, SchemaVersion),
-    "SEND" -> SchemaKey(Vendor, "SEND", Format, SchemaVersion),
-    "TAG_CHANGE" -> SchemaKey(Vendor, "TAG_CHANGE", Format, SchemaVersion),
-    "UNINSTALL" -> SchemaKey(Vendor, "UNINSTALL", Format, SchemaVersion)
+    "CLOSE" -> schemas.closeSchemaKey,
+    "CUSTOM" -> schemas.customSchemaKey,
+    "FIRST_OPEN" -> schemas.firstOpenSchemaKey,
+    "IN_APP_MESSAGE_DISPLAY" -> schemas.inAppMessageDisplaySchemaKey,
+    "IN_APP_MESSAGE_EXPIRATION" -> schemas.inAppMessageExpirationSchemaKey,
+    "IN_APP_MESSAGE_RESOLUTION" -> schemas.inAppMessageResolutionSchemaKey,
+    "LOCATION" -> schemas.locationSchemaKey,
+    "OPEN" -> schemas.openSchemaKey,
+    "PUSH_BODY" -> schemas.pushBodySchemaKey,
+    "REGION" -> schemas.regionSchemaKey,
+    "RICH_DELETE" -> schemas.richDeleteSchemaKey,
+    "RICH_DELIVERY" -> schemas.richDeliverySchemaKey,
+    "RICH_HEAD" -> schemas.richHeadSchemaKey,
+    "SEND" -> schemas.sendSchemaKey,
+    "TAG_CHANGE" -> schemas.tagChangeSchemaKey,
+    "UNINSTALL" -> schemas.uninstallSchemaKey
   )
 
   /**

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/VeroAdapter.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/VeroAdapter.scala
@@ -22,7 +22,6 @@ import cats.syntax.validated._
 
 import com.snowplowanalytics.iglu.client.IgluCirceClient
 import com.snowplowanalytics.iglu.client.resolver.registries.RegistryLookup
-import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer}
 
 import com.snowplowanalytics.snowplow.badrows._
 
@@ -33,24 +32,20 @@ import utils.{HttpClient, JsonUtils}
 import Adapter.Adapted
 
 /** Transforms a collector payload which fits the Vero webhook into raw events. */
-object VeroAdapter extends Adapter {
+case class VeroAdapter(schemas: VeroSchemas) extends Adapter {
   // Tracker version for an Vero webhook
   private val TrackerVersion = "com.getvero-v1"
 
-  private val Vendor = "com.getvero"
-  private val Format = "jsonschema"
-  private val SchemaVersion = SchemaVer.Full(1, 0, 0)
-
   // Schemas for reverse-engineering a Snowplow unstructured event
   private val EventSchemaMap = Map(
-    "bounced" -> SchemaKey(Vendor, "bounced", Format, SchemaVersion),
-    "clicked" -> SchemaKey(Vendor, "clicked", Format, SchemaVersion),
-    "delivered" -> SchemaKey(Vendor, "delivered", Format, SchemaVersion),
-    "opened" -> SchemaKey(Vendor, "opened", Format, SchemaVersion),
-    "sent" -> SchemaKey(Vendor, "sent", Format, SchemaVersion),
-    "unsubscribed" -> SchemaKey(Vendor, "unsubscribed", Format, SchemaVersion),
-    "user_created" -> SchemaKey(Vendor, "created", Format, SchemaVersion),
-    "user_updated" -> SchemaKey(Vendor, "updated", Format, SchemaVersion)
+    "bounced" -> schemas.bouncedSchemaKey,
+    "clicked" -> schemas.clickedSchemaKey,
+    "delivered" -> schemas.deliveredSchemaKey,
+    "opened" -> schemas.openedSchemaKey,
+    "sent" -> schemas.sentSchemaKey,
+    "unsubscribed" -> schemas.unsubscribedSchemaKey,
+    "user_created" -> schemas.createdSchemaKey,
+    "user_updated" -> schemas.updatedSchemaKey
   )
 
   /**

--- a/modules/common/src/test/resources/com/snowplowanalytics/snowplow/enrich/common/enrichments/registry/include_current.txt
+++ b/modules/common/src/test/resources/com/snowplowanalytics/snowplow/enrich/common/enrichments/registry/include_current.txt
@@ -6,3 +6,5 @@ user agent at the start only|1|1
 Some user agent|1|0
 #Commented browser|1|1
 Inactive Browser|0|0|03/30/2017
+# Exclude UA from IabEnrichmentSpec
+Mozilla/5.0%20(Windows%20NT%206.1;%20WOW64;%20rv:12.0)%20Gecko/20100101%20Firefox/12.0|1|1

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/EtlPipelineSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/EtlPipelineSpec.scala
@@ -37,6 +37,7 @@ import com.snowplowanalytics.snowplow.enrich.common.enrichments.EnrichmentRegist
 import com.snowplowanalytics.snowplow.enrich.common.loaders._
 import com.snowplowanalytics.snowplow.enrich.common.outputs.EnrichedEvent
 import com.snowplowanalytics.snowplow.enrich.common.utils.Clock._
+import com.snowplowanalytics.snowplow.enrich.common.SpecHelpers.adaptersSchemas
 
 class EtlPipelineSpec extends Specification with ValidatedMatchers {
   def is = s2"""
@@ -46,7 +47,9 @@ class EtlPipelineSpec extends Specification with ValidatedMatchers {
   Absence of CollectorPayload (None) should be supported                                   $e4
   """
 
-  val adapterRegistry = new AdapterRegistry()
+  val adapterRegistry = new AdapterRegistry(
+    adaptersSchemas = adaptersSchemas
+  )
   val enrichmentReg = EnrichmentRegistry[Id]()
   val igluCentral = Registry.IgluCentral
   val client = IgluCirceClient.fromResolver[Id](Resolver(List(igluCentral), None), cacheSize = 0)

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/SpecHelpers.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/SpecHelpers.scala
@@ -27,6 +27,7 @@ import io.circe.literal._
 import org.apache.http.NameValuePair
 import org.apache.http.message.BasicNameValuePair
 
+import com.snowplowanalytics.snowplow.enrich.common.adapters._
 import com.snowplowanalytics.snowplow.enrich.common.utils.JsonUtils
 
 object SpecHelpers {
@@ -107,4 +108,187 @@ object SpecHelpers {
   implicit class MapOps[A, B](underlying: Map[A, B]) {
     def toOpt: Map[A, Option[B]] = underlying.map { case (a, b) => (a, Option(b)) }
   }
+
+  val callrailSchemas = CallrailSchemas(
+    call_complete = "iglu:com.callrail/call_complete/jsonschema/1-0-2"
+  )
+
+  val cloudfrontAccessLogSchemas = CloudfrontAccessLogSchemas(
+    with_12_fields = "iglu:com.amazon.aws.cloudfront/wd_access_log/jsonschema/1-0-0",
+    with_15_fields = "iglu:com.amazon.aws.cloudfront/wd_access_log/jsonschema/1-0-1",
+    with_18_fields = "iglu:com.amazon.aws.cloudfront/wd_access_log/jsonschema/1-0-2",
+    with_19_fields = "iglu:com.amazon.aws.cloudfront/wd_access_log/jsonschema/1-0-3",
+    with_23_fields = "iglu:com.amazon.aws.cloudfront/wd_access_log/jsonschema/1-0-4",
+    with_24_fields = "iglu:com.amazon.aws.cloudfront/wd_access_log/jsonschema/1-0-5",
+    with_26_fields = "iglu:com.amazon.aws.cloudfront/wd_access_log/jsonschema/1-0-6"
+  )
+
+  val sendgridSchemas = SendgridSchemas(
+    processed = "iglu:com.sendgrid/processed/jsonschema/2-0-0",
+    dropped = "iglu:com.sendgrid/dropped/jsonschema/2-0-0",
+    delivered = "iglu:com.sendgrid/delivered/jsonschema/2-0-0",
+    bounce = "iglu:com.sendgrid/bounce/jsonschema/2-0-0",
+    deferred = "iglu:com.sendgrid/deferred/jsonschema/2-0-0",
+    open = "iglu:com.sendgrid/open/jsonschema/2-0-0",
+    click = "iglu:com.sendgrid/click/jsonschema/2-0-0",
+    unsubscribe = "iglu:com.sendgrid/unsubscribe/jsonschema/2-0-0",
+    group_unsubscribe = "iglu:com.sendgrid/group_unsubscribe/jsonschema/2-0-0",
+    group_resubscribe = "iglu:com.sendgrid/group_resubscribe/jsonschema/2-0-0",
+    spamreport = "iglu:com.sendgrid/spamreport/jsonschema/2-0-0"
+  )
+
+  val googleAnalyticsSchemas = GoogleAnalyticsSchemas(
+    page_view = "iglu:com.google.analytics.measurement-protocol/page_view/jsonschema/1-0-0",
+    screen_view = "iglu:com.google.analytics.measurement-protocol/screen_view/jsonschema/1-0-0",
+    event = "iglu:com.google.analytics.measurement-protocol/event/jsonschema/1-0-0",
+    transaction = "iglu:com.google.analytics.measurement-protocol/transaction/jsonschema/1-0-0",
+    item = "iglu:com.google.analytics.measurement-protocol/item/jsonschema/1-0-0",
+    social = "iglu:com.google.analytics.measurement-protocol/social/jsonschema/1-0-0",
+    exception = "iglu:com.google.analytics.measurement-protocol/exception/jsonschema/1-0-0",
+    timing = "iglu:com.google.analytics.measurement-protocol/timing/jsonschema/1-0-0",
+    undocumented = "iglu:com.google.analytics/undocumented/jsonschema/1-0-0",
+    `private` = "iglu:com.google.analytics/private/jsonschema/1-0-0",
+    general = "iglu:com.google.analytics.measurement-protocol/general/jsonschema/1-0-0",
+    user = "iglu:com.google.analytics.measurement-protocol/user/jsonschema/1-0-0",
+    session = "iglu:com.google.analytics.measurement-protocol/session/jsonschema/1-0-0",
+    traffic_source = "iglu:com.google.analytics.measurement-protocol/traffic_source/jsonschema/1-0-0",
+    system_info = "iglu:com.google.analytics.measurement-protocol/system_info/jsonschema/1-0-0",
+    link = "iglu:com.google.analytics.measurement-protocol/link/jsonschema/1-0-0",
+    app = "iglu:com.google.analytics.measurement-protocol/app/jsonschema/1-0-0",
+    product_action = "iglu:com.google.analytics.measurement-protocol/product_action/jsonschema/1-0-0",
+    content_experiment = "iglu:com.google.analytics.measurement-protocol/content_experiment/jsonschema/1-0-0",
+    hit = "iglu:com.google.analytics.measurement-protocol/hit/jsonschema/1-0-0",
+    promotion_action = "iglu:com.google.analytics.measurement-protocol/promotion_action/jsonschema/1-0-0",
+    product = "iglu:com.google.analytics.measurement-protocol/product/jsonschema/1-0-0",
+    product_custom_dimension = "iglu:com.google.analytics.measurement-protocol/product_custom_dimension/jsonschema/1-0-0",
+    product_custom_metric = "iglu:com.google.analytics.measurement-protocol/product_custom_metric/jsonschema/1-0-0",
+    product_impression_list = "iglu:com.google.analytics.measurement-protocol/product_impression_list/jsonschema/1-0-0",
+    product_impression = "iglu:com.google.analytics.measurement-protocol/product_impression/jsonschema/1-0-0",
+    product_impression_custom_dimension =
+      "iglu:com.google.analytics.measurement-protocol/product_impression_custom_dimension/jsonschema/1-0-0",
+    product_impression_custom_metric = "iglu:com.google.analytics.measurement-protocol/product_impression_custom_metric/jsonschema/1-0-0",
+    promotion = "iglu:com.google.analytics.measurement-protocol/promotion/jsonschema/1-0-0",
+    custom_dimension = "iglu:com.google.analytics.measurement-protocol/custom_dimension/jsonschema/1-0-0",
+    custom_metric = "iglu:com.google.analytics.measurement-protocol/custom_metric/jsonschema/1-0-0",
+    content_group = "iglu:com.google.analytics.measurement-protocol/content_group/jsonschema/1-0-0"
+  )
+
+  val hubspotSchemas = HubspotSchemas(
+    contact_creation = "iglu:com.hubspot/contact_creation/jsonschema/1-0-0",
+    contact_deletion = "iglu:com.hubspot/contact_deletion/jsonschema/1-0-0",
+    contact_change = "iglu:com.hubspot/contact_change/jsonschema/1-0-0",
+    company_creation = "iglu:com.hubspot/company_creation/jsonschema/1-0-0",
+    company_deletion = "iglu:com.hubspot/company_deletion/jsonschema/1-0-0",
+    company_change = "iglu:com.hubspot/company_change/jsonschema/1-0-0",
+    deal_creation = "iglu:com.hubspot/deal_creation/jsonschema/1-0-0",
+    deal_deletion = "iglu:com.hubspot/deal_deletion/jsonschema/1-0-0",
+    deal_change = "iglu:com.hubspot/deal_change/jsonschema/1-0-0"
+  )
+
+  val mailchimpSchemas = MailchimpSchemas(
+    subscribe = "iglu:com.mailchimp/subscribe/jsonschema/1-0-0",
+    unsubscribe = "iglu:com.mailchimp/unsubscribe/jsonschema/1-0-0",
+    campaign_sending_status = "iglu:com.mailchimp/campaign_sending_status/jsonschema/1-0-0",
+    cleaned_email = "iglu:com.mailchimp/cleaned_email/jsonschema/1-0-0",
+    email_address_change = "iglu:com.mailchimp/email_address_change/jsonschema/1-0-0",
+    profile_update = "iglu:com.mailchimp/profile_update/jsonschema/1-0-0"
+  )
+
+  val mailgunSchemas = MailgunSchemas(
+    message_bounced = "iglu:com.mailgun/message_bounced/jsonschema/1-0-0",
+    message_clicked = "iglu:com.mailgun/message_clicked/jsonschema/1-0-0",
+    message_complained = "iglu:com.mailgun/message_complained/jsonschema/1-0-0",
+    message_delivered = "iglu:com.mailgun/message_delivered/jsonschema/1-0-0",
+    message_dropped = "iglu:com.mailgun/message_dropped/jsonschema/1-0-0",
+    message_opened = "iglu:com.mailgun/message_opened/jsonschema/1-0-0",
+    recipient_unsubscribed = "iglu:com.mailgun/recipient_unsubscribed/jsonschema/1-0-0"
+  )
+
+  val mandrillSchemas = MandrillSchemas(
+    message_bounced = "iglu:com.mandrill/message_bounced/jsonschema/1-0-1",
+    message_clicked = "iglu:com.mandrill/message_clicked/jsonschema/1-0-1",
+    message_delayed = "iglu:com.mandrill/message_delayed/jsonschema/1-0-1",
+    message_marked_as_spam = "iglu:com.mandrill/message_marked_as_spam/jsonschema/1-0-1",
+    message_opened = "iglu:com.mandrill/message_opened/jsonschema/1-0-1",
+    message_rejected = "iglu:com.mandrill/message_rejected/jsonschema/1-0-0",
+    message_sent = "iglu:com.mandrill/message_sent/jsonschema/1-0-0",
+    message_soft_bounced = "iglu:com.mandrill/message_soft_bounced/jsonschema/1-0-1",
+    recipient_unsubscribed = "iglu:com.mandrill/recipient_unsubscribed/jsonschema/1-0-1"
+  )
+
+  val marketoSchemas = MarketoSchemas(
+    event = "iglu:com.marketo/event/jsonschema/2-0-0"
+  )
+
+  val olarkSchemas = OlarkSchemas(
+    transcript = "iglu:com.olark/transcript/jsonschema/1-0-0",
+    offline_message = "iglu:com.olark/offline_message/jsonschema/1-0-0"
+  )
+
+  val pagerdutySchemas = PagerdutySchemas(
+    incident = "iglu:com.pagerduty/incident/jsonschema/1-0-0"
+  )
+
+  val pingdomSchemas = PingdomSchemas(
+    incident_assign = "iglu:com.pingdom/incident_assign/jsonschema/1-0-0",
+    incident_notify_user = "iglu:com.pingdom/incident_notify_user/jsonschema/1-0-0",
+    incident_notify_of_close = "iglu:com.pingdom/incident_notify_of_close/jsonschema/1-0-0"
+  )
+
+  val statusGatorSchemas = StatusGatorSchemas(
+    status_change = "iglu:com.statusgator/status_change/jsonschema/1-0-0"
+  )
+
+  val unbounceSchemas = UnbounceSchemas(
+    form_post = "iglu:com.unbounce/form_post/jsonschema/1-0-0"
+  )
+
+  val urbanAirshipSchemas = UrbanAirshipSchemas(
+    close = "iglu:com.urbanairship.connect/CLOSE/jsonschema/1-0-0",
+    custom = "iglu:com.urbanairship.connect/CUSTOM/jsonschema/1-0-0",
+    first_open = "iglu:com.urbanairship.connect/FIRST_OPEN/jsonschema/1-0-0",
+    in_app_message_display = "iglu:com.urbanairship.connect/IN_APP_MESSAGE_DISPLAY/jsonschema/1-0-0",
+    in_app_message_expiration = "iglu:com.urbanairship.connect/IN_APP_MESSAGE_EXPIRATION/jsonschema/1-0-0",
+    in_app_message_resolution = "iglu:com.urbanairship.connect/IN_APP_MESSAGE_RESOLUTION/jsonschema/1-0-0",
+    location = "iglu:com.urbanairship.connect/LOCATION/jsonschema/1-0-0",
+    open = "iglu:com.urbanairship.connect/OPEN/jsonschema/1-0-0",
+    push_body = "iglu:com.urbanairship.connect/PUSH_BODY/jsonschema/1-0-0",
+    region = "iglu:com.urbanairship.connect/REGION/jsonschema/1-0-0",
+    rich_delete = "iglu:com.urbanairship.connect/RICH_DELETE/jsonschema/1-0-0",
+    rich_delivery = "iglu:com.urbanairship.connect/RICH_DELIVERY/jsonschema/1-0-0",
+    rich_head = "iglu:com.urbanairship.connect/RICH_HEAD/jsonschema/1-0-0",
+    send = "iglu:com.urbanairship.connect/SEND/jsonschema/1-0-0",
+    tag_change = "iglu:com.urbanairship.connect/TAG_CHANGE/jsonschema/1-0-0",
+    uninstall = "iglu:com.urbanairship.connect/UNINSTALL/jsonschema/1-0-0"
+  )
+
+  val veroSchemas = VeroSchemas(
+    bounced = "iglu:com.getvero/bounced/jsonschema/1-0-0",
+    clicked = "iglu:com.getvero/clicked/jsonschema/1-0-0",
+    delivered = "iglu:com.getvero/delivered/jsonschema/1-0-0",
+    opened = "iglu:com.getvero/opened/jsonschema/1-0-0",
+    sent = "iglu:com.getvero/sent/jsonschema/1-0-0",
+    unsubscribed = "iglu:com.getvero/unsubscribed/jsonschema/1-0-0",
+    created = "iglu:com.getvero/created/jsonschema/1-0-0",
+    updated = "iglu:com.getvero/updated/jsonschema/1-0-0"
+  )
+
+  val adaptersSchemas = AdaptersSchemas(
+    callrail = callrailSchemas,
+    cloudfrontAccessLog = cloudfrontAccessLogSchemas,
+    googleAnalytics = googleAnalyticsSchemas,
+    hubspot = hubspotSchemas,
+    mailchimp = mailchimpSchemas,
+    mailgun = mailgunSchemas,
+    mandrill = mandrillSchemas,
+    marketo = marketoSchemas,
+    olark = olarkSchemas,
+    pagerduty = pagerdutySchemas,
+    pingdom = pingdomSchemas,
+    sendgrid = sendgridSchemas,
+    statusgator = statusGatorSchemas,
+    unbounce = unbounceSchemas,
+    urbanAirship = urbanAirshipSchemas,
+    vero = veroSchemas
+  )
 }

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/CallrailAdapterSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/CallrailAdapterSpec.scala
@@ -34,6 +34,8 @@ class CallrailAdapterSpec extends Specification with DataTables with ValidatedMa
   toRawEvents should return a Validation Failure if there are no parameters on the querystring      $e2
   """
 
+  val adapterWithDefaultSchemas = CallrailAdapter(schemas = callrailSchemas)
+
   object Shared {
     val api = CollectorPayload.Api("com.callrail", "v1")
     val source = CollectorPayload.Source("clj-tomcat", "UTF-8", None)
@@ -97,7 +99,7 @@ class CallrailAdapterSpec extends Specification with DataTables with ValidatedMa
       "nuid" -> "-"
     )
     val payload = CollectorPayload(Shared.api, params, None, None, Shared.source, Shared.context)
-    val actual = CallrailAdapter.toRawEvents[Id](payload, SpecHelpers.client)
+    val actual = adapterWithDefaultSchemas.toRawEvents[Id](payload, SpecHelpers.client)
 
     val expectedJson =
       """|{
@@ -160,7 +162,7 @@ class CallrailAdapterSpec extends Specification with DataTables with ValidatedMa
   def e2 = {
     val params = toNameValuePairs()
     val payload = CollectorPayload(Shared.api, params, None, None, Shared.source, Shared.context)
-    val actual = CallrailAdapter.toRawEvents[Id](payload, SpecHelpers.client)
+    val actual = adapterWithDefaultSchemas.toRawEvents[Id](payload, SpecHelpers.client)
 
     actual must beInvalid(
       NonEmptyList.one(

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/CloudfrontAccessLogAdapterSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/CloudfrontAccessLogAdapterSpec.scala
@@ -54,6 +54,7 @@ class CloudfrontAccessLogAdapterSpec extends Specification with DataTables with 
   val singleEncodedQs = "a=b%20c"
 
   val url = "http://snowplowanalytics.com/analytics/index.html"
+  val adapterWithDefaultSchemas = CloudfrontAccessLogAdapter(schemas = cloudfrontAccessLogSchemas)
 
   object Shared {
     val api = CollectorPayload.Api("com.amazon.aws.cloudfront", "wd_access_log")
@@ -87,7 +88,7 @@ class CloudfrontAccessLogAdapterSpec extends Specification with DataTables with 
     val payload = loader.toCollectorPayload(input, processor)
 
     val actual = payload.map(
-      _.map(CloudfrontAccessLogAdapter.toRawEvents(_, SpecHelpers.client))
+      _.map(adapterWithDefaultSchemas.toRawEvents(_, SpecHelpers.client))
     )
 
     val expectedJson =
@@ -135,7 +136,7 @@ class CloudfrontAccessLogAdapterSpec extends Specification with DataTables with 
     val payload = loader.toCollectorPayload(input, processor)
 
     val actual = payload.map(
-      _.map(CloudfrontAccessLogAdapter.toRawEvents(_, SpecHelpers.client))
+      _.map(adapterWithDefaultSchemas.toRawEvents(_, SpecHelpers.client))
     )
 
     val expectedJson =
@@ -186,7 +187,7 @@ class CloudfrontAccessLogAdapterSpec extends Specification with DataTables with 
     val payload = loader.toCollectorPayload(input, processor)
 
     val actual = payload.map(
-      _.map(CloudfrontAccessLogAdapter.toRawEvents(_, SpecHelpers.client))
+      _.map(adapterWithDefaultSchemas.toRawEvents(_, SpecHelpers.client))
     )
 
     val expectedJson =
@@ -240,7 +241,7 @@ class CloudfrontAccessLogAdapterSpec extends Specification with DataTables with 
     val payload = loader.toCollectorPayload(input, processor)
 
     val actual = payload.map(
-      _.map(CloudfrontAccessLogAdapter.toRawEvents(_, SpecHelpers.client))
+      _.map(adapterWithDefaultSchemas.toRawEvents(_, SpecHelpers.client))
     )
 
     val expectedJson =
@@ -295,7 +296,7 @@ class CloudfrontAccessLogAdapterSpec extends Specification with DataTables with 
     val payload = loader.toCollectorPayload(input, processor)
 
     val actual = payload.map(
-      _.map(CloudfrontAccessLogAdapter.toRawEvents(_, SpecHelpers.client))
+      _.map(adapterWithDefaultSchemas.toRawEvents(_, SpecHelpers.client))
     )
 
     val expectedJson =
@@ -354,7 +355,7 @@ class CloudfrontAccessLogAdapterSpec extends Specification with DataTables with 
     val payload = loader.toCollectorPayload(input, processor)
 
     val actual = payload.map(
-      _.map(CloudfrontAccessLogAdapter.toRawEvents(_, SpecHelpers.client))
+      _.map(adapterWithDefaultSchemas.toRawEvents(_, SpecHelpers.client))
     )
 
     val expectedJson =
@@ -414,7 +415,7 @@ class CloudfrontAccessLogAdapterSpec extends Specification with DataTables with 
     val payload = loader.toCollectorPayload(input, processor)
 
     val actual = payload.map(
-      _.map(CloudfrontAccessLogAdapter.toRawEvents(_, SpecHelpers.client))
+      _.map(adapterWithDefaultSchemas.toRawEvents(_, SpecHelpers.client))
     )
 
     val expectedJson =
@@ -480,7 +481,7 @@ class CloudfrontAccessLogAdapterSpec extends Specification with DataTables with 
         Shared.source,
         Shared.context
       )
-    val actual = CloudfrontAccessLogAdapter.toRawEvents(payload, SpecHelpers.client)
+    val actual = adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client)
 
     actual must beInvalid(
       NonEmptyList
@@ -505,7 +506,7 @@ class CloudfrontAccessLogAdapterSpec extends Specification with DataTables with 
         Shared.source,
         Shared.context
       )
-    val actual = CloudfrontAccessLogAdapter.toRawEvents(payload, SpecHelpers.client)
+    val actual = adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client)
 
     actual must beInvalid(
       NonEmptyList.of(

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/GoogleAnalyticsAdapterSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/GoogleAnalyticsAdapterSpec.scala
@@ -26,7 +26,6 @@ import org.specs2.matcher.{DataTables, ValidatedMatchers}
 import com.snowplowanalytics.snowplow.badrows._
 
 import loaders._
-import GoogleAnalyticsAdapter._
 import utils.Clock._
 
 import SpecHelpers._
@@ -52,6 +51,7 @@ class GoogleAnalyticsAdapterSpec extends Specification with DataTables with Vali
   breakDownCompositeField should work properly                             $e20
   """
 
+  val adapterWithDefaultSchemas = GoogleAnalyticsAdapter(schemas = googleAnalyticsSchemas)
   val api = CollectorPayload.Api("com.google.analytics.measurement-protocol", "v1")
   val source = CollectorPayload.Source("clj-tomcat", "UTF-8", None)
   val context =
@@ -78,7 +78,7 @@ class GoogleAnalyticsAdapterSpec extends Specification with DataTables with Vali
 
   def e1 = {
     val payload = CollectorPayload(api, Nil, None, None, source, context)
-    val actual = toRawEvents(payload, SpecHelpers.client)
+    val actual = adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client)
     actual must beInvalid(
       NonEmptyList.one(
         FailureDetails.AdapterFailure.InputData("body", None, "empty body")
@@ -89,7 +89,7 @@ class GoogleAnalyticsAdapterSpec extends Specification with DataTables with Vali
   def e2 = {
     val body = "dl=docloc"
     val payload = CollectorPayload(api, Nil, None, body.some, source, context)
-    val actual = toRawEvents(payload, SpecHelpers.client)
+    val actual = adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client)
     actual must beInvalid(
       NonEmptyList.one(
         FailureDetails.AdapterFailure.InputData(
@@ -104,14 +104,14 @@ class GoogleAnalyticsAdapterSpec extends Specification with DataTables with Vali
   def e3 = {
     val body = "t=unknown&dl=docloc"
     val payload = CollectorPayload(api, Nil, None, body.some, source, context)
-    val actual = toRawEvents(payload, SpecHelpers.client)
+    val actual = adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client)
     actual must beInvalid(
       NonEmptyList.of(
         FailureDetails.AdapterFailure
           .InputData("t", "unknown".some, "no matching hit type"),
         FailureDetails.AdapterFailure.SchemaMapping(
           "unknown".some,
-          unstructEventData.mapValues(_.schemaKey),
+          adapterWithDefaultSchemas.unstructEventData.mapValues(_.schemaKey),
           "no schema associated with the provided type parameter"
         )
       )
@@ -121,7 +121,7 @@ class GoogleAnalyticsAdapterSpec extends Specification with DataTables with Vali
   def e4 = {
     val body = "t=pageview&dh=host&dp=path"
     val payload = CollectorPayload(api, Nil, None, body.some, source, context)
-    val actual = toRawEvents(payload, SpecHelpers.client)
+    val actual = adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client)
 
     val expectedJson =
       """|{
@@ -146,7 +146,7 @@ class GoogleAnalyticsAdapterSpec extends Specification with DataTables with Vali
   def e5 = {
     val body = "t=pageview&dh=host&cid=id&v=version"
     val payload = CollectorPayload(api, Nil, None, body.some, source, context)
-    val actual = toRawEvents(payload, SpecHelpers.client)
+    val actual = adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client)
 
     val expectedUE =
       """|{
@@ -176,7 +176,7 @@ class GoogleAnalyticsAdapterSpec extends Specification with DataTables with Vali
   def e6 = {
     val body = "t=pageview&dp=path&uip=ip"
     val payload = CollectorPayload(api, Nil, None, body.some, source, context)
-    val actual = toRawEvents(payload, SpecHelpers.client)
+    val actual = adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client)
 
     val expectedUE =
       """|{
@@ -202,7 +202,7 @@ class GoogleAnalyticsAdapterSpec extends Specification with DataTables with Vali
   def e7 = {
     val body = "t=item&in=name&ip=12.228&iq=12&aip=0"
     val payload = CollectorPayload(api, Nil, None, body.some, source, context)
-    val actual = toRawEvents(payload, SpecHelpers.client)
+    val actual = adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client)
 
     val expectedUE =
       """|{
@@ -238,7 +238,7 @@ class GoogleAnalyticsAdapterSpec extends Specification with DataTables with Vali
   def e8 = {
     val body = "t=exception&exd=desc&exf=1&dh=host"
     val payload = CollectorPayload(api, Nil, None, body.some, source, context)
-    val actual = toRawEvents(payload, SpecHelpers.client)
+    val actual = adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client)
 
     val expectedUE =
       """|{
@@ -263,7 +263,7 @@ class GoogleAnalyticsAdapterSpec extends Specification with DataTables with Vali
   def e9 = {
     val body = "t=transaction&ti=tr&cu=EUR&pr12id=ident&pr12cd42=val"
     val payload = CollectorPayload(api, Nil, None, body.some, source, context)
-    val actual = toRawEvents(payload, SpecHelpers.client)
+    val actual = adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client)
 
     val expectedUE =
       """|{
@@ -296,7 +296,7 @@ class GoogleAnalyticsAdapterSpec extends Specification with DataTables with Vali
   def e10 = {
     val body = "t=pageview&dp=path&il12pi42id=s&il12pi42cd36=dim"
     val payload = CollectorPayload(api, Nil, None, body.some, source, context)
-    val actual = toRawEvents(payload, SpecHelpers.client)
+    val actual = adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client)
 
     val expectedUE =
       """|{
@@ -324,7 +324,7 @@ class GoogleAnalyticsAdapterSpec extends Specification with DataTables with Vali
   def e11 = {
     val body = "t=screenview&cd=name&cd12=dim"
     val payload = CollectorPayload(api, Nil, None, body.some, source, context)
-    val actual = toRawEvents(payload, SpecHelpers.client)
+    val actual = adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client)
 
     val expectedUE =
       """|{
@@ -349,7 +349,7 @@ class GoogleAnalyticsAdapterSpec extends Specification with DataTables with Vali
   def e12 = {
     val body = "t=pageview&dp=path&pr1id=s1&pr2id=s2&pr1cd1=v1&pr1cd2=v2"
     val payload = CollectorPayload(api, Nil, None, body.some, source, context)
-    val actual = toRawEvents(payload, SpecHelpers.client)
+    val actual = adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client)
 
     val expectedUE =
       """|{
@@ -383,7 +383,7 @@ class GoogleAnalyticsAdapterSpec extends Specification with DataTables with Vali
   def e13 = {
     val body = "t=pageview&dp=path&promoa=action&promo12id=id"
     val payload = CollectorPayload(api, Nil, None, body.some, source, context)
-    val actual = toRawEvents(payload, SpecHelpers.client)
+    val actual = adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client)
 
     val expectedUE =
       """|{
@@ -411,7 +411,7 @@ class GoogleAnalyticsAdapterSpec extends Specification with DataTables with Vali
   def e14 = {
     val body = "t=pageview&dh=host&dp=path\nt=pageview&dh=host&dp=path"
     val payload = CollectorPayload(api, Nil, None, body.some, source, context)
-    val actual = toRawEvents(payload, SpecHelpers.client)
+    val actual = adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client)
 
     val expectedJson =
       """|{
@@ -438,7 +438,7 @@ class GoogleAnalyticsAdapterSpec extends Specification with DataTables with Vali
     val body =
       "t=pageview&dh=host&dp=path&cu=EUR&il1pi1pr=1&il1pi1nm=name1&il1pi1ps=1&il1pi1ca=cat1&il1pi1id=id1&il1pi1br=brand1&il1pi2pr=2&il1pi2nm=name2&il1pi2ps=2&il1pi2ca=cat2&il1pi2id=id2&il1pi2br=brand2&il2pi1pr=21&il2pi1nm=name21&il2pi1ps=21&il2pi1ca=cat21&il2pi1id=id21&il2pi1br=brand21"
     val payload = CollectorPayload(api, Nil, None, body.some, source, context)
-    val actual = toRawEvents(payload, SpecHelpers.client)
+    val actual = adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client)
 
     val expectedJson =
       """|{
@@ -482,22 +482,22 @@ class GoogleAnalyticsAdapterSpec extends Specification with DataTables with Vali
           """(pr|promo|il|cd|cm|cg)(\d+)([a-zA-Z]*)(\d*)([a-zA-Z]*)(\d*)$"""
       )
     val s = Seq(
-      breakDownCompField("pr") must beLeft(errorMessage("pr")),
-      breakDownCompField("pr12id") must beRight((List("pr", "id"), List("12"))),
-      breakDownCompField("12") must beLeft(errorMessage("12")),
-      breakDownCompField("") must beLeft(
+      adapterWithDefaultSchemas.breakDownCompField("pr") must beLeft(errorMessage("pr")),
+      adapterWithDefaultSchemas.breakDownCompField("pr12id") must beRight((List("pr", "id"), List("12"))),
+      adapterWithDefaultSchemas.breakDownCompField("12") must beLeft(errorMessage("12")),
+      adapterWithDefaultSchemas.breakDownCompField("") must beLeft(
         FailureDetails.AdapterFailure
           .InputData("", None, "cannot parse empty field name")
       ),
-      breakDownCompField("pr12id", "identifier", "IF") must beRight(
+      adapterWithDefaultSchemas.breakDownCompField("pr12id", "identifier", "IF") must beRight(
         Map("IFpr" -> "12", "prid" -> "identifier")
       ),
-      breakDownCompField("pr12cm42", "value", "IF") must beRight(
+      adapterWithDefaultSchemas.breakDownCompField("pr12cm42", "value", "IF") must beRight(
         Map("IFprcm" -> "12", "IFcm" -> "42", "prcm" -> "value")
       ),
-      breakDownCompField("pr", "value", "IF") must beLeft(errorMessage("pr")),
-      breakDownCompField("pr", "", "IF") must beLeft(errorMessage("pr")),
-      breakDownCompField("pr12", "val", "IF") must beRight(Map("IFpr" -> "12", "pr" -> "val"))
+      adapterWithDefaultSchemas.breakDownCompField("pr", "value", "IF") must beLeft(errorMessage("pr")),
+      adapterWithDefaultSchemas.breakDownCompField("pr", "", "IF") must beLeft(errorMessage("pr")),
+      adapterWithDefaultSchemas.breakDownCompField("pr12", "val", "IF") must beRight(Map("IFpr" -> "12", "pr" -> "val"))
     )
     s.reduce(_ and _)
   }

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/HubSpotAdapterSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/HubSpotAdapterSpec.scala
@@ -53,6 +53,7 @@ class HubSpotAdapterSpec extends Specification with DataTables with ValidatedMat
   }
 
   val ContentType = "application/json"
+  val adapterWithDefaultSchemas = HubSpotAdapter(schemas = hubspotSchemas)
 
   def e1 = {
     val bodyStr = """[{"subscriptionType":"company.change","eventId":16}]"""
@@ -60,7 +61,7 @@ class HubSpotAdapterSpec extends Specification with DataTables with ValidatedMat
       "subscriptionType": "company.change",
       "eventId": 16
     }"""
-    HubSpotAdapter.payloadBodyToEvents(bodyStr) must beRight(List(expected))
+    adapterWithDefaultSchemas.payloadBodyToEvents(bodyStr) must beRight(List(expected))
   }
 
   def e2 =
@@ -71,7 +72,7 @@ class HubSpotAdapterSpec extends Specification with DataTables with ValidatedMat
           """{"something:"some"}""".some,
           """invalid json: expected : got 'some"}' (line 1, column 14)"""
         ) |> { (_, input, expected) =>
-      HubSpotAdapter.payloadBodyToEvents(input) must beLeft(expected)
+      adapterWithDefaultSchemas.payloadBodyToEvents(input) must beLeft(expected)
     }
 
   def e3 = {
@@ -99,7 +100,7 @@ class HubSpotAdapterSpec extends Specification with DataTables with ValidatedMat
         Shared.context
       )
     )
-    HubSpotAdapter.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
   }
 
   def e4 = {
@@ -115,10 +116,10 @@ class HubSpotAdapterSpec extends Specification with DataTables with ValidatedMat
     )
     val expected = FailureDetails.AdapterFailure.SchemaMapping(
       "contact".some,
-      HubSpotAdapter.EventSchemaMap,
+      adapterWithDefaultSchemas.EventSchemaMap,
       "no schema associated with the provided type parameter at index 0"
     )
-    HubSpotAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(
       NonEmptyList.one(expected)
     )
   }
@@ -126,7 +127,7 @@ class HubSpotAdapterSpec extends Specification with DataTables with ValidatedMat
   def e5 = {
     val payload =
       CollectorPayload(Shared.api, Nil, ContentType.some, None, Shared.cljSource, Shared.context)
-    HubSpotAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(
       NonEmptyList.one(
         FailureDetails.AdapterFailure
           .InputData("body", None, "empty body: not events to process")
@@ -137,7 +138,7 @@ class HubSpotAdapterSpec extends Specification with DataTables with ValidatedMat
   def e6 = {
     val payload =
       CollectorPayload(Shared.api, Nil, None, "stub".some, Shared.cljSource, Shared.context)
-    HubSpotAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(
       NonEmptyList.one(
         FailureDetails.AdapterFailure.InputData(
           "contentType",
@@ -158,7 +159,7 @@ class HubSpotAdapterSpec extends Specification with DataTables with ValidatedMat
       Shared.cljSource,
       Shared.context
     )
-    HubSpotAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(
       NonEmptyList.one(
         FailureDetails.AdapterFailure
           .InputData("contentType", ct, "expected application/json")

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/MailchimpAdapterSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/MailchimpAdapterSpec.scala
@@ -63,13 +63,14 @@ class MailchimpAdapterSpec extends Specification with DataTables with ValidatedM
     )
   }
 
+  val adapterWithDefaultSchemas = MailchimpAdapter(schemas = mailchimpSchemas)
   val ContentType = "application/x-www-form-urlencoded"
 
   def e1 = {
     val keys = "data[merges][LNAME]"
     val expected = NonEmptyList.of("data", "merges", "LNAME")
 
-    MailchimpAdapter.toKeys(keys) mustEqual expected
+    adapterWithDefaultSchemas.toKeys(keys) mustEqual expected
   }
 
   def e2 = {
@@ -77,7 +78,7 @@ class MailchimpAdapterSpec extends Specification with DataTables with ValidatedM
     val value = "Beemster"
     val expected = ("data", json"""{ "merges": { "LNAME": "Beemster" }}""")
 
-    MailchimpAdapter.toNestedJson(keys, value) mustEqual expected
+    adapterWithDefaultSchemas.toNestedJson(keys, value) mustEqual expected
   }
 
   def e3 = {
@@ -89,7 +90,7 @@ class MailchimpAdapterSpec extends Specification with DataTables with ValidatedM
       ("data", json"""{ "merges": { "LNAME": "Beemster" }}"""),
       ("data", json"""{ "merges": { "FNAME": "Joshua" }}""")
     )
-    MailchimpAdapter.toJsons(map) mustEqual expected
+    adapterWithDefaultSchemas.toJsons(map) mustEqual expected
   }
 
   def e4 = {
@@ -105,7 +106,7 @@ class MailchimpAdapterSpec extends Specification with DataTables with ValidatedM
         }
       }
     }"""
-    MailchimpAdapter.mergeJsons(List(a, b)) mustEqual expected
+    adapterWithDefaultSchemas.mergeJsons(List(a, b)) mustEqual expected
   }
 
   def e5 =
@@ -118,7 +119,7 @@ class MailchimpAdapterSpec extends Specification with DataTables with ValidatedM
         "type" -> "subscribe",
         "id" -> "some_id"
       ).toOpt |> { (_, params, expected) =>
-      val actual = MailchimpAdapter.reformatParameters(params)
+      val actual = adapterWithDefaultSchemas.reformatParameters(params)
       actual mustEqual expected
     }
 
@@ -148,7 +149,7 @@ class MailchimpAdapterSpec extends Specification with DataTables with ValidatedM
             |}
           |}""".stripMargin.replaceAll("[\n\r]", "")
 
-    val actual = MailchimpAdapter.toRawEvents(payload, SpecHelpers.client)
+    val actual = adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client)
     actual must beValid(
       NonEmptyList.one(
         RawEvent(
@@ -189,7 +190,7 @@ class MailchimpAdapterSpec extends Specification with DataTables with ValidatedM
             |}
           |}""".stripMargin.replaceAll("[\n\r]", "")
 
-    val actual = MailchimpAdapter.toRawEvents(payload, SpecHelpers.client)
+    val actual = adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client)
     actual must beValid(
       NonEmptyList.one(
         RawEvent(
@@ -222,7 +223,7 @@ class MailchimpAdapterSpec extends Specification with DataTables with ValidatedM
       )
       val expectedJson =
         "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0\",\"data\":{\"schema\":\"" + expected + "\",\"data\":{\"type\":\"" + schema + "\"}}}"
-      val actual = MailchimpAdapter.toRawEvents(payload, SpecHelpers.client)
+      val actual = adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client)
       actual must beValid(
         NonEmptyList.one(
           RawEvent(
@@ -240,12 +241,12 @@ class MailchimpAdapterSpec extends Specification with DataTables with ValidatedM
     "SPEC NAME" || "SCHEMA TYPE" | "EXPECTED OUTPUT" |
       "Invalid, bad type" !! "bad" ! FailureDetails.AdapterFailure.SchemaMapping(
         "bad".some,
-        MailchimpAdapter.EventSchemaMap,
+        adapterWithDefaultSchemas.EventSchemaMap,
         "no schema associated with the provided type parameter"
       ) |
       "Invalid, no type" !! "" ! FailureDetails.AdapterFailure.SchemaMapping(
         "".some,
-        MailchimpAdapter.EventSchemaMap,
+        adapterWithDefaultSchemas.EventSchemaMap,
         "cannot determine event type: type parameter empty"
       ) |> { (_, schema, expected) =>
       val body = "type=" + schema
@@ -257,7 +258,7 @@ class MailchimpAdapterSpec extends Specification with DataTables with ValidatedM
         Shared.cljSource,
         Shared.context
       )
-      val actual = MailchimpAdapter.toRawEvents(payload, SpecHelpers.client)
+      val actual = adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client)
       actual must beInvalid(NonEmptyList.one(expected))
     }
 
@@ -300,7 +301,7 @@ class MailchimpAdapterSpec extends Specification with DataTables with ValidatedM
             |}
           |}""".stripMargin.replaceAll("[\n\r]", "")
 
-    val actual = MailchimpAdapter.toRawEvents(payload, SpecHelpers.client)
+    val actual = adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client)
     actual must beValid(
       NonEmptyList.one(
         RawEvent(
@@ -323,7 +324,7 @@ class MailchimpAdapterSpec extends Specification with DataTables with ValidatedM
   def e11 = {
     val payload =
       CollectorPayload(Shared.api, Nil, ContentType.some, None, Shared.cljSource, Shared.context)
-    val actual = MailchimpAdapter.toRawEvents(payload, SpecHelpers.client)
+    val actual = adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client)
     actual must beInvalid(
       NonEmptyList.one(
         FailureDetails.AdapterFailure
@@ -335,7 +336,7 @@ class MailchimpAdapterSpec extends Specification with DataTables with ValidatedM
   def e12 = {
     val payload =
       CollectorPayload(Shared.api, Nil, None, "stub".some, Shared.cljSource, Shared.context)
-    val actual = MailchimpAdapter.toRawEvents(payload, SpecHelpers.client)
+    val actual = adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client)
     actual must beInvalid(
       NonEmptyList.one(
         FailureDetails.AdapterFailure.InputData(
@@ -356,7 +357,7 @@ class MailchimpAdapterSpec extends Specification with DataTables with ValidatedM
       Shared.cljSource,
       Shared.context
     )
-    val actual = MailchimpAdapter.toRawEvents(payload, SpecHelpers.client)
+    val actual = adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client)
     actual must beInvalid(
       NonEmptyList.one(
         FailureDetails.AdapterFailure.InputData(
@@ -378,7 +379,7 @@ class MailchimpAdapterSpec extends Specification with DataTables with ValidatedM
       Shared.cljSource,
       Shared.context
     )
-    val actual = MailchimpAdapter.toRawEvents(payload, SpecHelpers.client)
+    val actual = adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client)
     actual must beInvalid(
       NonEmptyList.one(
         FailureDetails.AdapterFailure.InputData(

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/MailgunAdapterSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/MailgunAdapterSpec.scala
@@ -58,6 +58,7 @@ class MailgunAdapterSpec extends Specification with DataTables with ValidatedMat
     )
   }
 
+  val adapterWithDefaultSchemas = MailgunAdapter(schemas = mailgunSchemas)
   val ContentType = "application/json"
 
   def e1 = {
@@ -144,7 +145,7 @@ class MailgunAdapterSpec extends Specification with DataTables with ValidatedMat
         Shared.context
       )
     )
-    MailgunAdapter.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
   }
 
   def e2 = {
@@ -211,7 +212,7 @@ class MailgunAdapterSpec extends Specification with DataTables with ValidatedMat
         Shared.context
       )
     )
-    MailgunAdapter.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
   }
 
   def e3 = {
@@ -243,7 +244,7 @@ class MailgunAdapterSpec extends Specification with DataTables with ValidatedMat
         Shared.context
       )
     )
-    MailgunAdapter.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
   }
 
   def e4 = {
@@ -275,7 +276,7 @@ class MailgunAdapterSpec extends Specification with DataTables with ValidatedMat
         Shared.context
       )
     )
-    MailgunAdapter.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
   }
 
   def e5 = {
@@ -360,13 +361,13 @@ class MailgunAdapterSpec extends Specification with DataTables with ValidatedMat
         Shared.context
       )
     )
-    MailgunAdapter.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
   }
 
   def e6 = {
     val payload =
       CollectorPayload(Shared.api, Nil, ContentType.some, None, Shared.cljSource, Shared.context)
-    MailgunAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(
       NonEmptyList.one(
         FailureDetails.AdapterFailure
           .InputData("body", None, "empty body: no events to process")
@@ -378,7 +379,7 @@ class MailgunAdapterSpec extends Specification with DataTables with ValidatedMat
     val body = "body"
     val payload =
       CollectorPayload(Shared.api, Nil, None, body.some, Shared.cljSource, Shared.context)
-    MailgunAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(
       NonEmptyList.one(
         FailureDetails.AdapterFailure.InputData(
           "contentType",
@@ -394,7 +395,7 @@ class MailgunAdapterSpec extends Specification with DataTables with ValidatedMat
     val ct = "multipart/form-data"
     val payload =
       CollectorPayload(Shared.api, Nil, ct.some, body.some, Shared.cljSource, Shared.context)
-    MailgunAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(
       NonEmptyList.one(
         FailureDetails.AdapterFailure.InputData(
           "contentType",
@@ -420,7 +421,7 @@ class MailgunAdapterSpec extends Specification with DataTables with ValidatedMat
         FailureDetails.AdapterFailure
           .InputData("body", None, "empty body: no events to process")
       )
-    MailgunAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(expected)
   }
 
   def e10 = {
@@ -440,7 +441,7 @@ class MailgunAdapterSpec extends Specification with DataTables with ValidatedMat
         "no `event` parameter provided: cannot determine event type"
       )
     )
-    MailgunAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(expected)
   }
 
   def e11 = {
@@ -457,11 +458,11 @@ class MailgunAdapterSpec extends Specification with DataTables with ValidatedMat
     val expected = NonEmptyList.one(
       FailureDetails.AdapterFailure.SchemaMapping(
         "released".some,
-        MailgunAdapter.EventSchemaMap,
+        adapterWithDefaultSchemas.EventSchemaMap,
         "no schema associated with the provided type parameter"
       )
     )
-    MailgunAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(expected)
   }
 
   def e12 = {
@@ -480,7 +481,7 @@ class MailgunAdapterSpec extends Specification with DataTables with ValidatedMat
         FailureDetails.AdapterFailure
           .InputData("timestamp", None, "missing 'timestamp'")
       )
-    MailgunAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(expected)
   }
 
   def e13 = {
@@ -497,7 +498,7 @@ class MailgunAdapterSpec extends Specification with DataTables with ValidatedMat
     val expected = NonEmptyList.one(
       FailureDetails.AdapterFailure.InputData("token", None, "missing 'token'")
     )
-    MailgunAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(expected)
   }
 
   def e14 = {
@@ -516,6 +517,6 @@ class MailgunAdapterSpec extends Specification with DataTables with ValidatedMat
         FailureDetails.AdapterFailure
           .InputData("signature", None, "missing 'signature'")
       )
-    MailgunAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(expected)
   }
 }

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/MandrillAdapterSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/MandrillAdapterSpec.scala
@@ -52,12 +52,13 @@ class MandrillAdapterSpec extends Specification with DataTables with ValidatedMa
     )
   }
 
+  val adapterWithDefaultSchemas = MandrillAdapter(schemas = mandrillSchemas)
   val ContentType = "application/x-www-form-urlencoded"
 
   def e1 = {
     val bodyStr = "mandrill_events=%5B%7B%22event%22%3A%20%22subscribe%22%7D%5D"
     val expected = List(json"""{"event": "subscribe"}""")
-    MandrillAdapter.payloadBodyToEvents(bodyStr) must beRight(expected)
+    adapterWithDefaultSchemas.payloadBodyToEvents(bodyStr) must beRight(expected)
   }
 
   def e2 =
@@ -80,7 +81,7 @@ class MandrillAdapterSpec extends Specification with DataTables with ValidatedMa
           "events_mandrill=something".some,
           "no `mandrill_events` parameter provided"
         ) |> { (_, str, expected) =>
-      MandrillAdapter.payloadBodyToEvents(str) must beLeft(expected)
+      adapterWithDefaultSchemas.payloadBodyToEvents(str) must beLeft(expected)
     }
 
   def e3 = {
@@ -90,7 +91,7 @@ class MandrillAdapterSpec extends Specification with DataTables with ValidatedMa
       """[{"event":"click}]""".some,
       "invalid json: exhausted input"
     )
-    MandrillAdapter.payloadBodyToEvents(bodyStr) must beLeft(expected)
+    adapterWithDefaultSchemas.payloadBodyToEvents(bodyStr) must beLeft(expected)
   }
 
   def e4 = { // Spec for nine seperate events being passed and returned.
@@ -214,7 +215,7 @@ class MandrillAdapterSpec extends Specification with DataTables with ValidatedMa
         Shared.context
       )
     )
-    MandrillAdapter.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
   }
 
   def e5 = { // Spec for nine seperate events where two have incorrect event names and one does not have event as a parameter
@@ -231,27 +232,27 @@ class MandrillAdapterSpec extends Specification with DataTables with ValidatedMa
     val expected = NonEmptyList.of(
       FailureDetails.AdapterFailure.SchemaMapping(
         "sending".some,
-        MandrillAdapter.EventSchemaMap,
+        adapterWithDefaultSchemas.EventSchemaMap,
         "no schema associated with the provided type parameter at index 0"
       ),
       FailureDetails.AdapterFailure.SchemaMapping(
         "deferred".some,
-        MandrillAdapter.EventSchemaMap,
+        adapterWithDefaultSchemas.EventSchemaMap,
         "no schema associated with the provided type parameter at index 1"
       ),
       FailureDetails.AdapterFailure.SchemaMapping(
         None,
-        MandrillAdapter.EventSchemaMap,
+        adapterWithDefaultSchemas.EventSchemaMap,
         "cannot determine event type: type parameter not provided at index 2"
       )
     )
-    MandrillAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(expected)
   }
 
   def e6 = {
     val payload =
       CollectorPayload(Shared.api, Nil, ContentType.some, None, Shared.cljSource, Shared.context)
-    MandrillAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(
       NonEmptyList.one(
         FailureDetails.AdapterFailure
           .InputData("body", None, "empty body: no events to process")
@@ -263,7 +264,7 @@ class MandrillAdapterSpec extends Specification with DataTables with ValidatedMa
     val body = "mandrill_events=%5B%7B%22event%22%3A%20%22subscribe%22%7D%5D"
     val payload =
       CollectorPayload(Shared.api, Nil, None, body.some, Shared.cljSource, Shared.context)
-    MandrillAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(
       NonEmptyList.one(
         FailureDetails.AdapterFailure.InputData(
           "contentType",
@@ -279,7 +280,7 @@ class MandrillAdapterSpec extends Specification with DataTables with ValidatedMa
     val ct = "application/x-www-form-urlencoded; charset=utf-8".some
     val payload =
       CollectorPayload(Shared.api, Nil, ct, body.some, Shared.cljSource, Shared.context)
-    MandrillAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(
       NonEmptyList.one(
         FailureDetails.AdapterFailure
           .InputData("contentType", ct, "expected application/x-www-form-urlencoded")

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/MarketoAdapterSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/MarketoAdapterSpec.scala
@@ -45,6 +45,7 @@ class MarketoAdapterSpec extends Specification with DataTables with ValidatedMat
     )
   }
 
+  val adapterWithDefaultSchemas = MarketoAdapter(schemas = marketoSchemas)
   val ContentType = "application/json"
 
   def e1 = {
@@ -72,13 +73,13 @@ class MarketoAdapterSpec extends Specification with DataTables with ValidatedMat
         Shared.context
       )
     )
-    MarketoAdapter.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
   }
 
   def e2 = {
     val payload =
       CollectorPayload(Shared.api, Nil, ContentType.some, None, Shared.cljSource, Shared.context)
-    MarketoAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(
       NonEmptyList.one(
         FailureDetails.AdapterFailure
           .InputData("body", None, "empty body: no events to process")

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/OlarkAdapterSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/OlarkAdapterSpec.scala
@@ -54,6 +54,7 @@ class OlarkAdapterSpec extends Specification with DataTables with ValidatedMatch
     )
   }
 
+  val adapterWithDefaultSchemas = OlarkAdapter(schemas = olarkSchemas)
   val ContentType = "application/x-www-form-urlencoded"
 
   def e1 = {
@@ -142,7 +143,7 @@ class OlarkAdapterSpec extends Specification with DataTables with ValidatedMatch
         Shared.context
       )
     )
-    OlarkAdapter.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
   }
 
   def e2 = {
@@ -206,13 +207,13 @@ class OlarkAdapterSpec extends Specification with DataTables with ValidatedMatch
         Shared.context
       )
     )
-    OlarkAdapter.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
   }
 
   def e3 = {
     val payload =
       CollectorPayload(Shared.api, Nil, ContentType.some, None, Shared.cljSource, Shared.context)
-    OlarkAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(
       NonEmptyList.one(
         FailureDetails.AdapterFailure
           .InputData("body", None, "empty body: no events to process")
@@ -225,7 +226,7 @@ class OlarkAdapterSpec extends Specification with DataTables with ValidatedMatch
       "data=%7B%22kind%22%3A%20%22Conversation%22%2C%20%22tags%22%3A%20%5B%22olark%22%2C%20%22customer%22%5D%2C%20%22items%22%3A%20%5B%7B%22body%22%3A%20%22Hi%20there.%20Need%20any%20help%3F%22%2C%20%22timestamp%22%3A%20%221307116657.1%22%2C%20%22kind%22%3A%20%22MessageToVisitor%22%2C%20%22nickname%22%3A%20%22John%22%2C%20%22operatorId%22%3A%20%221234%22%7D%2C%20%7B%22body%22%3A%20%22Yes%2C%20please%20help%20me%20with%20billing.%22%2C%20%22timestamp%22%3A%20%221307116661.25%22%2C%20%22kind%22%3A%20%22MessageToOperator%22%2C%20%22nickname%22%3A%20%22Bob%22%7D%5D%2C%20%22operators%22%3A%20%7B%221234%22%3A%20%7B%22username%22%3A%20%22jdoe%22%2C%20%22emailAddress%22%3A%20%22john%40example.com%22%2C%20%22kind%22%3A%20%22Operator%22%2C%20%22nickname%22%3A%20%22John%22%2C%20%22id%22%3A%20%221234%22%7D%7D%2C%20%22groups%22%3A%20%5B%7B%22kind%22%3A%20%22Group%22%2C%20%22name%22%3A%20%22My%20Sales%20Group%22%2C%20%22id%22%3A%20%220123456789abcdef%22%7D%5D%2C%20%22visitor%22%3A%20%7B%22ip%22%3A%20%22123.4.56.78%22%2C%20%22city%22%3A%20%22Palo%20Alto%22%2C%20%22kind%22%3A%20%22Visitor%22%2C%20%22conversationBeginPage%22%3A%20%22http%3A%2F%2Fwww.example.com%2Fpath%22%2C%20%22countryCode%22%3A%20%22US%22%2C%20%22country%22%3A%20%22United%20State%22%2C%20%22region%22%3A%20%22CA%22%2C%20%22chat_feedback%22%3A%20%7B%22overall_chat%22%3A%205%2C%20%22responsiveness%22%3A%205%2C%20%22friendliness%22%3A%205%2C%20%22knowledge%22%3A%205%2C%20%22comments%22%3A%20%22Very%20helpful%2C%20thanks%22%7D%2C%20%22operatingSystem%22%3A%20%22Windows%22%2C%20%22emailAddress%22%3A%20%22bob%40example.com%22%2C%20%22organization%22%3A%20%22Widgets%20Inc.%22%2C%20%22phoneNumber%22%3A%20%22%28555%29%20555-5555%22%2C%20%22fullName%22%3A%20%22Bob%20Doe%22%2C%20%22customFields%22%3A%20%7B%22favoriteColor%22%3A%20%22blue%22%2C%20%22myInternalCustomerId%22%3A%20%2212341234%22%7D%2C%20%22id%22%3A%20%229QRF9YWM5XW3ZSU7P9CGWRU89944341%22%2C%20%22browser%22%3A%20%22Chrome%2012.1%22%7D%2C%20%22id%22%3A%20%22EV695BI2930A6XMO32886MPT899443414%22%7D"
     val payload =
       CollectorPayload(Shared.api, Nil, None, body.some, Shared.cljSource, Shared.context)
-    OlarkAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(
       NonEmptyList.one(
         FailureDetails.AdapterFailure.InputData(
           "contentType",
@@ -242,7 +243,7 @@ class OlarkAdapterSpec extends Specification with DataTables with ValidatedMatch
     val ct = "application/json"
     val payload =
       CollectorPayload(Shared.api, Nil, ct.some, body.some, Shared.cljSource, Shared.context)
-    OlarkAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(
       NonEmptyList.one(
         FailureDetails.AdapterFailure.InputData(
           "contentType",
@@ -268,7 +269,7 @@ class OlarkAdapterSpec extends Specification with DataTables with ValidatedMatch
         FailureDetails.AdapterFailure
           .InputData("body", None, "empty body: no events to process")
       )
-    OlarkAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(expected)
   }
 
   def e7 = {
@@ -285,7 +286,7 @@ class OlarkAdapterSpec extends Specification with DataTables with ValidatedMatch
     val expected = NonEmptyList.one(
       FailureDetails.AdapterFailure.InputData("data", None, "missing 'data' field")
     )
-    OlarkAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(expected)
   }
 
   def e8 = {
@@ -299,7 +300,7 @@ class OlarkAdapterSpec extends Specification with DataTables with ValidatedMatch
       Shared.cljSource,
       Shared.context
     )
-    OlarkAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid.like {
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid.like {
       case nel =>
         nel.size must_== 1
         nel.head must haveClass[FailureDetails.AdapterFailure.NotJson]

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/PagerdutyAdapterSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/PagerdutyAdapterSpec.scala
@@ -54,6 +54,7 @@ class PagerdutyAdapterSpec extends Specification with DataTables with ValidatedM
     )
   }
 
+  val adapterWithDefaultSchemas = PagerdutyAdapter(schemas = pagerdutySchemas)
   val ContentType = "application/json"
 
   def e1 =
@@ -61,13 +62,13 @@ class PagerdutyAdapterSpec extends Specification with DataTables with ValidatedM
       "Valid, update one value" !! json"""{"type":"null"}""" ! json"""{"type":null}""" |
       "Valid, update multiple values" !! json"""{"type":"null","some":"null"}""" ! json"""{"type":null,"some":null}""" |
       "Valid, update nested values" !! json"""{"type": {"some":"null"}}""" ! json"""{"type":{"some":null}}""" |> { (_, input, expected) =>
-      PagerdutyAdapter.reformatParameters(input) mustEqual expected
+      adapterWithDefaultSchemas.reformatParameters(input) mustEqual expected
     }
 
   def e2 = {
     val json = json"""{"type":"incident.trigger"}"""
     val expected = json"""{"type":"trigger"}"""
-    PagerdutyAdapter.reformatParameters(json) mustEqual expected
+    adapterWithDefaultSchemas.reformatParameters(json) mustEqual expected
   }
 
   def e3 =
@@ -76,7 +77,7 @@ class PagerdutyAdapterSpec extends Specification with DataTables with ValidatedM
       "Valid, update multiple values" !! json"""{"created_on":"2014-11-12T18:53:47 00:00","last_status_change_on":"2014-11-12T18:53:47 00:00"}""" ! json"""{"created_on":"2014-11-12T18:53:47+00:00","last_status_change_on":"2014-11-12T18:53:47+00:00"}""" |
       "Valid, update nested values" !! json"""{"created_on":"2014-12-15T08:19:54Z","nested":{"created_on":"2014-11-12T18:53:47 00:00"}}""" ! json"""{"created_on":"2014-12-15T08:19:54Z","nested":{"created_on":"2014-11-12T18:53:47+00:00"}}""" |> {
       (_, input, expected) =>
-        PagerdutyAdapter.reformatParameters(input) mustEqual expected
+        adapterWithDefaultSchemas.reformatParameters(input) mustEqual expected
     }
 
   def e4 = {
@@ -90,7 +91,7 @@ class PagerdutyAdapterSpec extends Specification with DataTables with ValidatedM
         }
       }
     }""")
-    PagerdutyAdapter.payloadBodyToEvents(bodyStr) must beRight(expected)
+    adapterWithDefaultSchemas.payloadBodyToEvents(bodyStr) must beRight(expected)
   }
 
   def e5 =
@@ -107,7 +108,7 @@ class PagerdutyAdapterSpec extends Specification with DataTables with ValidatedM
           """{"somekey":"key"}""".some,
           "field `messages` is not an array"
         ) |> { (_, input, expected) =>
-      PagerdutyAdapter.payloadBodyToEvents(input) must beLeft(expected)
+      adapterWithDefaultSchemas.payloadBodyToEvents(input) must beLeft(expected)
     }
 
   def e6 = {
@@ -135,7 +136,7 @@ class PagerdutyAdapterSpec extends Specification with DataTables with ValidatedM
         Shared.context
       )
     )
-    PagerdutyAdapter.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
   }
 
   def e7 = {
@@ -151,10 +152,10 @@ class PagerdutyAdapterSpec extends Specification with DataTables with ValidatedM
     )
     val expected = FailureDetails.AdapterFailure.SchemaMapping(
       "trigger".some,
-      PagerdutyAdapter.EventSchemaMap,
+      adapterWithDefaultSchemas.EventSchemaMap,
       "no schema associated with the provided type parameter at index 0"
     )
-    PagerdutyAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(
       NonEmptyList.one(expected)
     )
   }
@@ -162,7 +163,7 @@ class PagerdutyAdapterSpec extends Specification with DataTables with ValidatedM
   def e8 = {
     val payload =
       CollectorPayload(Shared.api, Nil, ContentType.some, None, Shared.cljSource, Shared.context)
-    PagerdutyAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(
       NonEmptyList.one(
         FailureDetails.AdapterFailure
           .InputData("body", None, "empty body: no events to process")
@@ -173,7 +174,7 @@ class PagerdutyAdapterSpec extends Specification with DataTables with ValidatedM
   def e9 = {
     val payload =
       CollectorPayload(Shared.api, Nil, None, "stub".some, Shared.cljSource, Shared.context)
-    PagerdutyAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(
       NonEmptyList.one(
         FailureDetails.AdapterFailure.InputData(
           "contentType",
@@ -194,7 +195,7 @@ class PagerdutyAdapterSpec extends Specification with DataTables with ValidatedM
       Shared.cljSource,
       Shared.context
     )
-    PagerdutyAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(
       NonEmptyList.one(
         FailureDetails.AdapterFailure
           .InputData("contentType", ct, "expected application/json")

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/PingdomAdapterSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/PingdomAdapterSpec.scala
@@ -32,6 +32,9 @@ import utils.Clock._
 import SpecHelpers._
 
 class PingdomAdapterSpec extends Specification with DataTables with ValidatedMatchers {
+
+  val adapterWithDefaultSchemas = PingdomAdapter(schemas = pingdomSchemas)
+
   def is = s2"""
   reformatParameters should return either an updated JSON without the 'action' field or the same JSON $e1
   reformatMapParams must return a Failure Nel for any Python Unicode wrapped values                   $e2
@@ -58,7 +61,7 @@ class PingdomAdapterSpec extends Specification with DataTables with ValidatedMat
       "Remove action field" !! json"""{"action":"assign","agent":"smith"}""" ! json"""{"agent":"smith"}""" |
       "Nothing removed" !! json"""{"actions":"assign","agent":"smith"}""" ! json"""{"actions":"assign","agent":"smith"}""" |> {
       (_, json, expected) =>
-        PingdomAdapter.reformatParameters(json) mustEqual expected
+        adapterWithDefaultSchemas.reformatParameters(json) mustEqual expected
     }
 
   def e2 = {
@@ -69,7 +72,7 @@ class PingdomAdapterSpec extends Specification with DataTables with ValidatedMat
         "apps".some,
         """should not pass regex \(u'(.+)',\)"""
       )
-    PingdomAdapter.reformatMapParams(nvPairs) must beLeft(NonEmptyList.one(expected))
+    adapterWithDefaultSchemas.reformatMapParams(nvPairs) must beLeft(NonEmptyList.one(expected))
   }
 
   def e3 = {
@@ -91,7 +94,7 @@ class PingdomAdapterSpec extends Specification with DataTables with ValidatedMat
       Shared.cljSource,
       Shared.context
     )
-    PingdomAdapter.toRawEvents(payload, SpecHelpers.client) must beValid(
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beValid(
       NonEmptyList.one(expected)
     )
   }
@@ -104,7 +107,7 @@ class PingdomAdapterSpec extends Specification with DataTables with ValidatedMat
         None,
         "empty querystring: no events to process"
       )
-    PingdomAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(
       NonEmptyList.one(expected)
     )
   }
@@ -119,7 +122,7 @@ class PingdomAdapterSpec extends Specification with DataTables with ValidatedMat
         "p=apps".some,
         "no `message` parameter provided"
       )
-    PingdomAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(
       NonEmptyList.one(expected)
     )
   }

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/StatusGatorAdapterSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/StatusGatorAdapterSpec.scala
@@ -49,6 +49,7 @@ class StatusGatorAdapterSpec extends Specification with DataTables with Validate
     )
   }
 
+  val adapterWithDefaultSchemas = StatusGatorAdapter(schemas = statusGatorSchemas)
   val ContentType = "application/x-www-form-urlencoded"
 
   def e1 = {
@@ -88,13 +89,13 @@ class StatusGatorAdapterSpec extends Specification with DataTables with Validate
         Shared.context
       )
     )
-    StatusGatorAdapter.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
   }
 
   def e2 = {
     val payload =
       CollectorPayload(Shared.api, Nil, ContentType.some, None, Shared.cljSource, Shared.context)
-    StatusGatorAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(
       NonEmptyList.one(
         FailureDetails.AdapterFailure
           .InputData("body", None, "empty body: no events to process")
@@ -107,7 +108,7 @@ class StatusGatorAdapterSpec extends Specification with DataTables with Validate
       "service_name=CloudFlare&favicon_url=https%3A%2F%2Fdwxjd9cd6rwno.cloudfront.net%2Ffavicons%2Fcloudflare.ico&status_page_url=https%3A%2F%2Fwww.cloudflarestatus.com%2F&home_page_url=http%3A%2F%2Fwww.cloudflare.com&current_status=up&last_status=warn&occurred_at=2016-05-19T09%3A26%3A31%2B00%3A00"
     val payload =
       CollectorPayload(Shared.api, Nil, None, body.some, Shared.cljSource, Shared.context)
-    StatusGatorAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(
       NonEmptyList.one(
         FailureDetails.AdapterFailure.InputData(
           "contentType",
@@ -124,7 +125,7 @@ class StatusGatorAdapterSpec extends Specification with DataTables with Validate
     val ct = "application/json"
     val payload =
       CollectorPayload(Shared.api, Nil, ct.some, body.some, Shared.cljSource, Shared.context)
-    StatusGatorAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(
       NonEmptyList.one(
         FailureDetails.AdapterFailure.InputData(
           "contentType",
@@ -150,7 +151,7 @@ class StatusGatorAdapterSpec extends Specification with DataTables with Validate
         FailureDetails.AdapterFailure
           .InputData("body", None, "empty body: no events to process")
       )
-    StatusGatorAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(expected)
   }
 
   def e6 = {
@@ -171,6 +172,6 @@ class StatusGatorAdapterSpec extends Specification with DataTables with Validate
         "could not parse body: Illegal character in query at index 18: http://localhost/?{service_name=CloudFlare&favicon_url=https%3A%2F%2Fdwxjd9cd6rwno.cloudfront.net%2Ffavicons%2Fcloudflare.ico&status_page_url=https%3A%2F%2Fwww.cloudflarestatus.com%2F&home_page_url=http%3A%2F%2Fwww.cloudflare.com&current_status=up&last_status=warn&occurred_at=2016-05-19T09%3A26%3A31%2B00%3A00"
       )
     )
-    StatusGatorAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(expected)
   }
 }

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/UnbounceAdapterSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/UnbounceAdapterSpec.scala
@@ -55,6 +55,7 @@ class UnbounceAdapterSpec extends Specification with DataTables with ValidatedMa
     )
   }
 
+  val adapterWithDefaultSchemas = UnbounceAdapter(schemas = unbounceSchemas)
   val ContentType = "application/x-www-form-urlencoded"
 
   def e1 = {
@@ -117,14 +118,14 @@ class UnbounceAdapterSpec extends Specification with DataTables with ValidatedMa
         Shared.context
       )
     )
-    UnbounceAdapter.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
   }
 
   def e2 = {
     val params = SpecHelpers.toNameValuePairs("schema" -> "iglu:com.unbounce/test/jsonschema/1-0-0")
     val payload =
       CollectorPayload(Shared.api, params, ContentType.some, None, Shared.cljSource, Shared.context)
-    UnbounceAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(
       NonEmptyList.one(
         FailureDetails.AdapterFailure
           .InputData("body", None, "empty body: no events to process")
@@ -137,7 +138,7 @@ class UnbounceAdapterSpec extends Specification with DataTables with ValidatedMa
       "page_id=f7afd389-65a3-45fa-8bad-b7a42236044c&page_name=Test-Webhook&variant=a&page_url=http%3A%2F%2Funbouncepages.com%2Ftest-webhook-1&data.json=%7B%22email%22%3A%5B%22test%40snowplowanalytics.com%22%5D%2C%22ip_address%22%3A%5B%22200.121.220.179%22%5D%2C%22time_submitted%22%3A%5B%2204%3A17%20PM%20UTC%22%5D%7D"
     val payload =
       CollectorPayload(Shared.api, Nil, None, body.some, Shared.cljSource, Shared.context)
-    UnbounceAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(
       NonEmptyList.one(
         FailureDetails.AdapterFailure.InputData(
           "contentType",
@@ -154,7 +155,7 @@ class UnbounceAdapterSpec extends Specification with DataTables with ValidatedMa
     val ct = "application/json"
     val payload =
       CollectorPayload(Shared.api, Nil, ct.some, body.some, Shared.cljSource, Shared.context)
-    UnbounceAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(
       NonEmptyList.one(
         FailureDetails.AdapterFailure.InputData(
           "contentType",
@@ -181,7 +182,7 @@ class UnbounceAdapterSpec extends Specification with DataTables with ValidatedMa
         FailureDetails.AdapterFailure
           .InputData("body", None, "empty body: no events to process")
       )
-    UnbounceAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(expected)
   }
 
   def e6 = {
@@ -200,7 +201,7 @@ class UnbounceAdapterSpec extends Specification with DataTables with ValidatedMa
       FailureDetails.AdapterFailure
         .InputData("data.json", None, "missing 'data.json' field in body")
     )
-    UnbounceAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(expected)
   }
 
   def e7 = {
@@ -219,7 +220,7 @@ class UnbounceAdapterSpec extends Specification with DataTables with ValidatedMa
       FailureDetails.AdapterFailure
         .InputData("data.json", None, "empty 'data.json' field in body")
     )
-    UnbounceAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(expected)
   }
 
   def e8 = {
@@ -241,7 +242,7 @@ class UnbounceAdapterSpec extends Specification with DataTables with ValidatedMa
         """invalid json: expected " got '{"emai...' (line 1, column 2)"""
       )
     )
-    UnbounceAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(expected)
   }
 
   def e9 = {
@@ -261,7 +262,7 @@ class UnbounceAdapterSpec extends Specification with DataTables with ValidatedMa
         FailureDetails.AdapterFailure
           .InputData("page_id", None, "missing 'page_id' field in body")
       )
-    UnbounceAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(expected)
   }
 
   def e10 = {
@@ -280,7 +281,7 @@ class UnbounceAdapterSpec extends Specification with DataTables with ValidatedMa
       FailureDetails.AdapterFailure
         .InputData("page_name", None, "missing 'page_name' field in body")
     )
-    UnbounceAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(expected)
   }
 
   def e11 = {
@@ -300,7 +301,7 @@ class UnbounceAdapterSpec extends Specification with DataTables with ValidatedMa
         FailureDetails.AdapterFailure
           .InputData("variant", None, "missing 'variant' field in body")
       )
-    UnbounceAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(expected)
   }
 
   def e12 = {
@@ -319,6 +320,6 @@ class UnbounceAdapterSpec extends Specification with DataTables with ValidatedMa
       FailureDetails.AdapterFailure
         .InputData("page_url", None, "missing 'page_url' field in body")
     )
-    UnbounceAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(expected)
   }
 }

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/UrbanAirshipAdapterSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/UrbanAirshipAdapterSpec.scala
@@ -17,6 +17,7 @@ import cats.data.{NonEmptyList, Validated}
 import cats.syntax.either._
 import cats.syntax.option._
 import com.snowplowanalytics.snowplow.badrows._
+import com.snowplowanalytics.snowplow.enrich.common.SpecHelpers.urbanAirshipSchemas
 import io.circe.literal._
 import io.circe.parser._
 import org.joda.time.DateTime
@@ -40,6 +41,8 @@ class UrbanAirshipAdapterSpec extends Specification with ValidatedMatchers {
       None
     ) // NB the collector timestamp is set to None!
   }
+
+  val adapterWithDefaultSchemas = UrbanAirshipAdapter(schemas = urbanAirshipSchemas)
 
   "toRawEvents" should {
 
@@ -79,7 +82,7 @@ class UrbanAirshipAdapterSpec extends Specification with ValidatedMatchers {
       Shared.cljSource,
       Shared.context
     )
-    val actual = UrbanAirshipAdapter.toRawEvents(payload, SpecHelpers.client)
+    val actual = adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client)
 
     val expectedUnstructEventJson = json"""{
       "schema":"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0",
@@ -128,13 +131,13 @@ class UrbanAirshipAdapterSpec extends Specification with ValidatedMatchers {
         Shared.cljSource,
         Shared.context
       )
-      UrbanAirshipAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid
+      adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid
     }
 
     "reject unparsable json" in {
       val payload =
         CollectorPayload(Shared.api, Nil, None, """{ """.some, Shared.cljSource, Shared.context)
-      UrbanAirshipAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid
+      adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid
     }
 
     "reject badly formatted json" in {
@@ -147,7 +150,7 @@ class UrbanAirshipAdapterSpec extends Specification with ValidatedMatchers {
           Shared.cljSource,
           Shared.context
         )
-      UrbanAirshipAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid
+      adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid
     }
 
     "reject content types" in {
@@ -159,7 +162,7 @@ class UrbanAirshipAdapterSpec extends Specification with ValidatedMatchers {
         Shared.cljSource,
         Shared.context
       )
-      val res = UrbanAirshipAdapter.toRawEvents(payload, SpecHelpers.client)
+      val res = adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client)
 
       res must beInvalid(
         NonEmptyList.one(

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/VeroAdapterSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/VeroAdapterSpec.scala
@@ -53,6 +53,7 @@ class VeroAdapterSpec extends Specification with DataTables with ValidatedMatche
     )
   }
 
+  val adapterWithDefaultSchemas = VeroAdapter(schemas = veroSchemas)
   val ContentType = "application/json"
 
   def e1 = {
@@ -80,7 +81,7 @@ class VeroAdapterSpec extends Specification with DataTables with ValidatedMatche
         Shared.context
       )
     )
-    VeroAdapter.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
   }
 
   def e2 = {
@@ -108,7 +109,7 @@ class VeroAdapterSpec extends Specification with DataTables with ValidatedMatche
         Shared.context
       )
     )
-    VeroAdapter.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
   }
 
   def e3 = {
@@ -136,7 +137,7 @@ class VeroAdapterSpec extends Specification with DataTables with ValidatedMatche
         Shared.context
       )
     )
-    VeroAdapter.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
   }
 
   def e4 = {
@@ -164,7 +165,7 @@ class VeroAdapterSpec extends Specification with DataTables with ValidatedMatche
         Shared.context
       )
     )
-    VeroAdapter.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
   }
 
   def e5 = {
@@ -192,7 +193,7 @@ class VeroAdapterSpec extends Specification with DataTables with ValidatedMatche
         Shared.context
       )
     )
-    VeroAdapter.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
   }
 
   def e6 = {
@@ -220,7 +221,7 @@ class VeroAdapterSpec extends Specification with DataTables with ValidatedMatche
         Shared.context
       )
     )
-    VeroAdapter.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
   }
 
   def e7 = {
@@ -248,7 +249,7 @@ class VeroAdapterSpec extends Specification with DataTables with ValidatedMatche
         Shared.context
       )
     )
-    VeroAdapter.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
   }
 
   def e8 = {
@@ -276,7 +277,7 @@ class VeroAdapterSpec extends Specification with DataTables with ValidatedMatche
         Shared.context
       )
     )
-    VeroAdapter.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beValid(expected)
   }
 
   def e9 =
@@ -300,7 +301,7 @@ class VeroAdapterSpec extends Specification with DataTables with ValidatedMatche
       )
       val expectedJson =
         "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0\",\"data\":{\"schema\":\"" + expected + "\",\"data\":{}}}"
-      val actual = VeroAdapter.toRawEvents(payload, SpecHelpers.client)
+      val actual = adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client)
       actual must beValid(
         NonEmptyList.one(
           RawEvent(
@@ -317,7 +318,7 @@ class VeroAdapterSpec extends Specification with DataTables with ValidatedMatche
   def e10 = {
     val payload =
       CollectorPayload(Shared.api, Nil, ContentType.some, None, Shared.cljSource, Shared.context)
-    VeroAdapter.toRawEvents(payload, SpecHelpers.client) must beInvalid(
+    adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client) must beInvalid(
       NonEmptyList.one(
         FailureDetails.AdapterFailure
           .InputData("body", None, "empty body: no events to process")

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/pii/PiiPseudonymizerEnrichmentSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/pii/PiiPseudonymizerEnrichmentSpec.scala
@@ -45,6 +45,7 @@ import com.snowplowanalytics.snowplow.enrich.common.outputs.EnrichedEvent
 import com.snowplowanalytics.snowplow.enrich.common.utils.BlockerF
 import com.snowplowanalytics.snowplow.enrich.common.utils.Clock._
 import com.snowplowanalytics.snowplow.enrich.common.AcceptInvalid
+import com.snowplowanalytics.snowplow.enrich.common.SpecHelpers.adaptersSchemas
 
 class PiiPseudonymizerEnrichmentSpec extends Specification with ValidatedMatchers {
   def is = s2"""
@@ -168,7 +169,7 @@ class PiiPseudonymizerEnrichmentSpec extends Specification with ValidatedMatcher
     val client = IgluCirceClient.fromResolver[Id](Resolver(List(reg), None), cacheSize = 0)
     EtlPipeline
       .processEvents[Id](
-        new AdapterRegistry(),
+        new AdapterRegistry(adaptersSchemas = adaptersSchemas),
         enrichmentReg,
         client,
         Processor("spark", "0.0.0"),

--- a/modules/stream/common/src/main/scala/com.snowplowanalytics.snowplow.enrich.stream/model.scala
+++ b/modules/stream/common/src/main/scala/com.snowplowanalytics.snowplow.enrich.stream/model.scala
@@ -22,6 +22,7 @@ import java.text.SimpleDateFormat
 import java.net.URI
 
 import cats.syntax.either._
+import com.snowplowanalytics.snowplow.enrich.common.adapters.AdaptersSchemas
 
 object model {
 
@@ -168,10 +169,12 @@ object model {
     url: String
   )
   final case class SentryConfig(dsn: URI)
+
   final case class EnrichConfig(
     streams: StreamsConfig,
     remoteAdapters: Option[List[RemoteAdapterConfig]],
     monitoring: Option[MonitoringConfig],
-    sentry: Option[SentryConfig]
+    sentry: Option[SentryConfig],
+    adapters: AdaptersSchemas
   )
 }

--- a/modules/stream/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.stream/SpecHelpers.scala
+++ b/modules/stream/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.stream/SpecHelpers.scala
@@ -25,6 +25,7 @@ import com.snowplowanalytics.snowplow.enrich.common.adapters.registry.RemoteAdap
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.{EnrichmentRegistry, MiscEnrichments}
 import com.snowplowanalytics.snowplow.enrich.common.outputs.EnrichedEvent
 import com.snowplowanalytics.snowplow.enrich.common.utils.{BlockerF, JsonUtils, ShiftExecution}
+import com.snowplowanalytics.snowplow.enrich.common.SpecHelpers.adaptersSchemas
 import com.snowplowanalytics.snowplow.enrich.stream.model.{AWSCredentials, CloudAgnosticPlatformConfig, GCPCredentials, Kafka, Nsq, Stdin}
 import org.specs2.matcher.{Expectable, Matcher}
 import sources.TestSource
@@ -294,7 +295,8 @@ object SpecHelpers {
 
   // Init AdapterRegistry with one RemoteAdapter used for integration tests
   val adapterRegistry = new AdapterRegistry(
-    Map(("remoteVendor", "v42") -> new RemoteAdapter("http://localhost:9090/", None, None))
+    Map(("remoteVendor", "v42") -> RemoteAdapter("http://localhost:9090/", None, None)),
+    adaptersSchemas = adaptersSchemas
   )
 
   val kafkaConfig: CloudAgnosticPlatformConfig =

--- a/modules/stream/kinesis/src/main/scala/com.snowplowanalytics.snowplow.enrich.stream/KinesisEnrich.scala
+++ b/modules/stream/kinesis/src/main/scala/com.snowplowanalytics.snowplow.enrich.stream/KinesisEnrich.scala
@@ -75,7 +75,10 @@ object KinesisEnrich extends Enrich {
            )
       enrichmentRegistry <- EnrichmentRegistry.build[Id](enrichmentsConf, BlockerF.noop, ShiftExecution.noop).value
       tracker = enrichConfig.monitoring.map(c => SnowplowTracking.initializeTracker(c.snowplow))
-      adapterRegistry = new AdapterRegistry(prepareRemoteAdapters(enrichConfig.remoteAdapters))
+      adapterRegistry = new AdapterRegistry(
+                          prepareRemoteAdapters(enrichConfig.remoteAdapters),
+                          adaptersSchemas = enrichConfig.adapters
+                        )
       processor = Processor(generated.BuildInfo.name, generated.BuildInfo.version)
       source <- getSource(
                   enrichConfig.streams,


### PR DESCRIPTION
Issue #791 

This PR adds configuration for adapters to change the schema URIs used for tracking events and entities. The goal is to make it possible for the user to change the schema without having to redeploy the adapter, which would for example enable them to change validation rules of properties in the schemas.

The suggested approach is quite general and enables changing the schemas in any adapter (except the `CloudfrontAccessLogAdapter` which tracks multiple versions of the same event schema). One configures the schemas by adding a dictionary under `adapters.schemas` in the config file. This dictionary first maps schema vendors to sub-dictionaries with a mapping of schema names to new schema URIs. For example:

```hocon
{
  ...

  "adapters": {
    # This would make any adapter tracking an event using a schema such as `iglu:com.acme/event/1-0-0`
    # to use `iglu:com.custom/other_event/jsonschema/1-2-3` instead.
    "schemas": {
      "com.acme": {
        "event": "iglu:com.custom/other_event/jsonschema/1-2-3"
      }
    }
  }
}
```

To implement this, I changed the adapters to be `class` instead of `object` and accept a `config: AdapterConfig` that contains the `schemas` mapping. The adapters instead of calling `SchemaKey(vendor, name, format, version)` to create a schema URI, now call `config.schemaKey(vendor, name, format, version)`.