### PR TITLE
Add eventbride module

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,11 @@ jobs:
       env:
         AWS_ACCESS_KEY_ID: foo
         AWS_SECRET_ACCESS_KEY: bar
+    - name: Run integration tests for enrich-eventbridge
+      run: sbt "project eventbridgeDistroless" IntegrationTest/test
+      env:
+        AWS_ACCESS_KEY_ID: foo
+        AWS_SECRET_ACCESS_KEY: bar
     - name: Run integration tests for enrich-kafka
       run: |
         sbt "project kafka" "docker:publishLocal"

--- a/config/config.eventbridge.extended.hocon
+++ b/config/config.eventbridge.extended.hocon
@@ -1,0 +1,366 @@
+{
+  # Where to read collector payloads from
+  "input": {
+    "type": "Kinesis"
+
+    # Name of the application which the KCL daemon should assume
+    "appName": "snowplow-enrich-eventbridge"
+
+    # Name of the Kinesis stream to read from
+    "streamName": "input-stream-name"
+
+    # Optional. Region where the Kinesis stream is located
+    # This field is optional if it can be resolved with AWS region provider chain.
+    # It checks places like env variables, system properties, AWS profile file.
+    # https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/regions/providers/DefaultAwsRegionProviderChain.html
+    "region": "us-west-2"
+
+    # Optional, set the initial position to consume the Kinesis stream
+    # Must be TRIM_HORIZON, LATEST or AT_TIMESTAMP
+    # LATEST: most recent data.
+    # TRIM_HORIZON: oldest available data.
+    # AT_TIMESTAMP: start from the record at or after the specified timestamp
+    "initialPosition": {
+      "type": "LATEST"
+    }
+    # "initialPosition": {
+    #   "type": "AT_TIMESTAMP"
+    #   "timestamp": "2020-07-17T10:00:00Z" # Required for AT_TIMESTAMP
+    # }
+
+    # Optional, set the mode for retrieving records.
+    "retrievalMode": {
+      "type": "Polling"
+
+      # Maximum size of a batch returned by a call to getRecords.
+      # Records are checkpointed after a batch has been fully processed,
+      # thus the smaller maxRecords, the more often records can be checkpointed
+      # into DynamoDb, but possibly reducing the throughput.
+      "maxRecords": 10000
+    }
+    # "retrievalMode": {
+    #   "type": "FanOut"
+    # }
+
+    # Optional. Size of the internal buffer used when reading messages from Kinesis,
+    # each buffer holding up to maxRecords from above
+    "bufferSize": 3
+
+    # Optional. Settings for backoff policy for checkpointing.
+    # Records are checkpointed after all the records of the same chunk have been enriched
+    "checkpointBackoff": {
+      "minBackoff": 100 milliseconds
+      "maxBackoff": 10 seconds
+      "maxRetries": 10
+    }
+
+    # Optional, endpoint url configuration to override aws kinesis endpoints
+    # Can be used to specify local endpoint when using localstack
+    # "customEndpoint": "http://localhost:4566"
+
+    # Optional, endpoint url configuration to override aws dyanomdb endpoint for Kinesis checkpoints lease table
+    # Can be used to specify local endpoint when using localstack
+    # "dynamodbCustomEndpoint": "http://localhost:4566"
+
+    # Optional, endpoint url configuration to override aws cloudwatch endpoint for metrics
+    # Can be used to specify local endpoint when using localstack
+    # "cloudwatchCustomEndpoint": "http://localhost:4566"
+  }
+
+  "output": {
+    # Enriched events output
+    "good": {
+      "type": "Eventbridge"
+
+      # Name of the event bus to write events to
+      "eventBusName": "output-good-eventbus-name"
+
+      # The source used to filter events in the event bus
+      "eventBusSource": "output-good-eventbus-source"
+
+      # Optional. Add a "collector" parameter from contexts_org_ietf_http_header_1 Host Value. Defaults to false.
+      "collector": true
+      
+      # Optional. Add a "payload" parameter with the original base64 encoded TSV. Defaults to false.
+      "payload": true
+
+      # Optional. Region where the Eventbridge stream is located
+      # This field is optional if it can be resolved with AWS region provider chain.
+      # It checks places like env variables, system properties, AWS profile file.
+      # https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/regions/providers/DefaultAwsRegionProviderChain.html
+      "region": "us-west-2"
+
+      # Optional. Policy to retry if writing to eventbridge fails with unexepected errors
+      "backoffPolicy": {
+        "minBackoff": 100 milliseconds
+        "maxBackoff": 10 seconds
+        "maxRetries": 10
+      }
+
+      # Optional. Policy to retry if writing to eventbridge exceeds the provisioned throughput.
+      "throttledBackoffPolicy": {
+        "minBackoff": 100 milliseconds
+        "maxBackoff": 1 second
+      }
+
+      # Limits the number of events in a single PutEvents request.
+      # Several requests are made in parallel
+      # Maximum allowed: 10 entries (see https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-pipes-batching-concurrency.html)
+      "recordLimit": 10
+
+      # Limits the number of bytes in a single PutEvents request,
+      # Several requests are made in parallel
+      # Maximum allowed: 256 KB (see https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-putevent-size.html)
+      "byteLimit": 250000
+
+      # Optional. Use a custom EventBridge endpoint.
+      # Can be used for instance to work locally with localstack
+      # "customEndpoint": "https://localhost:4566"
+    }
+
+    # Optional. Pii events output
+    "pii": {
+      "type": "Eventbridge"
+
+      # Name of the event bus to write events to
+      "eventBusName": "output-pii-eventbus-name"
+
+      # The source used to filter events in the event bus
+      "eventBusSource": "output-pii-eventbus-source"
+
+      # Optional. Add a "collector" parameter from contexts_org_ietf_http_header_1 Host Value. Defaults to false.
+      "collector": true
+
+      # Optional. Add a "payload" parameter with the original base64 encoded TSV. Defaults to false.
+      "payload": true
+
+      # Optional. Region where the Eventbridge stream is located
+      # This field is optional if it can be resolved with AWS region provider chain.
+      # It checks places like env variables, system properties, AWS profile file.
+      # https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/regions/providers/DefaultAwsRegionProviderChain.html
+      "region": "us-west-2"
+
+      # Optional. Policy to retry if writing to eventbridge fails with unexepcted errors
+      "backoffPolicy": {
+        "minBackoff": 100 milliseconds
+        "maxBackoff": 10 seconds
+        "maxRetries": 10
+      }
+
+      # Optional. Policy to retry if writing to eventbridge exceeds the provisioned throughput.
+      "throttledBackoffPolicy": {
+        "minBackoff": 100 milliseconds
+        "maxBackoff": 1 second
+      }
+
+      # Limits the number of events in a single PutEvents request.
+      # Several requests are made in parallel
+      # Maximum allowed: 10 entries (see https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-pipes-batching-concurrency.html)
+      "recordLimit": 10
+
+      # Limits the number of bytes in a single PutEvents request,
+      # Several requests are made in parallel
+      # Maximum allowed: 256 KB (see https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-putevent-size.html)
+      "byteLimit": 250000
+
+      # Optional. Use a custom Eventbridge endpoint.
+      # Can be used for instance to work locally with localstack
+      # "customEndpoint": "https://localhost:4566"
+    }
+
+    # Bad rows output
+    "bad": {
+      "type": "Eventbridge"
+
+      # Name of the event bus to write events to
+      "eventBusName": "output-bad-eventbus-name"
+
+      # The source used to filter events in the event bus
+      "eventBusSource": "output-bad-eventbus-source"
+
+      # Optional. Region where the Eventbridge stream is located
+      # This field is optional if it can be resolved with AWS region provider chain.
+      # It checks places like env variables, system properties, AWS profile file.
+      # https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/regions/providers/DefaultAwsRegionProviderChain.html
+      "region": "us-west-2"
+
+      # Optional. Policy to retry if writing to eventbridge fails with unexepcted errors
+      "backoffPolicy": {
+        "minBackoff": 100 milliseconds
+        "maxBackoff": 10 seconds
+        "maxRetries": 10
+      }
+
+      # Optional. Policy to retry if writing to eventbridge exceeds the provisioned throughput.
+      "throttledBackoffPolicy": {
+        "minBackoff": 100 milliseconds
+        "maxBackoff": 1 second
+      }
+
+      # Limits the number of events in a single PutEvents request.
+      # Several requests are made in parallel
+      # Maximum allowed: 10 entries (see https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-pipes-batching-concurrency.html)
+      "recordLimit": 10
+
+      # Limits the number of bytes in a single PutEvents request,
+      # Several requests are made in parallel
+      # Maximum allowed: 256 KB (see https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-putevent-size.html)
+      "byteLimit": 250000
+
+      # Optional. Use a custom Eventbridge endpoint.
+      # Can be used for instance to work locally with localstack
+      # "customEndpoint": "https://localhost:4566"
+    }
+  }
+
+  # Optional. Concurrency of the app
+  "concurrency" : {
+    # Number of events that can get enriched at the same time within a chunk
+    "enrich": 256
+    # Number of chunks that can get sunk at the same time
+    # WARNING: if greater than 1, records can get checkpointed before they are sunk
+    "sink": 1
+  }
+
+  # Optional, period after which enrich assets should be checked for updates
+  # no assets will be updated if the key is absent
+  "assetsUpdatePeriod": "7 days"
+
+  # Optional, configuration of remote adapters
+  "remoteAdapters": {
+    # how long enrich waits to establish a connection to remote adapters
+    "connectionTimeout": "10 seconds",
+    # how long enrich waits to get a response from remote adapters
+    "readTimeout": "45 seconds",
+    # how many connections enrich opens at maximum for remote adapters
+    # increasing this could help with throughput in case of adapters with high latency
+    "maxConnections": 10,
+    # a list of remote adapter configs
+    "configs": [
+      {
+        "vendor": "com.example",
+        "version": "v1",
+        "url": "https://remote-adapter.com"
+      }
+    ]
+  }
+
+  "monitoring": {
+
+    # Optional, for tracking runtime exceptions
+    # "sentry": {
+    #   "dsn": "http://sentry.acme.com"
+    # }
+
+    # Optional, configure how metrics are reported
+    "metrics": {
+
+      # Optional. Send metrics to a StatsD server on localhost
+      "statsd": {
+        "hostname": "localhost"
+        "port": 8125
+
+        # Required, how frequently to report metrics
+        "period": "10 seconds"
+
+        # Any key-value pairs to be tagged on every StatsD metric
+        "tags": {
+          "app": enrich
+        }
+
+        # Optional, override the default metric prefix
+        # "prefix": "snowplow.enrich."
+      }
+
+      # Optional. Log to stdout using Slf4j
+      "stdout": {
+        "period": "10 seconds"
+
+        # Optional, override the default metric prefix
+        # "prefix": "snowplow.enrich."
+      }
+
+      # Optional. Send KCL and KPL metrics to Cloudwatch
+      "cloudwatch": true
+    }
+  }
+
+  # Optional, configure telemetry
+  # All the fields are optional
+  "telemetry": {
+
+    # Set to true to disable telemetry
+    "disable": false
+
+    # Interval for the heartbeat event
+    "interval": 15 minutes
+
+    # HTTP method used to send the heartbeat event
+    "method": POST
+
+    # URI of the collector receiving the heartbeat event
+    "collectorUri": collector-g.snowplowanalytics.com
+
+    # Port of the collector receiving the heartbeat event
+    "collectorPort": 443
+
+    # Whether to use https or not
+    "secure": true
+
+    # Identifier intended to tie events together across modules,
+    # infrastructure and apps when used consistently
+    "userProvidedId": my_pipeline
+
+    # ID automatically generated upon running a modules deployment script
+    # Intended to identify each independent module, and the infrastructure it controls
+    "autoGeneratedId": hfy67e5ydhtrd
+
+    # Unique identifier for the VM instance
+    # Unique for each instance of the app running within a module
+    "instanceId": 665bhft5u6udjf
+
+    # Name of the terraform module that deployed the app
+    "moduleName": enrich-eventbridge-ce
+
+    # Version of the terraform module that deployed the app
+    "moduleVersion": 1.0.0
+  }
+
+  # Optional. To activate/deactive enrich features that are still in beta
+  # or that are here for transition.
+  # This section might change in future versions
+  "featureFlags" : {
+
+    # Enrich 3.0.0 introduces the validation of the enriched events against atomic schema
+    # before emitting.
+    # If set to false, a bad row will be emitted instead of the enriched event
+    # if validation fails.
+    # If set to true, invalid enriched events will be emitted, as before.
+    # WARNING: this feature flag will be removed in a future version
+    # and it will become impossible to emit invalid enriched events.
+    # More details: https://github.com/snowplow/enrich/issues/517#issuecomment-1033910690
+    "acceptInvalid": false
+
+    # In early versions of enrich-kinesis and enrich-pubsub (pre-3.1.4), the Javascript enrichment
+    # incorrectly ran before the currency, weather, and IP Lookups enrichments. Set this flag to true
+    # to keep the erroneous behaviour of those previous versions. This flag will be removed in a
+    # future version.
+    # More details: https://github.com/snowplow/enrich/issues/619
+    "legacyEnrichmentOrder": false
+
+    # Try to base64 decode event if initial Thrift serialization fail
+    "tryBase64Decoding": true
+  }
+
+  # Optional. Configuration for experimental/preview features
+  "experimental": {
+    # Whether to export metadata using a webhook URL.
+    # Follows iglu-webhook protocol.
+    "metadata": {
+      "endpoint": "https://my_pipeline.my_domain.com/iglu"
+      "interval": 5 minutes
+      "organizationId": "c5f3a09f-75f8-4309-bec5-fea560f78455"
+      "pipelineId": "75a13583-5c99-40e3-81fc-541084dfc784"
+    }
+  }
+}

