### PR TITLE
Additional logging

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -243,6 +243,7 @@ object Dependencies {
       iabClient,
       yauaa,
       log4jToSlf4j,
+      log4cats,
       guava,
       circeOptics,
       circeJackson,


### PR DESCRIPTION
Additional DEBUG logs:
- Log the size of the biggest event of a chunk (an event being a collector payload that can contain several actual events)
- Log how many events a collector payload contains
For each event (identified by `event_id`):
- Log when the contexts are going to be validated
- Log when the contexts have been validated
- Log when the enrichments are going to be executed
- Log when the enrichments have been executed
- Log when the contexts added by the enrichments are going to be validated
- Log when the contexts added by the enrichments have been validated