### PR TITLE
Update default schema versions for the Sendgrid adapter to 3-0-0 (close #797)

### DIFF
--- a/modules/common-fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/blackbox/adapters/SendgridAdapterSpec.scala
+++ b/modules/common-fs2/src/test/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/blackbox/adapters/SendgridAdapterSpec.scala
@@ -39,7 +39,7 @@ class SendgridAdapterSpec extends Specification with CatsIO {
         "event_format" -> "jsonschema",
         "event_version" -> "2-0-0",
         "event" -> "unstruct",
-        "unstruct_event" -> json"""{"schema":"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0","data":{"schema":"iglu:com.sendgrid/processed/jsonschema/2-0-0","data":{"timestamp":"2015-11-03T11:20:15.000Z","email":"example@test.com","marketing_campaign_name":"campaign name","sg_event_id":"sZROwMGMagFgnOEmSdvhig==","smtp-id":"<14c5d75ce93.dfd.64b469@ismtpd-555>","marketing_campaign_version":"B","marketing_campaign_id":12345,"marketing_campaign_split_id":13471,"category":"cat facts","sg_message_id":"14c5d75ce93.dfd.64b469.filter0001.16648.5515E0B88.0"}}}""".noSpaces
+        "unstruct_event" -> json"""{"schema":"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0","data":{"schema":"iglu:com.sendgrid/processed/jsonschema/3-0-0","data":{"timestamp":"2015-11-03T11:20:15.000Z","email":"example@test.com","marketing_campaign_name":"campaign name","sg_event_id":"sZROwMGMagFgnOEmSdvhig==","smtp-id":"<14c5d75ce93.dfd.64b469@ismtpd-555>","marketing_campaign_version":"B","marketing_campaign_id":12345,"marketing_campaign_split_id":13471,"category":"cat facts","sg_message_id":"14c5d75ce93.dfd.64b469.filter0001.16648.5515E0B88.0"}}}""".noSpaces
       )
       BlackBoxTesting.runTest(input, expected)
     }