--- a/config/config.eventbridge.minimal.hocon
+++ b/config/config.eventbridge.minimal.hocon
@@ -1,0 +1,32 @@
+{
+  "input": {
+    "type": "Kinesis"
+    "appName": "snowplow-enrich-eventbridge"
+    "streamName": "input-stream-name"
+    "region": "us-west-2"
+    "initialPosition": {
+      "type": "LATEST"
+    }
+  }
+
+  "output": {
+    "good": {
+      "type": "Eventbridge"
+      "eventBusName": "output-good-eventbus-name"
+      "eventBusSource": "output-good-eventbus-source"
+      "region": "us-west-2"
+      "recordLimit": 10
+      "byteLimit": 250000
+    }
+
+    "bad": {
+      "type": "Eventbridge"
+      "eventBusName": "output-bad-eventbus-name"
+      "eventBusSource": "output-bad-eventbus-source"
+      "region": "us-west-2"
+      "recordLimit": 10
+      "byteLimit": 250000
+    }
+  }
+}
+

--- a/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/config/ConfigFile.scala
+++ b/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/config/ConfigFile.scala
@@ -72,6 +72,11 @@ object ConfigFile {
       // Remove pii output if topic empty
       case c @ ConfigFile(_, Outputs(good, Some(Output.Kafka(topicName, _, _, _, _)), bad), _, _, _, _, _, _, _, _) if topicName.isEmpty =>
         c.copy(output = Outputs(good, None, bad)).asRight
+
+      // Remove pii output if eventBusName is empty
+      case c @ ConfigFile(_, Outputs(good, Some(output: Output.Eventbridge), bad), _, _, _, _, _, _, _, _) if output.eventBusName.isEmpty =>
+        c.copy(output = Outputs(good, None, bad)).asRight
+
       case other => other.asRight
     }
   implicit val configFileEncoder: Encoder[ConfigFile] =

--- a/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/config/io.scala
+++ b/modules/common-fs2/src/main/scala/com/snowplowanalytics/snowplow/enrich/common/fs2/config/io.scala
@@ -308,6 +308,18 @@ object io {
       byteLimit: Int,
       customEndpoint: Option[URI]
     ) extends Output
