### PR TITLE
 Update Iglu Scala Client to 1.5.0 (close #794)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -63,7 +63,7 @@ object Dependencies {
     val gatlingJsonpath  = "0.6.14"
     val scalaUri         = "1.5.1"
     val badRows          = "2.1.2"
-    val igluClient       = "1.4.0"
+    val igluClient       = "1.5.0"
 
     val snowplowRawEvent = "0.1.0"
     val collectorPayload = "0.0.0"


### PR DESCRIPTION
Bumps iglu scala client to 1.5.0, which retries calls to iglu on retryable errors.

@benjben I know you're working on enrich release at the moment, so just assigned you since this is a literal 1 line change.

All tests pass locally, and asset builds w/assembly commands in the CI definition. :)