--- a/modules/common/src/main/resources/reference.conf
+++ b/modules/common/src/main/resources/reference.conf
@@ -101,17 +101,17 @@
       "incident_notify_of_close": "iglu:com.pingdom/incident_notify_of_close/jsonschema/1-0-0"
     },
     "sendgrid": {
-      "processed": "iglu:com.sendgrid/processed/jsonschema/2-0-0",
-      "dropped": "iglu:com.sendgrid/dropped/jsonschema/2-0-0",
-      "delivered": "iglu:com.sendgrid/delivered/jsonschema/2-0-0",
-      "deferred": "iglu:com.sendgrid/deferred/jsonschema/2-0-0",
-      "bounce": "iglu:com.sendgrid/bounce/jsonschema/2-0-0",
-      "open": "iglu:com.sendgrid/open/jsonschema/2-0-0",
-      "click": "iglu:com.sendgrid/click/jsonschema/2-0-0",
-      "spamreport": "iglu:com.sendgrid/spamreport/jsonschema/2-0-0",
-      "unsubscribe": "iglu:com.sendgrid/unsubscribe/jsonschema/2-0-0",
-      "group_unsubscribe": "iglu:com.sendgrid/group_unsubscribe/jsonschema/2-0-0",
-      "group_resubscribe": "iglu:com.sendgrid/group_resubscribe/jsonschema/2-0-0"
+      "processed": "iglu:com.sendgrid/processed/jsonschema/3-0-0",
+      "dropped": "iglu:com.sendgrid/dropped/jsonschema/3-0-0",
+      "delivered": "iglu:com.sendgrid/delivered/jsonschema/3-0-0",
+      "deferred": "iglu:com.sendgrid/deferred/jsonschema/3-0-0",
+      "bounce": "iglu:com.sendgrid/bounce/jsonschema/3-0-0",
+      "open": "iglu:com.sendgrid/open/jsonschema/3-0-0",
+      "click": "iglu:com.sendgrid/click/jsonschema/3-0-0",
+      "spamreport": "iglu:com.sendgrid/spamreport/jsonschema/3-0-0",
+      "unsubscribe": "iglu:com.sendgrid/unsubscribe/jsonschema/3-0-0",
+      "group_unsubscribe": "iglu:com.sendgrid/group_unsubscribe/jsonschema/3-0-0",
+      "group_resubscribe": "iglu:com.sendgrid/group_resubscribe/jsonschema/3-0-0"
     },
     "statusgator": {
       "status_change": "iglu:com.statusgator/status_change/jsonschema/1-0-0"

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/SpecHelpers.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/SpecHelpers.scala
@@ -124,17 +124,17 @@ object SpecHelpers {
   )
 
   val sendgridSchemas = SendgridSchemas(
-    processed = "iglu:com.sendgrid/processed/jsonschema/2-0-0",
-    dropped = "iglu:com.sendgrid/dropped/jsonschema/2-0-0",
-    delivered = "iglu:com.sendgrid/delivered/jsonschema/2-0-0",
-    bounce = "iglu:com.sendgrid/bounce/jsonschema/2-0-0",
-    deferred = "iglu:com.sendgrid/deferred/jsonschema/2-0-0",
-    open = "iglu:com.sendgrid/open/jsonschema/2-0-0",
-    click = "iglu:com.sendgrid/click/jsonschema/2-0-0",
-    unsubscribe = "iglu:com.sendgrid/unsubscribe/jsonschema/2-0-0",
-    group_unsubscribe = "iglu:com.sendgrid/group_unsubscribe/jsonschema/2-0-0",
-    group_resubscribe = "iglu:com.sendgrid/group_resubscribe/jsonschema/2-0-0",
-    spamreport = "iglu:com.sendgrid/spamreport/jsonschema/2-0-0"
+    processed = "iglu:com.sendgrid/processed/jsonschema/3-0-0",
+    dropped = "iglu:com.sendgrid/dropped/jsonschema/3-0-0",
+    delivered = "iglu:com.sendgrid/delivered/jsonschema/3-0-0",
+    bounce = "iglu:com.sendgrid/bounce/jsonschema/3-0-0",
+    deferred = "iglu:com.sendgrid/deferred/jsonschema/3-0-0",
+    open = "iglu:com.sendgrid/open/jsonschema/3-0-0",
+    click = "iglu:com.sendgrid/click/jsonschema/3-0-0",
+    unsubscribe = "iglu:com.sendgrid/unsubscribe/jsonschema/3-0-0",
+    group_unsubscribe = "iglu:com.sendgrid/group_unsubscribe/jsonschema/3-0-0",
+    group_resubscribe = "iglu:com.sendgrid/group_resubscribe/jsonschema/3-0-0",
+    spamreport = "iglu:com.sendgrid/spamreport/jsonschema/3-0-0"
   )
 
   val googleAnalyticsSchemas = GoogleAnalyticsSchemas(

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/SendgridAdapterSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/SendgridAdapterSpec.scala
@@ -450,7 +450,7 @@ class SendgridAdapterSpec extends Specification with ValidatedMatchers {
         )
 
       val expectedJson =
-        """{"schema":"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0","data":{"schema":"iglu:com.sendgrid/processed/jsonschema/2-0-0","data":{"timestamp":"2015-11-03T11:20:15.000Z","email":"example@test.com","marketing_campaign_name":"campaign name","sg_event_id":"sZROwMGMagFgnOEmSdvhig==","smtp-id":"\u003c14c5d75ce93.dfd.64b469@ismtpd-555\u003e","marketing_campaign_version":"B","marketing_campaign_id":12345,"marketing_campaign_split_id":13471,"category":"cat facts","sg_message_id":"14c5d75ce93.dfd.64b469.filter0001.16648.5515E0B88.0"}}}"""
+        """{"schema":"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0","data":{"schema":"iglu:com.sendgrid/processed/jsonschema/3-0-0","data":{"timestamp":"2015-11-03T11:20:15.000Z","email":"example@test.com","marketing_campaign_name":"campaign name","sg_event_id":"sZROwMGMagFgnOEmSdvhig==","smtp-id":"\u003c14c5d75ce93.dfd.64b469@ismtpd-555\u003e","marketing_campaign_version":"B","marketing_campaign_id":12345,"marketing_campaign_split_id":13471,"category":"cat facts","sg_message_id":"14c5d75ce93.dfd.64b469.filter0001.16648.5515E0B88.0"}}}"""
 
       val actual = adapterWithDefaultSchemas.toRawEvents(payload, SpecHelpers.client)
       actual must beValid(
@@ -575,7 +575,7 @@ class SendgridAdapterSpec extends Specification with ValidatedMatchers {
       val expectedJsonProcessed =
         """{"schema":"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0","data":{"schema":"iglu:com.custom/processed/jsonschema/1-2-3","data":{"timestamp":"2015-11-03T11:20:15.000Z","email":"example@test.com","marketing_campaign_name":"campaign name","sg_event_id":"sZROwMGMagFgnOEmSdvhig==","smtp-id":"\u003c14c5d75ce93.dfd.64b469@ismtpd-555\u003e","marketing_campaign_version":"B","marketing_campaign_id":12345,"marketing_campaign_split_id":13471,"category":"cat facts","sg_message_id":"14c5d75ce93.dfd.64b469.filter0001.16648.5515E0B88.0"}}}"""
       val expectedJsonDeferred =
-        """{"schema":"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0","data":{"schema":"iglu:com.sendgrid/deferred/jsonschema/2-0-0","data":{"timestamp":"2015-11-03T11:20:15.000Z","email":"example@test.com","marketing_campaign_name":"campaign name","sg_event_id":"jWmZXTZbtHTV2-S47asrww==","smtp-id":"<14c5d75ce93.dfd.64b469@ismtpd-555>","marketing_campaign_version":"B","response":"400 try again later","marketing_campaign_id":12345,"marketing_campaign_split_id":13471,"category":"cat facts","attempt":"5","sg_message_id":"14c5d75ce93.dfd.64b469.filter0001.16648.5515E0B88.0"}}}"""
+        """{"schema":"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0","data":{"schema":"iglu:com.sendgrid/deferred/jsonschema/3-0-0","data":{"timestamp":"2015-11-03T11:20:15.000Z","email":"example@test.com","marketing_campaign_name":"campaign name","sg_event_id":"jWmZXTZbtHTV2-S47asrww==","smtp-id":"<14c5d75ce93.dfd.64b469@ismtpd-555>","marketing_campaign_version":"B","response":"400 try again later","marketing_campaign_id":12345,"marketing_campaign_split_id":13471,"category":"cat facts","attempt":"5","sg_message_id":"14c5d75ce93.dfd.64b469.filter0001.16648.5515E0B88.0"}}}"""
 
       val actual = adapter.toRawEvents(payload, SpecHelpers.client)
       actual must beValid(


### PR DESCRIPTION
Issue #797 

This PR updates the default versions of schemas for the Sendgrid adapter to version 3-0-0 instead of 2-0-0.

The new schema version contains changes in the validation of the properties (removed validation for email, IP address, increased length of an ID property). There are no structural changes in the schemas.