+    case class Eventbridge(
+      eventBusName: String,
+      eventBusSource: String,
+      region: Option[String],
+      backoffPolicy: BackoffPolicy,
+      throttledBackoffPolicy: BackoffPolicy,
+      recordLimit: Int,
+      byteLimit: Int,
+      customEndpoint: Option[URI],
+      collector: Option[Boolean],
+      payload: Option[Boolean]
+    ) extends Output
     case class RabbitMQ(
       cluster: RabbitMQConfig,
       exchange: String,
@@ -329,6 +341,8 @@ object io {
             }
           case k: Kinesis if k.streamName.isEmpty && k.region.nonEmpty =>
             "streamName needs to be set".asLeft
+          case k: Eventbridge if k.eventBusName.isEmpty && k.region.nonEmpty =>
+            "eventBusName needs to be set".asLeft
           case other => other.asRight
         }
         .emap {

--- a/modules/eventbridge/src/it/resources/enrich/enrich-localstack.hocon
+++ b/modules/eventbridge/src/it/resources/enrich/enrich-localstack.hocon
@@ -1,0 +1,50 @@
+{
+  "input": {
+    "type": "Kinesis"
+    "appName": ${APP_NAME}
+    "streamName": ${KINESIS_STREAM_INPUT}
+    "region": ${REGION}
+    "customEndpoint": ${LOCALSTACK_ENDPOINT}
+    "dynamodbCustomEndpoint": ${LOCALSTACK_ENDPOINT}
+    "cloudwatchCustomEndpoint": ${LOCALSTACK_ENDPOINT}
+  }
+
+  "output": {
+    "good": {
+      "type": "Eventbridge"
+      "eventBusName": ${EVENTBRIDGE_STREAM_OUTPUT_GOOD_EVENTBUS_NAME}
+      "eventBusSource": ${EVENTBRIDGE_STREAM_OUTPUT_GOOD_EVENTBUS_SOURCE}
+      "collector": true
+      "payload": true
+      "recordLimit": 5
+      "byteLimit": 10000
+      "region": ${REGION}
+      "customEndpoint": ${LOCALSTACK_ENDPOINT}
+    }
+
+    "bad": {
+      "type": "Eventbridge"
+      "eventBusName": ${EVENTBRIDGE_STREAM_OUTPUT_BAD_EVENTBUS_NAME}
+      "eventBusSource": ${EVENTBRIDGE_STREAM_OUTPUT_BAD_EVENTBUS_SOURCE}
+      "collector": false
+      "payload": false
+      "recordLimit": 5
+      "byteLimit": 10000
+      "region": ${REGION}
+      "customEndpoint": ${LOCALSTACK_ENDPOINT}
+    }
+  }
+
+  "monitoring": {
+    "metrics": {
+      "stdout": {
+        "period": "10 seconds"
+      }
+      "cloudwatch": true
+    }
+  }
+
+  "telemetry": {
+    "disable": true
+  }
+}

--- a/modules/eventbridge/src/it/resources/enrich/iglu_resolver.json
+++ b/modules/eventbridge/src/it/resources/enrich/iglu_resolver.json
@@ -1,0 +1,19 @@
+{
+  "schema": "iglu:com.snowplowanalytics.iglu/resolver-config/jsonschema/1-0-3",
+  "data": {
+    "cacheSize": 500,
+    "cacheTtl": 600,
+    "repositories": [
+      {
+        "name": "Iglu Central",
+        "priority": 0,
+        "vendorPrefixes": [ "com.snowplowanalytics" ],
+        "connection": {
+          "http": {
+            "uri": "http://iglucentral.com"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/modules/eventbridge/src/it/resources/mysql/init.sql
+++ b/modules/eventbridge/src/it/resources/mysql/init.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS coordinates(
+  latitude FLOAT NOT NULL PRIMARY KEY,
+  longitude FLOAT NOT NULL
+);
+
+INSERT INTO coordinates(latitude, longitude) VALUES (51.507322, -0.127647);

--- a/modules/eventbridge/src/it/resources/nginx/.htpasswd
+++ b/modules/eventbridge/src/it/resources/nginx/.htpasswd
@@ -1,0 +1,1 @@
+xxxxx:$apr1$z1vqk0cy$l5ewxz0a8NpL3KYyRmWHE.

--- a/modules/eventbridge/src/it/resources/nginx/default.conf
+++ b/modules/eventbridge/src/it/resources/nginx/default.conf
@@ -1,0 +1,18 @@
+server {
+  listen       80;
+  listen  [::]:80;
+  server_name  localhost;
+
+  auth_basic "Authentication required";
+  auth_basic_user_file /etc/.htpasswd;
+
+  location / {
+    root   /usr/share/nginx/html;
+    index  index.html index.htm;
+  }
+
+  error_page   500 502 503 504  /50x.html;
+  location = /50x.html {
+    root   /usr/share/nginx/html;
+  }
+}

--- a/modules/eventbridge/src/it/resources/nginx/www/index.html
+++ b/modules/eventbridge/src/it/resources/nginx/www/index.html
@@ -1,0 +1,1 @@
+{"message": "hello world"}

--- a/modules/eventbridge/src/it/scala/com/snowplowanalytics/snowplow/enrich/eventbridge/Containers.scala
+++ b/modules/eventbridge/src/it/scala/com/snowplowanalytics/snowplow/enrich/eventbridge/Containers.scala
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2022-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.enrich.eventbridge
+
+import java.util.UUID
+
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext
+
+import org.slf4j.LoggerFactory
+
+import retry.syntax.all._
+import retry.RetryPolicies
+
+import cats.syntax.flatMap._
+
+import cats.effect.{IO, Resource, Timer}
+
+import org.testcontainers.containers.{BindMode, GenericContainer => JGenericContainer, Network}
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.containers.output.Slf4jLogConsumer
+
+import com.dimafeng.testcontainers.GenericContainer
+
+import com.snowplowanalytics.snowplow.enrich.eventbridge.enrichments.{Enrichment, Enrichments}
+import com.snowplowanalytics.snowplow.enrich.eventbridge.generated.BuildInfo
+
+object Containers {
+
+  private val executionContext: ExecutionContext = ExecutionContext.global
+  implicit val ioTimer: Timer[IO] = IO.timer(executionContext)
+
+  private val network = Network.newNetwork()
+
+  private val localstackPort = 4566
+  private val localstackAlias = "localstack"
+
+  val localstack = {
+    val container = GenericContainer(
+      dockerImage = "localstack/localstack:2.1.0",
+      fileSystemBind = Seq(
+        GenericContainer.FileSystemBind(
+          "modules/eventbridge/src/it/resources/localstack",
+          "/docker-entrypoint-initaws.d",
+          BindMode.READ_ONLY
+        )
+      ),
+      env = Map(
+        "AWS_ACCESS_KEY_ID" -> "foo",
+        "AWS_SECRET_ACCESS_KEY" -> "bar"
+      ),
+      waitStrategy = Wait.forLogMessage(".*Ready.*", 1),
+      exposedPorts = Seq(localstackPort)
+    )
+    container.underlyingUnsafeContainer.withNetwork(network)
+    container.underlyingUnsafeContainer.withNetworkAliases(localstackAlias)
+    container.container
+  }
+
+  def localstackMappedPort = localstack.getMappedPort(localstackPort)
+
+  def enrich(
+    configPath: String,
+    testName: String,
+    needsLocalstack: Boolean,
+    enrichments: List[Enrichment],
+    uuid: String = UUID.randomUUID().toString,
+    waitLogMessage: String = "Running Enrich"
+  ): Resource[IO, JGenericContainer[_]] = {
+    val streams = IntegrationTestConfig.getStreams(uuid)
+
+    val container = GenericContainer(
+      dockerImage = s"snowplow/snowplow-enrich-eventbridge:${BuildInfo.version}-distroless",
+      env = Map(
+        "AWS_REGION" -> IntegrationTestConfig.region,
+        "AWS_ACCESS_KEY_ID" -> "foo",
+        "AWS_SECRET_ACCESS_KEY" -> "bar",
+        "JDK_JAVA_OPTIONS" -> "-Dorg.slf4j.simpleLogger.defaultLogLevel=info",
+        // appName must be unique in enrich config so that Kinesis consumers in tests don't interfere
+        "APP_NAME" -> s"${testName}_$uuid",
+        "REGION" -> IntegrationTestConfig.region,
+        "KINESIS_STREAM_INPUT" -> streams.kinesisInput,
+        "EVENTBRIDGE_STREAM_OUTPUT_GOOD_EVENTBUS_NAME" -> streams.eventbridgeGood.eventBusName,
+        "EVENTBRIDGE_STREAM_OUTPUT_GOOD_EVENTBUS_SOURCE" -> streams.eventbridgeGood.eventBusSource,
+        "EVENTBRIDGE_STREAM_OUTPUT_BAD_EVENTBUS_NAME" -> streams.eventbridgeBad.eventBusName,
+        "EVENTBRIDGE_STREAM_OUTPUT_BAD_EVENTBUS_SOURCE" -> streams.eventbridgeBad.eventBusSource,
+        "KINESIS_STREAM_OUTPUT_GOOD" -> streams.kinesisOutputGood,
+        "KINESIS_STREAM_OUTPUT_BAD" -> streams.kinesisOutputBad,
+        "LOCALSTACK_ENDPOINT" -> s"http://$localstackAlias:$localstackPort"
+      ),
+      fileSystemBind = Seq(
+        GenericContainer.FileSystemBind(
+          configPath,
+          "/snowplow/config/enrich.hocon",
+          BindMode.READ_ONLY
+        ),
+        GenericContainer.FileSystemBind(
+          "modules/eventbridge/src/it/resources/enrich/iglu_resolver.json",
+          "/snowplow/config/iglu_resolver.json",
+          BindMode.READ_ONLY
+        )
+      ),
+      command = Seq(
+        "--config",
+        "/snowplow/config/enrich.hocon",
+        "--iglu-config",
+        "/snowplow/config/iglu_resolver.json",
+        "--enrichments",
+        Enrichments.mkJson(enrichments.map(_.config))
+      ),
+      waitStrategy = Wait.forLogMessage(s".*$waitLogMessage.*", 1)
+    )
+    container.container.withNetwork(network)
+    Resource.make(
+      IO(startLocalstack(needsLocalstack, IntegrationTestConfig.region, streams)) >>
+        IO(startContainerWithLogs(container.container, testName))
+    )(e => IO(e.stop()))
+  }
+
+  def mysqlServer: Resource[IO, JGenericContainer[_]] =
+    Resource.make {
+      val container = GenericContainer(
+        dockerImage = "mysql:8.0.31",
+        fileSystemBind = Seq(
+          GenericContainer.FileSystemBind(
+            "modules/eventbridge/src/it/resources/mysql",
+            "/docker-entrypoint-initdb.d",
+            BindMode.READ_ONLY
+          )
+        ),
+        env = Map(
+          "MYSQL_RANDOM_ROOT_PASSWORD" -> "yes",
+          "MYSQL_DATABASE" -> "snowplow",
+          "MYSQL_USER" -> "enricher",
+          "MYSQL_PASSWORD" -> "supersecret1"
+        ),
+        waitStrategy = Wait.forLogMessage(".*ready for connections.*", 1)
+      )
+      container.underlyingUnsafeContainer.withNetwork(network)
+      container.underlyingUnsafeContainer.withNetworkAliases("mysql")
+      IO(container.start()) >> IO.pure(container.container)
+    } { c =>
+      IO(c.stop())
+    }
+
+  def httpServer: Resource[IO, JGenericContainer[_]] =
+    Resource.make {
+      val container = GenericContainer(
+        dockerImage = "nginx:1.23.2",
+        fileSystemBind = Seq(
+          GenericContainer.FileSystemBind(
+            "modules/eventbridge/src/it/resources/nginx/default.conf",
+            "/etc/nginx/conf.d/default.conf",
+            BindMode.READ_ONLY
+          ),
+          GenericContainer.FileSystemBind(
+            "modules/eventbridge/src/it/resources/nginx/.htpasswd",
+            "/etc/.htpasswd",
+            BindMode.READ_ONLY
+          ),
+          GenericContainer.FileSystemBind(
+            "modules/eventbridge/src/it/resources/nginx/www",
+            "/usr/share/nginx/html",
+            BindMode.READ_ONLY
+          )
+        ),
+        waitStrategy = Wait.forLogMessage(".*start worker processes.*", 1)
+      )
+      container.underlyingUnsafeContainer.withNetwork(network)
+      container.underlyingUnsafeContainer.withNetworkAliases("api")
+      IO(container.start()) >> IO.pure(container.container)
+    } { c =>
+      IO(c.stop())
+    }
+
+  private def startContainerWithLogs(
+    container: JGenericContainer[_],
+    loggerName: String
+  ): JGenericContainer[_] = {
+    val logger = LoggerFactory.getLogger(loggerName)
+    val logs = new Slf4jLogConsumer(logger)
+    container.start()
+    container.followOutput(logs)
+    container
+  }
+
+  def waitUntilStopped(container: JGenericContainer[_]): IO[Boolean] = {
+    val retryPolicy = RetryPolicies.limitRetriesByCumulativeDelay(
+      5.minutes,
+      RetryPolicies.capDelay[IO](
+        2.second,
+        RetryPolicies.fullJitter[IO](1.second)
+      )
+    )
+
+    IO(container.isRunning()).retryingOnFailures(
+      _ == false,
+      retryPolicy,
+      (_, _) => IO.unit
+    )
+  }
+
+  // synchronized so that start() isn't called by several threads at the same time.
+  // start() is blocking.
+  // Calling start() on an already started container has no effect.
+  private def startLocalstack(
+    needsLocalstack: Boolean,
+    region: String,
+    streams: IntegrationTestConfig.Streams
+  ): Unit =
+    synchronized {
+      if (needsLocalstack) {
+        localstack.start()
+        createStreams(
+          localstack.getMappedPort(localstackPort),
+          region,
+          streams
+        )
+      } else ()
+    }
+
+  private def createStreams(
+    localstackPort: Int,
+    region: String,
+    streams: IntegrationTestConfig.Streams
+  ): Unit = {
+    import software.amazon.awssdk.services._
+
+    val endpoint = java.net.URI.create(s"http://127.0.0.4:$localstackPort")
+    val eventBridgeClient = eventbridge.EventBridgeClient
+            .builder()
+            .region(software.amazon.awssdk.regions.Region.of(region))
+            .endpointOverride(endpoint)
+            .build()
+
+    val kinesisClient = kinesis.KinesisClient
+            .builder()
+            .region(software.amazon.awssdk.regions.Region.of(region))
+            .endpointOverride(java.net.URI.create(s"http://127.0.0.4:$localstackMappedPort"))
+            .build()
+
+    // kinesis streams
+    val kinesisStreamNames = List(streams.kinesisInput, streams.kinesisOutputGood, streams.kinesisOutputBad)
+    kinesisStreamNames.foreach { stream =>
+      kinesisClient.createStream(kinesis.model.CreateStreamRequest.builder.streamName(stream).shardCount(1).build)
+    }
+
+    def getKinesisARN(streamName: String): String = {
+      kinesisClient.describeStream(kinesis.model.DescribeStreamRequest.builder.streamName(streamName).build()).streamDescription().streamARN()
+    }
+
+    val eventbridgeStreams = List(
+      streams.eventbridgeGood -> getKinesisARN(streams.kinesisOutputGood),
+      streams.eventbridgeBad -> getKinesisARN(streams.kinesisOutputBad))
+
+    eventbridgeStreams.foreach { case (eventbridgeStream, kinesisStreamARN) =>
+      // event-bus
+      eventBridgeClient.createEventBus(eventbridge.model.CreateEventBusRequest.builder()
+        .name(eventbridgeStream.eventBusName)
+        .build()
+      )
+
+      // rule
+      val ruleName = s"rule-${eventbridgeStream.eventBusName}"
+      val eventPattern = s"""{ "source": ["${eventbridgeStream.eventBusSource}"] }"""//.replace("\"", "\\\"")
+      eventBridgeClient.putRule(eventbridge.model.PutRuleRequest.builder()
+        .eventBusName(eventbridgeStream.eventBusName)
+        .name(ruleName)
+        .eventPattern(eventPattern)
+        .build()
+      )
+
+      // target
+      val targetId = s"${eventbridgeStream.eventBusName}-target".take(64)
+      val targetCreationResult = eventBridgeClient.putTargets(eventbridge.model.PutTargetsRequest.builder()
+        .eventBusName(eventbridgeStream.eventBusName)
+        .rule(ruleName)
+        .targets(eventbridge.model.Target.builder().id(targetId).arn(kinesisStreamARN).build())
+        .build()
+      )
+      assert(targetCreationResult.failedEntryCount == 0, s"Target creation failed: $targetCreationResult")
+    }
+  }
+}

--- a/modules/eventbridge/src/it/scala/com/snowplowanalytics/snowplow/enrich/eventbridge/EnrichEventbridgeSpec.scala
+++ b/modules/eventbridge/src/it/scala/com/snowplowanalytics/snowplow/enrich/eventbridge/EnrichEventbridgeSpec.scala
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2022-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.enrich.eventbridge
+
+import java.util.UUID
+
+import scala.concurrent.duration._
+
+import cats.effect.IO
+
+import cats.effect.testing.specs2.CatsIO
+
+import org.specs2.mutable.Specification
+import org.specs2.specification.AfterAll
+
+import com.snowplowanalytics.snowplow.enrich.eventbridge.enrichments._
+import com.snowplowanalytics.snowplow.enrich.common.fs2.test.CollectorPayloadGen
+
+class EnrichEventbridgeSpec extends Specification with AfterAll with CatsIO {
+
+  implicit val concurrentIO = IO.ioConcurrentEffect
+
+  override protected val Timeout = 10.minutes
+
+  def afterAll: Unit = Containers.localstack.stop()
+
+  "enrich-eventbridge" should {
+    "be able to parse the minimal config" in {
+      Containers.enrich(
+        configPath = "config/config.eventbridge.minimal.hocon",
+        testName = "minimal",
+        needsLocalstack = false,
+        enrichments = Nil
+      ).use { e =>
+        IO(e.getLogs must contain("Running Enrich"))
+      }
+    }
+
+   "emit the correct number of enriched events and bad rows" in {
+     import utils._
+
+     val testName = "count"
+     val nbGood = 100l
+     val nbBad = 100l
+     val uuid = UUID.randomUUID().toString
+
+     val resources = for {
+       _ <- Containers.enrich(
+         configPath = "modules/eventbridge/src/it/resources/enrich/enrich-localstack.hocon",
+         testName = "count",
+         needsLocalstack = true,
+         enrichments = Nil,
+         uuid = uuid
+       )
+       enrichPipe <- mkEnrichPipe(Containers.localstackMappedPort, uuid)
+     } yield enrichPipe
+
+     val input = CollectorPayloadGen.generate(nbGood, nbBad)
+
+     resources.use { enrich =>
+       for {
+         // for some weird reason, the records don't get consumed until the second time calling enrich pipeline
+         _ <- enrich(CollectorPayloadGen.generate(0)).compile.toList
+         output <- enrich(input).compile.toList
+         (good, bad) = parseOutput(output, testName)
+       } yield {
+         println(s"${good.size} and ${bad.size}")
+         good.size.toLong must beEqualTo(nbGood)
+         bad.size.toLong must beEqualTo(nbBad)
+       }
+     }
+   }
+
+   "run the enrichments and attach their context" in {
+     import utils._
+
+     val testName = "enrichments"
+     val nbGood = 100l
+     val uuid = UUID.randomUUID().toString
+
+     val enrichments = List(
+       ApiRequest,
+       Javascript,
+       SqlQuery,
+       Yauaa
+     )
+
+     val enrichmentsContexts = enrichments.map(_.outputSchema)
+
+     val resources = for {
+       _ <- Containers.mysqlServer
+       _ <- Containers.httpServer
+       _ <- Containers.enrich(
+         configPath = "modules/eventbridge/src/it/resources/enrich/enrich-localstack.hocon",
+         testName = "enrichments",
+         needsLocalstack = true,
+         enrichments = enrichments,
+         uuid = uuid
+       )
+       enrichPipe <- mkEnrichPipe(Containers.localstackMappedPort, uuid)
+     } yield enrichPipe
+
+     val input = CollectorPayloadGen.generate(nbGood)
+
+     resources.use { enrich =>
+       for {
+         // for some weird reason, the records don't get consumed until the second time calling enrich pipeline
+         _ <- enrich(CollectorPayloadGen.generate(0)).compile.toList
+         output <- enrich(input).compile.toList
+         (good, bad) = parseOutput(output, testName)
+       } yield {
+         good.size.toLong must beEqualTo(nbGood)
+         good.map { enriched =>
+           enriched.derived_contexts.data.map(_.schema) must containTheSameElementsAs(enrichmentsContexts)
+         }
+         bad.size.toLong must beEqualTo(0l)
+       }
+     }
+   }
+
+   "shutdown when it receives a SIGTERM" in {
+     Containers.enrich(
+       configPath = "modules/eventbridge/src/it/resources/enrich/enrich-localstack.hocon",
+       testName = "stop",
+       needsLocalstack = true,
+       enrichments = Nil,
+       waitLogMessage = "enrich.metrics"
+     ).use { enrich =>
+       for {
+         _ <- IO(println("stop - Sending signal"))
+         _ <- IO(enrich.getDockerClient().killContainerCmd(enrich.getContainerId()).withSignal("TERM").exec())
+         _ <- Containers.waitUntilStopped(enrich)
+       } yield {
+         enrich.isRunning() must beFalse
+         enrich.getLogs() must contain("Enrich stopped")
+       }
+     }
+   }
+  }
+}

--- a/modules/eventbridge/src/it/scala/com/snowplowanalytics/snowplow/enrich/eventbridge/IntegrationTestConfig.scala
+++ b/modules/eventbridge/src/it/scala/com/snowplowanalytics/snowplow/enrich/eventbridge/IntegrationTestConfig.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2022-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.enrich.eventbridge
+
+import java.net.URI
+import java.util.UUID
+
+import scala.concurrent.duration._
+
+import com.snowplowanalytics.snowplow.enrich.common.fs2.config.io.{BackoffPolicy, Input, MetricsReporters, Monitoring, Output}
+
+object IntegrationTestConfig {
+
+  val region = "eu-central-1"
+  val endpoint = "localhost"
+
+  def eventBridgeOutputStreamConfig(localstackPort: Int, stream: EventbridgeStream) = Output.Eventbridge(
+    eventBusName = stream.eventBusName,
+    eventBusSource = stream.eventBusSource,
+    region = Some(region),
+    backoffPolicy = BackoffPolicy(10.millis, 10.seconds, Some(10)),
+    throttledBackoffPolicy = BackoffPolicy(10.millis, 10.seconds, Some(10)),
+    recordLimit = 10,
+    byteLimit = 100000,
+    customEndpoint = Some(URI.create(getEndpoint(localstackPort))),
+    collector = None,
+    payload = None
+  )
+
+  def kinesisOutputStreamConfig(localstackPort: Int, streamName: String) = Output.Kinesis(
+    streamName,
+    Some(region),
+    None,
+    BackoffPolicy(10.millis, 10.seconds, Some(10)),
+    BackoffPolicy(100.millis, 1.second, None),
+    500,
+    5242880,
+    Some(URI.create(getEndpoint(localstackPort)))
+  )
+
+  def kinesisInputStreamConfig(localstackPort: Int, streamName: String) = Input.Kinesis(
+    UUID.randomUUID().toString,
+    streamName,
+    Some(region),
+    Input.Kinesis.InitPosition.TrimHorizon,
+    Input.Kinesis.Retrieval.Polling(1000),
+    1000,
+    BackoffPolicy(10.millis, 10.seconds, Some(10)),
+    Some(URI.create(getEndpoint(localstackPort))),
+    Some(URI.create(getEndpoint(localstackPort))),
+    Some(URI.create(getEndpoint(localstackPort)))
+  )
+
+  val monitoring = Monitoring(
+    None,
+    MetricsReporters(None, None, false)
+  )
+
+  private def getEndpoint(localstackPort: Int): String =
+    s"http://$endpoint:$localstackPort"
+
+  case class EventbridgeStream(
+    eventBusName: String,
+    eventBusSource: String
+  )
+  case class Streams(
+    kinesisInput: String, // events are received on this kinesis stream
+    eventbridgeGood: EventbridgeStream, // enriched events get routed to this event bridge stream
+    eventbridgeBad: EventbridgeStream, // bad events get routed to this event bridge stream
+    kinesisOutputGood: String, // eventbridge routes good events to this kinesis stream
+    kinesisOutputBad: String // eventbridge routes bad events to this kinesis stream
+  )
+
+  def getStreams(uuid: String): Streams = Streams(
+    kinesisInput = s"kinesis-input-$uuid",
+    eventbridgeGood = EventbridgeStream(
+      eventBusName = s"eventbridge-output-good-name-$uuid",
+      eventBusSource = s"eventbridge-output-good-source-$uuid"),
+    eventbridgeBad = EventbridgeStream(
+      eventBusName = s"eventbridge-output-bad-name-$uuid",
+      eventBusSource = s"eventbridge-output-bad-source-$uuid"),
+    kinesisOutputGood = s"kinesis-output-good-$uuid",
+    kinesisOutputBad = s"kinesis-output-bad-$uuid"
+      )
+}

--- a/modules/eventbridge/src/it/scala/com/snowplowanalytics/snowplow/enrich/eventbridge/enrichments/ApiRequest.scala
+++ b/modules/eventbridge/src/it/scala/com/snowplowanalytics/snowplow/enrich/eventbridge/enrichments/ApiRequest.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.enrich.eventbridge.enrichments
+
+import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer}
+
+case object ApiRequest extends Enrichment {
+  val config = """
+    {
+      "schema": "iglu:com.snowplowanalytics.snowplow.enrichments/api_request_enrichment_config/jsonschema/1-0-0",
+      "data": {
+        "vendor": "com.snowplowanalytics.snowplow.enrichments",
+        "name": "api_request_enrichment_config",
+        "enabled": true,
+        "parameters": {
+          "inputs": [],
+          "api": {
+            "http": {
+              "method": "GET",
+              "uri": "http://api",
+              "timeout": 2000,
+              "authentication": {
+                "httpBasic": {
+                  "username": "xxxxx",
+                  "password": "yyyyy"
+                }
+              }
+            }
+          },
+          "outputs": [
+            {
+              "schema": "iglu:com.snowplowanalytics.snowplow/diagnostic_error/jsonschema/1-0-0",
+              "json": {
+                "jsonPath": "$"
+              }
+            }
+          ],
+          "cache": {
+            "size": 3000,
+            "ttl": 60
+          }
+        }
+      }
+    }
+  """
+
+  val outputSchema = SchemaKey(
+    "com.snowplowanalytics.snowplow",
+    "diagnostic_error",
+    "jsonschema",
+    SchemaVer.Full(1, 0, 0)
+  )
+}

--- a/modules/eventbridge/src/it/scala/com/snowplowanalytics/snowplow/enrich/eventbridge/enrichments/Enrichment.scala
+++ b/modules/eventbridge/src/it/scala/com/snowplowanalytics/snowplow/enrich/eventbridge/enrichments/Enrichment.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2023-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.enrich.eventbridge.enrichments
+
+import com.snowplowanalytics.iglu.core.SchemaKey
+
+trait Enrichment {
+  def config: String
+  def outputSchema: SchemaKey
+}

--- a/modules/eventbridge/src/it/scala/com/snowplowanalytics/snowplow/enrich/eventbridge/enrichments/Enrichments.scala
+++ b/modules/eventbridge/src/it/scala/com/snowplowanalytics/snowplow/enrich/eventbridge/enrichments/Enrichments.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.enrich.eventbridge.enrichments
+
+import java.util.Base64
+
+object Enrichments {
+  private val base64Encoder = Base64.getEncoder()
+
+  def mkJson(enrichments: List[String]): String = {
+    val raw = s"""
+      {
+        "schema": "iglu:com.snowplowanalytics.snowplow/enrichments/jsonschema/1-0-0",
+        "data": [
+          ${enrichments.mkString(",")}
+        ]
+      }
+    """
+    new String(base64Encoder.encode(raw.getBytes()))
+  }
+}

--- a/modules/eventbridge/src/it/scala/com/snowplowanalytics/snowplow/enrich/eventbridge/enrichments/Javascript.scala
+++ b/modules/eventbridge/src/it/scala/com/snowplowanalytics/snowplow/enrich/eventbridge/enrichments/Javascript.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2023-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.enrich.eventbridge.enrichments
+
+import java.util.Base64
+
+import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer}
+
+case object Javascript extends Enrichment {
+  private val base64Encoder = Base64.getEncoder()
+
+  val script = """
+    const cipher = javax.crypto.Cipher.getInstance("AES/CBC/PKCS5Padding")
+    const generator = javax.crypto.KeyGenerator.getInstance("AES")
+    generator.init(new java.security.SecureRandom())
+    const key = generator.generateKey()
+    cipher.init(javax.crypto.Cipher.ENCRYPT_MODE, key, new javax.crypto.spec.IvParameterSpec(key.getEncoded()))
+
+    function process(event){
+      var appId = event.getApp_id()
+      if (appId == null) {
+        return []
+      } else {
+        return [ {
+          schema: "iglu:com.snowplowanalytics.snowplow/identify/jsonschema/1-0-0",
+          data: { id:  new java.lang.String(cipher.doFinal(appId.getBytes())) }
+        } ]
+      }
+    }
+  """
+  val config = s"""
+    {
+      "schema": "iglu:com.snowplowanalytics.snowplow/javascript_script_config/jsonschema/1-0-0",
+      "data": {
+        "vendor": "com.snowplowanalytics.snowplow",
+        "name": "javascript_script_config",
+        "enabled": true,
+        "parameters": {
+          "script": "${new String(base64Encoder.encode(script.getBytes()))}"
+        }
+      }
+    }
+  """
+  val outputSchema = SchemaKey(
+    "com.snowplowanalytics.snowplow",
+    "identify",
+    "jsonschema",
+    SchemaVer.Full(1, 0, 0)
+  )
+}

--- a/modules/eventbridge/src/it/scala/com/snowplowanalytics/snowplow/enrich/eventbridge/enrichments/SqlQuery.scala
+++ b/modules/eventbridge/src/it/scala/com/snowplowanalytics/snowplow/enrich/eventbridge/enrichments/SqlQuery.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.enrich.eventbridge.enrichments
+
+import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer}
+
+case object SqlQuery extends Enrichment {
+  val config = """
+    {
+      "schema": "iglu:com.snowplowanalytics.snowplow.enrichments/sql_query_enrichment_config/jsonschema/1-0-0",
+      "data": {
+        "vendor": "com.snowplowanalytics.snowplow.enrichments",
+        "name": "sql_query_enrichment_config",
+        "enabled": true,
+        "parameters": {
+          "inputs": [],
+          "database": {
+            "mysql": {
+              "host": "mysql",
+              "port": 3306,
+              "sslMode": false,
+              "database": "snowplow",
+              "username": "enricher",
+              "password": "supersecret1"
+            }
+          },
+          "query": {
+            "sql": "SELECT * FROM coordinates LIMIT 1"
+          },
+          "output": {
+            "expectedRows": "AT_MOST_ONE",
+            "json": {
+              "schema": "iglu:com.snowplowanalytics.snowplow/geolocation_context/jsonschema/1-1-0",
+              "describes": "ALL_ROWS",
+              "propertyNames": "AS_IS"
+            }
+          },
+          "cache": {
+            "size": 3000,
+            "ttl": 60
+          }
+        }
+      }
+    }
+  """
+
+  val outputSchema = SchemaKey(
+    "com.snowplowanalytics.snowplow",
+    "geolocation_context",
+    "jsonschema",
+    SchemaVer.Full(1, 1, 0)
+  )
+}

--- a/modules/eventbridge/src/it/scala/com/snowplowanalytics/snowplow/enrich/eventbridge/enrichments/Yauaa.scala
+++ b/modules/eventbridge/src/it/scala/com/snowplowanalytics/snowplow/enrich/eventbridge/enrichments/Yauaa.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.enrich.eventbridge.enrichments
+
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.YauaaEnrichment
+
+case object Yauaa extends Enrichment {
+  val config = """
+    {
+      "schema": "iglu:com.snowplowanalytics.snowplow.enrichments/yauaa_enrichment_config/jsonschema/1-0-0",
+      "data": {
+        "enabled": true,
+        "vendor": "com.snowplowanalytics.snowplow.enrichments",
+        "name": "yauaa_enrichment_config"
+      }
+    }
+  """
+
+  val outputSchema = YauaaEnrichment.outputSchema
+}

--- a/modules/eventbridge/src/it/scala/com/snowplowanalytics/snowplow/enrich/eventbridge/utils.scala
+++ b/modules/eventbridge/src/it/scala/com/snowplowanalytics/snowplow/enrich/eventbridge/utils.scala
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2022-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.enrich.eventbridge
+
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext
+
+import cats.effect.{Blocker, ContextShift, IO, Resource, Timer}
+
+import fs2.{Pipe, Stream}
+
+import com.snowplowanalytics.snowplow.analytics.scalasdk.Event
+
+import com.snowplowanalytics.snowplow.badrows.BadRow
+
+import com.snowplowanalytics.snowplow.enrich.common.fs2.config.io.Input
+import com.snowplowanalytics.snowplow.enrich.common.fs2.test.Utils
+
+object utils {
+
+  private val executionContext: ExecutionContext = ExecutionContext.global
+  implicit val ioContextShift: ContextShift[IO] = IO.contextShift(executionContext)
+  implicit val ioTimer: Timer[IO] = IO.timer(executionContext)
+
+  sealed trait OutputRow
+  object OutputRow {
+    final case class Good(event: Event) extends OutputRow
+    final case class Bad(badRow: BadRow) extends OutputRow
+  }
+
+  def mkEnrichPipe(
+    localstackPort: Int,
+    uuid: String
+  ): Resource[IO, Pipe[IO, Array[Byte], OutputRow]] = {
+    for {
+      blocker <- Blocker[IO]
+      streams = IntegrationTestConfig.getStreams(uuid)
+      kinesisRawSink <- com.snowplowanalytics.snowplow.enrich.kinesis.Sink.init[IO](blocker, IntegrationTestConfig.kinesisOutputStreamConfig(localstackPort, streams.kinesisInput))
+    } yield {
+      val kinesisGoodOutput = asGood(outputStream(blocker, IntegrationTestConfig.kinesisInputStreamConfig(localstackPort, streams.kinesisOutputGood)))
+      val kinesisBadOutput = asBad(outputStream(blocker, IntegrationTestConfig.kinesisInputStreamConfig(localstackPort, streams.kinesisOutputBad)))
+
+      collectorPayloads =>
+        kinesisGoodOutput.merge(kinesisBadOutput)
+          .interruptAfter(3.minutes)
+          .concurrently(collectorPayloads.evalMap(bytes => kinesisRawSink(List(bytes))))
+    }
+  }
+
+  private def outputStream(blocker: Blocker, config: Input.Kinesis): Stream[IO, Array[Byte]] =
+    com.snowplowanalytics.snowplow.enrich.kinesis.Source.init[IO](blocker, config, IntegrationTestConfig.monitoring)
+      .map(com.snowplowanalytics.snowplow.enrich.kinesis.KinesisRun.getPayload)
+
+  private def asGood(source: Stream[IO, Array[Byte]]): Stream[IO, OutputRow.Good] = {
+    source.map { bytes =>
+        val s = new String(bytes)
+        // this is an eventbridge event, we need to extract the `detail` entry from it
+        val parsed = io.circe.parser.parse(s) match {
+          case Right(json) =>
+            json.hcursor.downField("detail")
+            .as[Event] match {
+              case Right(r) => r
+              case Left(e) =>throw new RuntimeException(s"Can't parse enriched events from eventbridge: $e, json: $json")
+            }
+          case Left(e) => throw new RuntimeException(s"Can't parse enriched event [$s]. Error: $e")
+        }
+      OutputRow.Good(parsed)
+    }
+  }
+
+  private def asBad(source: Stream[IO, Array[Byte]]): Stream[IO, OutputRow.Bad] =
+    source.map { bytes =>
+      val s = new String(bytes)
+      // this is an eventbridge event, we need to extract the `detail` entry from it
+      val parsed = io.circe.parser.parse(s) match {
+        case Right(json) =>
+          json.hcursor.downField("detail")
+          .as[io.circe.Json]
+          .getOrElse(throw new RuntimeException(s"Can't parse bad row from eventbridge: $s"))
+
+        case Left(e) => throw new RuntimeException(s"Can't parse bad row [$s]. Error: $e")
+      }
+          Utils.parseBadRow(parsed.noSpaces) match {
+            case Right(br) => OutputRow.Bad(br)
+            case Left(e) =>
+              throw new RuntimeException(s"Can't decode bad row $s. Error: $e")
+          }
+    }
+
+  def parseOutput(output: List[OutputRow], testName: String): (List[Event], List[BadRow]) = {
+    val good = output.collect { case OutputRow.Good(e) => e}
+    println(s"[$testName] Bad rows:")
+    val bad = output.collect { case OutputRow.Bad(b) =>
+      println(s"[$testName] ${b.compact}")
+      b
+    }
+    (good, bad)
+  }
+}

--- a/modules/eventbridge/src/main/resources/application.conf
+++ b/modules/eventbridge/src/main/resources/application.conf
@@ -1,0 +1,106 @@
+{
+  "input": {
+    "type": "Kinesis"
+    "appName": "snowplow-enrich-kinesis"
+    "initialPosition": {
+      "type": "LATEST"
+    }
+    "retrievalMode": {
+      "type": "Polling"
+      "maxRecords": 10000
+    }
+    "bufferSize": 3
+    "checkpointBackoff": {
+      "minBackoff": 100 milliseconds
+      "maxBackoff": 10 seconds
+      "maxRetries": 10
+    }
+  }
+
+  "output": {
+    "good": {
+      "type": "Eventbridge"
+      "eventBusName": ""
+      "eventBusSource": ""
+      "backoffPolicy": {
+        "minBackoff": 100 milliseconds
+        "maxBackoff": 10 seconds
+        "maxRetries": 10
+      }
+      "throttledBackoffPolicy": {
+        "minBackoff": 100 milliseconds
+        "maxBackoff": 1 second
+      }
+      "recordLimit": 10
+      "byteLimit": 250000
+    }
+
+    "pii": {
+      "type": "Eventbridge"
+      "eventBusName": ""
+      "eventBusSource": ""
+      "backoffPolicy": {
+        "minBackoff": 100 milliseconds
+        "maxBackoff": 10 seconds
+        "maxRetries": 10
+      }
+      "throttledBackoffPolicy": {
+        "minBackoff": 100 milliseconds
+        "maxBackoff": 1 second
+      }
+      "recordLimit": 10
+      "byteLimit": 250000
+    }
+
+    "bad": {
+      "type": "Eventbridge"
+      "eventBusName": ""
+      "eventBusSource": ""
+      "backoffPolicy": {
+        "minBackoff": 100 milliseconds
+        "maxBackoff": 10 seconds
+        "maxRetries": 10
+      }
+      "throttledBackoffPolicy": {
+        "minBackoff": 100 milliseconds
+        "maxBackoff": 1 second
+      }
+      "recordLimit": 10
+      "byteLimit": 250000
+    }
+  }
+
+  "concurrency" : {
+    "enrich": 256
+    "sink": 1
+  }
+
+  "remoteAdapters" : {
+    "connectionTimeout": 10 seconds,
+    "readTimeout": 45 seconds,
+    "maxConnections": 10,
+    "configs" : []
+  }
+
+  "monitoring": {
+    "metrics": {
+      "cloudwatch": true
+    }
+  }
+
+  "telemetry": {
+    "disable": false
+    "interval": 15 minutes
+    "method": POST
+    "collectorUri": collector-g.snowplowanalytics.com
+    "collectorPort": 443
+    "secure": true
+  }
+
+  "featureFlags" : {
+    "acceptInvalid": false
+    "legacyEnrichmentOrder": false
+    "tryBase64Decoding": true
+  }
+}
+

--- a/modules/eventbridge/src/main/scala/com/snowplowanalytics/snowplow/enrich/eventbridge/EventbridgeRun.scala
+++ b/modules/eventbridge/src/main/scala/com/snowplowanalytics/snowplow/enrich/eventbridge/EventbridgeRun.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2022-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.enrich.eventbridge
+
+import cats.Parallel
+import cats.effect.{Clock, ConcurrentEffect, ContextShift, ExitCode, Sync, Timer}
+import cats.implicits._
+import com.snowplowanalytics.snowplow.enrich.common.fs2.Run
+import com.snowplowanalytics.snowplow.enrich.common.fs2.config.io.Cloud
+import com.snowplowanalytics.snowplow.enrich.eventbridge.generated.BuildInfo
+import fs2.aws.kinesis.CommittableRecord
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+import software.amazon.kinesis.exceptions.ShutdownException
+
+import scala.concurrent.ExecutionContext
+
+object EventbridgeRun {
+
+  // Kinesis records must not exceed 1 MB
+  private val MaxRecordSize = 1024 * 1024
+
+  private implicit def unsafeLogger[F[_]: Sync]: Logger[F] =
+    Slf4jLogger.getLogger[F]
+
+  def run[F[_]: Clock: ConcurrentEffect: ContextShift: Parallel: Timer](args: List[String], ec: ExecutionContext): F[ExitCode] =
+    Run.run[F, CommittableRecord](
+      args,
+      BuildInfo.name,
+      BuildInfo.version,
+      BuildInfo.description,
+      ec,
+      com.snowplowanalytics.snowplow.enrich.kinesis.DynamoDbConfig.updateCliConfig[F],
+      com.snowplowanalytics.snowplow.enrich.kinesis.Source.init[F],
+      (blocker, out) => Sink.initAttributed(blocker, out),
+      (blocker, out) => Sink.initAttributed(blocker, out),
+      (blocker, out) => Sink.init(blocker, out),
+      checkpoint[F],
+      List(_ => com.snowplowanalytics.snowplow.enrich.kinesis.S3Client.mk[F]),
+      com.snowplowanalytics.snowplow.enrich.kinesis.KinesisRun.getPayload,
+      MaxRecordSize,
+      Some(Cloud.Aws),
+      getRuntimeRegion
+    )
+
+  /** For each shard, the record with the biggest sequence number is found, and checkpointed. */
+  private def checkpoint[F[_]: Parallel: Sync: Timer](records: List[CommittableRecord]): F[Unit] =
+    records
+      .groupBy(_.shardId)
+      .foldLeft(List.empty[CommittableRecord]) { (acc, shardRecords) =>
+        shardRecords._2
+          .reduceLeft[CommittableRecord] { (biggest, record) =>
+            if (record.sequenceNumber > biggest.sequenceNumber)
+              record
+            else
+              biggest
+          } :: acc
+      }
+      .parTraverse_ { record =>
+        record.checkpoint
+          .recoverWith {
+            case _: ShutdownException =>
+              // The ShardRecordProcessor instance has been shutdown. This just means another KCL
+              // worker has stolen our lease. It is expected during autoscaling of instances, and is
+              // safe to ignore.
+              Logger[F].warn(s"Skipping checkpointing of shard ${record.shardId} because this worker no longer owns the lease")
+
+            case _: IllegalArgumentException if record.isLastInShard =>
+              // See https://github.com/snowplow/enrich/issues/657
+              // This can happen at the shard end when KCL no longer allows checkpointing of the last record in the shard.
+              // We need to release the semaphore, so that fs2-aws handles checkpointing the end of the shard.
+              Logger[F].warn(
+                s"Checkpointing failed on last record in shard. Ignoring error and instead try checkpointing of the shard end"
+              ) *>
+                Sync[F].delay(record.lastRecordSemaphore.release())
+
+            case _: IllegalArgumentException if record.lastRecordSemaphore.availablePermits === 0 =>
+              // See https://github.com/snowplow/enrich/issues/657 and https://github.com/snowplow/enrich/pull/658
+              // This can happen near the shard end, e.g. the penultimate batch in the shard, when KCL has already enqueued the final record in the shard to the fs2 queue.
+              // We must not release the semaphore yet, because we are not ready for fs2-aws to checkpoint the end of the shard.
+              // We can safely ignore the exception and move on.
+              Logger[F].warn(
+                s"Checkpointing failed on a record which was not the last in the shard. Meanwhile, KCL has already enqueued the final record in the shard to the fs2 queue. Ignoring error and instead continue processing towards the shard end"
+              )
+          }
+      }
+}

--- a/modules/eventbridge/src/main/scala/com/snowplowanalytics/snowplow/enrich/eventbridge/Main.scala
+++ b/modules/eventbridge/src/main/scala/com/snowplowanalytics/snowplow/enrich/eventbridge/Main.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020-2021 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.enrich.eventbridge
+
+import cats.effect.{ExitCode, IO, IOApp, Resource, SyncIO}
+
+import java.util.concurrent.{Executors, TimeUnit}
+import scala.concurrent.ExecutionContext
+
+object Main extends IOApp.WithContext {
+
+  /**
+   * An execution context matching the cats effect IOApp default. We create it explicitly so we can
+   * also use it for our Blaze client.
+   */
+  override protected val executionContextResource: Resource[SyncIO, ExecutionContext] = {
+    val poolSize = math.max(2, Runtime.getRuntime().availableProcessors())
+    Resource
+      .make(SyncIO(Executors.newFixedThreadPool(poolSize)))(pool =>
+        SyncIO {
+          pool.shutdown()
+          pool.awaitTermination(10, TimeUnit.SECONDS)
+          ()
+        }
+      )
+      .map(ExecutionContext.fromExecutorService)
+  }
+
+  def run(args: List[String]): IO[ExitCode] =
+    EventbridgeRun.run[IO](args, executionContext)
+}

--- a/modules/eventbridge/src/main/scala/com/snowplowanalytics/snowplow/enrich/eventbridge/Sink.scala
+++ b/modules/eventbridge/src/main/scala/com/snowplowanalytics/snowplow/enrich/eventbridge/Sink.scala
@@ -1,0 +1,351 @@
+/*
+ * Copyright (c) 2022-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.enrich.eventbridge
+
+import cats.data.Validated
+import cats.effect.concurrent.Ref
+import cats.effect.{Blocker, Concurrent, ContextShift, Resource, Sync, Timer}
+import cats.implicits._
+import cats.{Monoid, Parallel}
+import com.snowplowanalytics.snowplow.analytics.scalasdk.Event
+import com.snowplowanalytics.snowplow.enrich.common.fs2.config.io.Output
+import com.snowplowanalytics.snowplow.enrich.common.fs2.io.Retries
+import com.snowplowanalytics.snowplow.enrich.common.fs2.{AttributedByteSink, AttributedData, ByteSink}
+import io.circe.Json
+import io.circe.syntax._
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+import retry.RetryPolicy
+import retry.implicits.{retrySyntaxBase, retrySyntaxError}
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.eventbridge.EventBridgeClient
+import software.amazon.awssdk.services.eventbridge.model.{PutEventsRequest, PutEventsRequestEntry, PutEventsResponse}
+
+import java.nio.charset.StandardCharsets
+import java.util.{Base64, UUID}
+import scala.jdk.CollectionConverters.{collectionAsScalaIterableConverter, seqAsJavaListConverter}
+
+object Sink {
+
+  private implicit def unsafeLogger[F[_]: Sync]: Logger[F] =
+    Slf4jLogger.getLogger[F]
+
+  def init[F[_]: Concurrent: ContextShift: Parallel: Timer](
+    blocker: Blocker,
+    output: Output
+  ): Resource[F, ByteSink[F]] =
+    for {
+      sink <- initAttributed(blocker, output)
+    } yield (records: List[Array[Byte]]) => sink(records.map(AttributedData(_, UUID.randomUUID().toString, Map.empty)))
+
+  def initAttributed[F[_]: Concurrent: ContextShift: Parallel: Timer](
+    blocker: Blocker,
+    output: Output
+  ): Resource[F, AttributedByteSink[F]] =
+    output match {
+      case o: Output.Eventbridge =>
+        o.region.orElse(getRuntimeRegion) match {
+          case Some(region) =>
+            for {
+              producer <- Resource.eval[F, EventBridgeClient](mkProducer(o, region))
+            } yield (records: List[AttributedData[Array[Byte]]]) =>
+              writeToEventbridge(blocker, o, producer, toEventBridgeEvents(records, o))
+          case None =>
+            Resource.eval(Sync[F].raiseError(new RuntimeException(s"Region not found in the config and in the runtime")))
+        }
+      case o =>
+        Resource.eval(Sync[F].raiseError(new IllegalArgumentException(s"Output $o is not Eventbridge")))
+    }
+
+  private def mkProducer[F[_]: Sync](
+    config: Output.Eventbridge,
+    region: String
+  ): F[EventBridgeClient] =
+    Sync[F].delay {
+      val builder =
+        EventBridgeClient
+          .builder()
+          .region(Region.of(region))
+
+      config.customEndpoint
+        .map(builder.endpointOverride)
+        .getOrElse(builder)
+        .build
+    }
+
+  def toEventBridgeEvents(
+    events: List[AttributedData[Array[Byte]]],
+    output: Output.Eventbridge
+  ): List[PutEventsRequestEntry] =
+    events
+      .map { event =>
+        val tsv = new String(event.data)
+        lazy val base64TSV = Base64.getEncoder.encodeToString(tsv.getBytes(StandardCharsets.UTF_8))
+
+        val json = Event.parse(tsv) match {
+          case Validated.Valid(event) =>
+            val eventJson = event.toJson(false)
+
+            lazy val host = for {
+              headers <- eventJson.hcursor
+                           .downField("contexts_org_ietf_http_header_1")
+                           .as[List[Json]]
+                           .toOption
+
+              hostHeader <- headers.find { header =>
+                              header.hcursor
+                                .downField("name")
+                                .as[String]
+                                .toOption
+                                .contains("Host")
+                            }
+
+              host <- hostHeader.hcursor
+                        .downField("value")
+                        .as[String]
+                        .toOption
+            } yield host
+            val attachments = List((output.payload.contains(true), "payload", () => base64TSV.asJson),
+                                   (output.collector.contains(true), "collector", () => host.asJson)
+            )
+
+            attachments.foldLeft(eventJson) {
+              case (current, (include, key, getValue)) =>
+                if (include) current.deepMerge(Map(key -> getValue()).asJson)
+                else current
+            }
+          case Validated.Invalid(error) =>
+            // when the event content is not a TSV, there is a chance that we are processing a bad row, in such a case
+            // we are interested in sending the raw event if it is a json, otherwise, we return a generic error.
+            io.circe.parser.parse(tsv).getOrElse {
+              Map("error" -> error.toString, "tsv" -> base64TSV).asJson
+            }
+        }
+
+        PutEventsRequestEntry
+          .builder()
+          .eventBusName(output.eventBusName)
+          .source(output.eventBusSource)
+          .detail(json.noSpaces)
+          .detailType("enrich-event")
+          .build()
+      }
+
+  private def writeToEventbridge[F[_]: ContextShift: Parallel: Sync: Timer](
+    blocker: Blocker,
+    config: Output.Eventbridge,
+    eventbridge: EventBridgeClient,
+    events: List[PutEventsRequestEntry]
+  ): F[Unit] = {
+    val policyForErrors = Retries.fullJitter[F](config.backoffPolicy)
+    val policyForThrottling = Retries.fibonacci[F](config.throttledBackoffPolicy)
+
+    def runAndCaptureFailures(ref: Ref[F, List[PutEventsRequestEntry]]): F[List[PutEventsRequestEntry]] =
+      for {
+        records <- ref.get
+        failures <- group(records, recordLimit = config.recordLimit, sizeLimit = config.byteLimit, getRecordSize)
+                      .parTraverse(g => tryWriteToEventbridge(blocker, config, eventbridge, g, policyForErrors))
+        flattened = failures.flatten
+        _ <- ref.set(flattened)
+      } yield flattened
+
+    for {
+      ref <- Ref.of(events)
+      failures <- runAndCaptureFailures(ref)
+                    .retryingOnFailures(
+                      policy = policyForThrottling,
+                      wasSuccessful = _.isEmpty,
+                      onFailure = {
+                        case (result, retryDetails) =>
+                          val msg = failureMessageForThrottling(result, config.eventBusName)
+                          Logger[F].warn(s"$msg (${retryDetails.retriesSoFar} retries from cats-retry)")
+                      }
+                    )
+      _ <- if (failures.isEmpty) Sync[F].unit
+           else Sync[F].raiseError(new RuntimeException(failureMessageForThrottling(failures, config.eventBusName)))
+    } yield ()
+  }
+
+  /**
+   * This function takes a list of records and splits it into several lists,
+   * where each list is as big as possible with respecting the record limit and the size limit
+   */
+  private[eventbridge] def group[A](
+    records: List[A],
+    recordLimit: Int,
+    sizeLimit: Int,
+    getRecordSize: A => Int
+  ): List[List[A]] = {
+
+    case class Batch(
+      size: Int,
+      count: Int,
+      records: List[A]
+    )
+
+    records
+      .foldLeft(List.empty[Batch]) {
+        case (acc, record) =>
+          val recordSize = getRecordSize(record)
+          acc match {
+            case head :: tail =>
+              if (head.count + 1 > recordLimit || head.size + recordSize > sizeLimit)
+                List(Batch(recordSize, 1, List(record))) ++ List(head) ++ tail
+              else
+                List(Batch(head.size + recordSize, head.count + 1, record :: head.records)) ++ tail
+            case Nil =>
+              List(Batch(recordSize, 1, List(record)))
+          }
+      }
+      .map(_.records)
+  }
+
+  /**
+   * Try writing a batch, and returns a list of the failures to be retried:
+   *
+   * If we are not throttled by eventbridge, then the list is empty.
+   * If we are throttled by eventbridge, the list contains throttled records and records that gave internal errors.
+   * If there is an exception, or if all records give internal errors, then we retry using the policy.
+   */
+  private def tryWriteToEventbridge[F[_]: ContextShift: Sync: Timer](
+    blocker: Blocker,
+    config: Output.Eventbridge,
+    eventbridge: EventBridgeClient,
+    events: List[PutEventsRequestEntry],
+    retryPolicy: RetryPolicy[F]
+  ): F[Vector[PutEventsRequestEntry]] =
+    Logger[F].debug(s"Writing ${events.size} records to ${config.eventBusName}") *>
+      blocker
+        .blockOn(Sync[F].delay(putEvents(eventbridge, events)))
+        .map(TryBatchResult.build(events, _))
+        .retryingOnFailuresAndAllErrors(
+          policy = retryPolicy,
+          wasSuccessful = r => !r.shouldRetrySameBatch,
+          onFailure = {
+            case (result, retryDetails) =>
+              val msg = failureMessageForInternalErrors(events, config.eventBusName, result)
+              Logger[F].error(s"$msg (${retryDetails.retriesSoFar} retries from cats-retry)")
+          },
+          onError = (exception, retryDetails) =>
+            Logger[F]
+              .error(exception)(
+                s"Writing ${events.size} records to ${config.eventBusName} errored (${retryDetails.retriesSoFar} retries from cats-retry)"
+              )
+        )
+        .flatMap { result =>
+          if (result.shouldRetrySameBatch)
+            Sync[F].raiseError(new RuntimeException(failureMessageForInternalErrors(events, config.eventBusName, result)))
+          else
+            result.nextBatchAttempt.pure[F]
+        }
+
+  /**
+   * The result of trying to write a batch to eventbridge
+   *
+   * @param nextBatchAttempt     Records to re-package into another batch, either because of throttling or an internal error
+   * @param hadSuccess           Whether one or more records in the batch were written successfully
+   * @param wasThrottled         Whether at least one of retries is because of throttling
+   * @param exampleInternalError A message to help with logging
+   */
+  private case class TryBatchResult(
+    nextBatchAttempt: Vector[PutEventsRequestEntry],
+    hadSuccess: Boolean,
+    wasThrottled: Boolean,
+    exampleInternalError: Option[String]
+  ) {
+    // Only retry the exact same again if no record was successfully inserted, and all the errors
+    // were not throughput exceeded exceptions
+    def shouldRetrySameBatch: Boolean =
+      !hadSuccess && !wasThrottled
+  }
+
+  private object TryBatchResult {
+
+    implicit private def tryBatchResultMonoid: Monoid[TryBatchResult] =
+      new Monoid[TryBatchResult] {
+        override val empty: TryBatchResult = TryBatchResult(Vector.empty, false, false, None)
+
+        override def combine(x: TryBatchResult, y: TryBatchResult): TryBatchResult =
+          TryBatchResult(
+            x.nextBatchAttempt ++ y.nextBatchAttempt,
+            x.hadSuccess || y.hadSuccess,
+            x.wasThrottled || y.wasThrottled,
+            x.exampleInternalError.orElse(y.exampleInternalError)
+          )
+      }
+
+    def build(records: List[PutEventsRequestEntry], prr: PutEventsResponse): TryBatchResult =
+      if (prr.failedEntryCount().toInt =!= 0)
+        records
+          .zip(prr.entries().asScala)
+          .foldMap {
+            case (orig, recordResult) =>
+              Option(recordResult.errorCode()) match {
+                case None =>
+                  TryBatchResult(Vector.empty, true, false, None)
+                case Some("ThrottlingException") =>
+                  TryBatchResult(Vector(orig), false, true, None)
+                case Some(_) =>
+                  TryBatchResult(Vector(orig), false, false, Option(recordResult.errorMessage()))
+              }
+          }
+      else
+        TryBatchResult(Vector.empty, true, false, None)
+  }
+
+  private def putEvents(
+    eventbridge: EventBridgeClient,
+    events: List[PutEventsRequestEntry]
+  ): PutEventsResponse = {
+    val request = PutEventsRequest
+      .builder()
+      .entries(events.asJava)
+      .build()
+
+    eventbridge.putEvents(request)
+  }
+
+  /**
+   * Official AWS code adapted to Scala to compute the entry size
+   *
+   * See https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-putevent-size.html
+   */
+  private def getRecordSize(entry: PutEventsRequestEntry): Int = {
+    var size = 0
+    if (entry.time() != null) size += 14
+    size += entry.source().getBytes(StandardCharsets.UTF_8).length
+    size += entry.detailType().getBytes(StandardCharsets.UTF_8).length
+    if (entry.detail() != null) size += entry.detail().getBytes(StandardCharsets.UTF_8).length
+    if (entry.resources() != null) {
+      import scala.collection.JavaConverters._
+      for (resource <- entry.resources().asScala)
+        if (resource != null) size += resource.getBytes(StandardCharsets.UTF_8).length
+    }
+    size
+  }
+
+  private def failureMessageForInternalErrors(
+    records: List[PutEventsRequestEntry],
+    streamName: String,
+    result: TryBatchResult
+  ): String = {
+    val exampleMessage = result.exampleInternalError.getOrElse("none")
+    s"Writing ${records.size} records to $streamName errored with internal failures. Example error message [$exampleMessage]"
+  }
+
+  private def failureMessageForThrottling(
+    records: List[PutEventsRequestEntry],
+    streamName: String
+  ): String =
+    s"Exceeded Eventbridge provisioned throughput: ${records.size} records failed writing to $streamName."
+}

--- a/modules/eventbridge/src/main/scala/com/snowplowanalytics/snowplow/enrich/eventbridge/package.scala
+++ b/modules/eventbridge/src/main/scala/com/snowplowanalytics/snowplow/enrich/eventbridge/package.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2021-2021 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.enrich
+
+import com.amazonaws.regions.DefaultAwsRegionProviderChain
+
+package object eventbridge {
+  def getRuntimeRegion: Option[String] =
+    Option((new DefaultAwsRegionProviderChain).getRegion)
+}

--- a/modules/eventbridge/src/test/scala/com/snowplowanalytics/snowplow/enrich/eventbridge/SinkSpec.scala
+++ b/modules/eventbridge/src/test/scala/com/snowplowanalytics/snowplow/enrich/eventbridge/SinkSpec.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2022-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.enrich.eventbridge
+
+import org.specs2.mutable.Specification
+
+class SinkSpec extends Specification {
+
+  private def getSize(record: String) = record.length
+
+  "group" should {
+    "leave a list untouched if its number of records and its size are below the limits" in {
+      val records = List("a", "b", "c")
+      val expected = List(records)
+      val actual = Sink.group(records, 3, 4, getSize)
+      actual.reverse.map(_.reverse) must beEqualTo(expected)
+    }
+
+    "split a list if it reaches recordLimit" in {
+      val expected = List(List("a", "b", "c"), List("d", "e", "f"), List("g"))
+      val records = expected.flatten
+      val actual = Sink.group(records, 3, 4, getSize)
+      actual.reverse.map(_.reverse) must beEqualTo(expected)
+    }
+
+    "split a list if it reaches sizeLimit" in {
+      val expected = List(List("aa", "bb", "cc"), List("dd", "ee", "ff"), List("g"))
+      val records = expected.flatten
+      val actual = Sink.group(records, 3, 6, getSize)
+      actual.reverse.map(_.reverse) must beEqualTo(expected)
+    }
+
+    "split a list if it reaches recordLimit and then sizeLimit" in {
+      val expected = List(List("a", "b", "c"), List("dd", "ee", "ff"), List("g"))
+      val records = expected.flatten
+      val actual = Sink.group(records, 3, 6, getSize)
+      actual.reverse.map(_.reverse) must beEqualTo(expected)
+    }
+  }
+}

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -122,6 +122,14 @@ object BuildSettings {
     buildInfoPackage := "com.snowplowanalytics.snowplow.enrich.nsq.generated"
   )
 
+  lazy val eventbridgeProjectSettings = projectSettings ++ Seq(
+    name := "snowplow-enrich-eventbridge",
+    moduleName := "snowplow-enrich-eventbridge",
+    description := "High-performance streaming enrich app working with Kinesis source and Eventbridge sink, built on top of functional streams",
+    buildInfoKeys := Seq[BuildInfoKey](organization, name, version, description),
+    buildInfoPackage := "com.snowplowanalytics.snowplow.enrich.eventbridge.generated"
+  )
+
   /** Make package (build) metadata available within source code. */
   lazy val scalifiedSettings = Seq(
     Compile / sourceGenerators += Def.task {
@@ -353,6 +361,18 @@ object BuildSettings {
   }
 
   lazy val nsqDistrolessBuildSettings = nsqBuildSettings.diff(dockerSettingsFocal) ++ dockerSettingsDistroless
+
+  lazy val eventbridgeBuildSettings = {
+    // Project
+    eventbridgeProjectSettings ++ buildSettings ++
+      // Build and publish
+      assemblySettings ++ dockerSettingsFocal ++
+      Seq(Docker / packageName := "snowplow-enrich-eventbridge") ++
+      // Tests
+      scoverageSettings ++ noParallelTestExecution ++ Seq(Test / fork := true)
+  }
+
+  lazy val eventbridgeDistrolessBuildSettings = eventbridgeBuildSettings.diff(dockerSettingsFocal) ++ dockerSettingsDistroless
 
   /** Fork a JVM per test in order to not reuse enrichment registries. */
   def oneJVMPerTest(tests: Seq[TestDefinition]): Seq[Tests.Group] =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -205,6 +205,7 @@ object Dependencies {
     val fs2Io            = "co.fs2"                           %% "fs2-io"                                % V.fs2
     val fs2Kafka         = "com.github.fd4s"                  %% "fs2-kafka"                             % V.fs2Kafka
     val kinesisSdk2      = "software.amazon.awssdk"           %  "kinesis"                               % V.awsSdk2
+    val eventbridgeSdk2  = "software.amazon.awssdk"           %  "eventbridge"                           % V.awsSdk2
     val dynamoDbSdk2     = "software.amazon.awssdk"           %  "dynamodb"                              % V.awsSdk2
     val s3Sdk2           = "software.amazon.awssdk"           %  "s3"                                    % V.awsSdk2
     val cloudwatchSdk2   = "software.amazon.awssdk"           %  "cloudwatch"                            % V.awsSdk2
@@ -370,6 +371,22 @@ object Dependencies {
       fs2BlobS3,
       fs2BlobGcs,
       log4j // for security vulnerabilities
+    )
+
+    val eventbridgeDependencies = Seq(
+      dynamodbSdk,
+      kinesisSdk,
+      fs2BlobS3,
+      fs2Aws,
+      kinesisSdk2,
+      dynamoDbSdk2,
+      s3Sdk2,
+      cloudwatchSdk2,
+      kinesisClient2,
+      stsSdk2,
+      sts,
+      specs2,
+      eventbridgeSdk2
     )
 
     // exclusions


### PR DESCRIPTION
The Enrich EventBridge module streams Snowplow enriched data in JSON (with the original base64 TSV payload) to AWS EventBridge, which enables routing events based on any parameter on the payload while retaining compatibility for use with other Snowplow components downstream (S3 loader for example).

This contribution is approved for release and license to recipients of Snowplow Enrich only under the Apache License, version 2.0.

<!--
Thank you for contributing to Snowplow Enrich!

You'll find a small checklist below which should help speed up the review process:

- [ ] Have you signed the [contributor license agreement](https://github.com/snowplow/snowplow/wiki/CLA)?
- [ ] Have you read the [contributing guide](https://github.com/snowplow/enrich/blob/master/CONTRIBUTING.md)?
- [ ] Have you added the appropriate unit tests?
- [ ] Have you run the tests through `sbt test`?
- [ ] Is your pull request against the `master` branch?
-->

