### PR TITLE
Add Cross Navigation Enrichment

### DIFF
--- a/config/enrichments/cross_navigation_config.json
+++ b/config/enrichments/cross_navigation_config.json
@@ -1,0 +1,9 @@
+{
+    "schema": "iglu:com.snowplowanalytics.snowplow.enrichments/cross_navigation_config/jsonschema/1-0-0",
+
+    "data": {
+        "enabled": false,
+        "vendor": "com.snowplowanalytics.snowplow.enrichments",
+        "name": "cross_navigation_config"
+    }
+}

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/EnrichmentManager.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/EnrichmentManager.scala
@@ -614,7 +614,7 @@ object EnrichmentManager {
       case (event, _) =>
         pageQsMap match {
           case Some(qsMap) =>
-            WPE
+            CNE
               .parseCrossDomain(qsMap)
               .bimap(
                 err =>
@@ -623,15 +623,10 @@ object EnrichmentManager {
                     case None => NonEmptyList.one(err)
                   },
                 crossNavMap => {
-                  val crossNavKeys = crossNavMap.keySet
-                  val duidKey = CNE.CrossNavProps(0)
-                  val tstampKey = CNE.CrossNavProps(1)
-                  if (crossNavKeys.contains(duidKey))
-                    crossNavMap(duidKey).foreach(event.refr_domain_userid = _)
-                  if (crossNavKeys.contains(tstampKey))
-                    crossNavMap(tstampKey).foreach(event.refr_dvce_tstamp = _)
+                  crossNavMap.duid.foreach(event.refr_domain_userid = _)
+                  crossNavMap.tstamp.foreach(event.refr_dvce_tstamp = _)
                   crossNavEnrichment match {
-                    case Some(cn) => cn.getCrossNavigationContext(crossNavMap)
+                    case Some(_) => crossNavMap.getCrossNavigationContext
                     case None => Nil
                   }
                 }

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/EnrichmentRegistry.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/EnrichmentRegistry.scala
@@ -163,6 +163,7 @@ object EnrichmentRegistry {
             registry <- er
           } yield registry.copy(weather = enrichment.some)
         case c: YauaaConf => er.map(_.copy(yauaa = c.enrichment.some))
+        case c: CrossNavigationConf => er.map(_.copy(crossNavigation = c.enrichment.some))
       }
     }
 
@@ -226,6 +227,8 @@ object EnrichmentRegistry {
             PiiPseudonymizerEnrichment.parse(enrichmentConfig, schemaKey).map(_.some)
           case "iab_spiders_and_robots_enrichment" =>
             IabEnrichment.parse(enrichmentConfig, schemaKey, localMode).map(_.some)
+          case "cross_navigation_config" =>
+            CrossNavigationEnrichment.parse(enrichmentConfig, schemaKey).map(_.some)
           case _ =>
             Option.empty[EnrichmentConf].validNel // Enrichment is not recognized
         }
@@ -250,5 +253,6 @@ final case class EnrichmentRegistry[F[_]](
   uaParser: Option[UaParserEnrichment[F]] = None,
   userAgentUtils: Option[UserAgentUtilsEnrichment] = None,
   weather: Option[WeatherEnrichment[F]] = None,
-  yauaa: Option[YauaaEnrichment] = None
+  yauaa: Option[YauaaEnrichment] = None,
+  crossNavigation: Option[CrossNavigationEnrichment] = None
 )

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/CrossNavigationEnrichment.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/CrossNavigationEnrichment.scala
@@ -141,17 +141,23 @@ object CrossNavigationEnrichment extends ParseableEnrichment {
      * @return either a map of query string parameters or enrichment failure
      */
     def makeCrossDomainMap(sp: String): Either[FailureDetails.EnrichmentFailure, CrossDomainMap] = {
-      val values = sp.split("\\.", -1)
+      val values = sp
+        .split("\\.", -1)
         .padTo(
           CrossNavProps.size,
           ""
-        ).toList
-      val result = if (values.size == CrossNavProps.size)
-        values.zip(CrossNavProps).map {
-          case (value, (propName, f)) => f(value).map(propName -> _)
-        }.sequence
-          .map(_.filterNot { case (key, value) => key != timestampFieldName && value.isEmpty }.toMap)
-      else Map.empty[String, Option[String]].asRight
+        )
+        .toList
+      val result =
+        if (values.size == CrossNavProps.size)
+          values
+            .zip(CrossNavProps)
+            .map {
+              case (value, (propName, f)) => f(value).map(propName -> _)
+            }
+            .sequence
+            .map(_.filterNot { case (key, value) => key != timestampFieldName && value.isEmpty }.toMap)
+        else Map.empty[String, Option[String]].asRight
       result.map(CrossDomainMap(_))
     }
 

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/CrossNavigationEnrichment.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/CrossNavigationEnrichment.scala
@@ -1,0 +1,213 @@
+/**
+ * Copyright (c) 2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.enrich.common.enrichments.registry
+
+import java.time.format.DateTimeFormatter
+
+import cats.data.ValidatedNel
+import cats.syntax.either._
+import cats.syntax.option._
+
+import io.circe.Json
+import io.circe.syntax._
+
+import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey, SchemaVer, SelfDescribingData}
+import com.snowplowanalytics.snowplow.badrows.FailureDetails
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.{EventEnrichments => EE}
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf.CrossNavigationConf
+import com.snowplowanalytics.snowplow.enrich.common.utils.{ConversionUtils => CU}
+
+/**
+ * Companion object to create an instance of CrossNavigationEnrichment
+ * from the configuration.
+ */
+object CrossNavigationEnrichment extends ParseableEnrichment {
+  val supportedSchema = SchemaCriterion(
+    "com.snowplowanalytics.snowplow.enrichments",
+    "cross_navigation_config",
+    "jsonschema",
+    1,
+    0
+  )
+
+  val outputSchema = SchemaKey(
+    "com.snowplowanalytics.snowplow",
+    "cross_navigation",
+    "jsonschema",
+    SchemaVer.Full(1, 0, 0)
+  )
+
+  val CrossNavProps = List(
+    "domain_user_id",
+    "timestamp",
+    "session_id",
+    "user_id",
+    "source_id",
+    "source_platform",
+    "reason"
+  )
+
+  /**
+   * Creates a CrossNavigationConf instance from a Json.
+   * @param config The cross_navigation_config enrichment JSON
+   * @param schemaKey provided for the enrichment, must be supported by this enrichment
+   * @return a CrossNavigation configuration
+   */
+  override def parse(
+    config: Json,
+    schemaKey: SchemaKey,
+    localMode: Boolean = false
+  ): ValidatedNel[String, CrossNavigationConf] =
+    (for {
+      _ <- isParseable(config, schemaKey)
+    } yield CrossNavigationConf(schemaKey)).toValidatedNel
+
+  /**
+   * Wrapper around CU.decodeBase64Url.
+   * If passed an empty string returns Right(None).
+   * @param str The string to decode
+   * @return either the decoded string or enrichment failure
+   */
+  private def decodeWithFailure(str: String): Either[FailureDetails.EnrichmentFailure, Option[String]] =
+    CU.decodeBase64Url(str) match {
+      case Right(r) => Option(r).filter(_.trim.nonEmpty).asRight
+      case Left(msg) =>
+        FailureDetails
+          .EnrichmentFailure(
+            None,
+            FailureDetails.EnrichmentFailureMessage.Simple(msg)
+          )
+          .asLeft
+    }
+
+  /**
+   * Wrapper around EE.extractTimestamp
+   * If passed an empty string returns Right(None).
+   * @param str The string to extract the timestamp from
+   * @return either the extracted timestamp or enrichment failure
+   */
+  private def extractTstamp(str: String): Either[FailureDetails.EnrichmentFailure, Option[String]] =
+    str match {
+      case "" => None.asRight
+      case s => EE.extractTimestamp("sp_dtm", s).map(_.some)
+    }
+
+  /**
+   * Converts a timestamp to an ISO-8601 format
+   *
+   * @param tstamp The timestamp expected as output of EE.extractTimestamp
+   * @return ISO-8601 timestamp
+   */
+  private def reformatTstamp(tstamp: Option[String]): Option[String] = {
+    val pFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
+    val formatter = DateTimeFormatter.ISO_DATE_TIME
+
+    tstamp match {
+      case Some(t) =>
+        Some(formatter.format(pFormatter.parse(t)).replaceAll(" ", "T") + "Z")
+      case None => None
+    }
+  }
+
+  /**
+   * Finalizes the cross navigation map by reformatting its timestamp key
+   *
+   * @param inputMap A Map of cross navigation properties
+   * @return The finalized Map
+   */
+  private def finalizeCrossNavigationMap(inputMap: Map[String, Option[String]]): Map[String, Option[String]] =
+    inputMap
+      .map({
+        case ("timestamp", t) => ("timestamp" -> reformatTstamp(t))
+        case kvPair => kvPair
+      })
+
+  /**
+   * Parses the QueryString into a Map
+   * @param sp QueryString
+   * @return either a map of query string parameters or enrichment failure
+   */
+  def makeCrossDomainMap(sp: String): Either[FailureDetails.EnrichmentFailure, Map[String, Option[String]]] =
+    sp.split("\\.", -1)
+      .padTo(
+        CrossNavProps.size,
+        ""
+      )
+      .toList match {
+      case List(
+            duidElt,
+            tstampElt,
+            sessionIdElt,
+            userIdElt,
+            sourceIdElt,
+            sourcePlatformElt,
+            reasonElt
+          ) =>
+        for {
+          domainUserId <- CU.makeTsvSafe(duidElt).some.asRight
+          timestamp <- extractTstamp(tstampElt)
+          sessionId <- Option(sessionIdElt).filter(_.trim.nonEmpty).asRight
+          userId <- decodeWithFailure(userIdElt)
+          sourceId <- decodeWithFailure(sourceIdElt)
+          sourcePlatform <- Option(sourcePlatformElt).filter(_.trim.nonEmpty).asRight
+          reason <- decodeWithFailure(reasonElt)
+        } yield (CrossNavProps zip List(
+          domainUserId,
+          timestamp,
+          sessionId,
+          userId,
+          sourceId,
+          sourcePlatform,
+          reason
+        )).filterNot(t => t._1 != "timestamp" && t._2 == None).toMap
+      case _ => Map.empty[String, Option[String]].asRight
+    }
+}
+
+/**
+ * Enrichment adding cross navigation context
+ */
+final case class CrossNavigationEnrichment(schemaKey: SchemaKey) extends Enrichment {
+  private val enrichmentInfo =
+    FailureDetails.EnrichmentInformation(schemaKey, "cross-navigation").some
+
+  /**
+   * Gets the cross navigation parameters as self-describing JSON.
+   * @param cnMap The map of cross navigation data
+   * @return the cross navigation context wrapped in a List
+   */
+  def getCrossNavigationContext(cnMap: Map[String, Option[String]]): List[SelfDescribingData[Json]] =
+    cnMap match {
+      case m: Map[String, Option[String]] if m.isEmpty => Nil
+      case _ =>
+        List(
+          SelfDescribingData(
+            CrossNavigationEnrichment.outputSchema,
+            CrossNavigationEnrichment.finalizeCrossNavigationMap(cnMap).asJson
+          )
+        )
+    }
+
+  /**
+   * Given an EnrichmentFailure, returns one with the cross-navigation
+   *  enrichment information added.
+   * @param failure The input enrichment failure
+   * @return the EnrichmentFailure with cross-navigation enrichment information
+   */
+  def addEnrichmentInfo(failure: FailureDetails.EnrichmentFailure): FailureDetails.EnrichmentFailure =
+    failure match {
+      case FailureDetails.EnrichmentFailure(_, msg) => FailureDetails.EnrichmentFailure(enrichmentInfo, msg)
+      case _ => failure
+    }
+
+}

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/CrossNavigationEnrichment.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/CrossNavigationEnrichment.scala
@@ -17,6 +17,7 @@ import java.time.format.DateTimeFormatter
 import cats.data.ValidatedNel
 import cats.syntax.either._
 import cats.syntax.option._
+import cats.syntax.traverse._
 
 import io.circe.Json
 import io.circe.syntax._
@@ -26,12 +27,16 @@ import com.snowplowanalytics.snowplow.badrows.FailureDetails
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.{EventEnrichments => EE}
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf.CrossNavigationConf
 import com.snowplowanalytics.snowplow.enrich.common.utils.{ConversionUtils => CU}
+import com.snowplowanalytics.snowplow.enrich.common.QueryStringParameters
 
 /**
  * Companion object to create an instance of CrossNavigationEnrichment
  * from the configuration.
  */
 object CrossNavigationEnrichment extends ParseableEnrichment {
+
+  type CrossNavTransformation = String => Either[FailureDetails.EnrichmentFailure, Option[String]]
+
   val supportedSchema = SchemaCriterion(
     "com.snowplowanalytics.snowplow.enrichments",
     "cross_navigation_config",
@@ -45,16 +50,6 @@ object CrossNavigationEnrichment extends ParseableEnrichment {
     "cross_navigation",
     "jsonschema",
     SchemaVer.Full(1, 0, 0)
-  )
-
-  val CrossNavProps = List(
-    "domain_user_id",
-    "timestamp",
-    "session_id",
-    "user_id",
-    "source_id",
-    "source_platform",
-    "reason"
   )
 
   /**
@@ -73,105 +68,139 @@ object CrossNavigationEnrichment extends ParseableEnrichment {
     } yield CrossNavigationConf(schemaKey)).toValidatedNel
 
   /**
-   * Wrapper around CU.decodeBase64Url.
-   * If passed an empty string returns Right(None).
-   * @param str The string to decode
-   * @return either the decoded string or enrichment failure
-   */
-  private def decodeWithFailure(str: String): Either[FailureDetails.EnrichmentFailure, Option[String]] =
-    CU.decodeBase64Url(str) match {
-      case Right(r) => Option(r).filter(_.trim.nonEmpty).asRight
-      case Left(msg) =>
-        FailureDetails
-          .EnrichmentFailure(
-            None,
-            FailureDetails.EnrichmentFailureMessage.Simple(msg)
-          )
-          .asLeft
-    }
-
-  /**
-   * Wrapper around EE.extractTimestamp
-   * If passed an empty string returns Right(None).
-   * @param str The string to extract the timestamp from
-   * @return either the extracted timestamp or enrichment failure
-   */
-  private def extractTstamp(str: String): Either[FailureDetails.EnrichmentFailure, Option[String]] =
-    str match {
-      case "" => None.asRight
-      case s => EE.extractTimestamp("sp_dtm", s).map(_.some)
-    }
-
-  /**
-   * Converts a timestamp to an ISO-8601 format
+   * Extract the referrer domain user ID and timestamp from the "_sp={{DUID}}.{{TSTAMP}}"
+   * portion of the querystring
    *
-   * @param tstamp The timestamp expected as output of EE.extractTimestamp
-   * @return ISO-8601 timestamp
+   * @param qsMap The querystring parameters
+   * @return Validation boxing a pair of optional strings corresponding to the two fields
    */
-  private def reformatTstamp(tstamp: Option[String]): Option[String] = {
-    val pFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
-    val formatter = DateTimeFormatter.ISO_DATE_TIME
-
-    tstamp match {
-      case Some(t) =>
-        Some(formatter.format(pFormatter.parse(t)).replaceAll(" ", "T") + "Z")
-      case None => None
+  def parseCrossDomain(qsMap: QueryStringParameters): Either[FailureDetails.EnrichmentFailure, CrossDomainMap] =
+    qsMap.toMap
+      .map { case (k, v) => (k, v.getOrElse("")) }
+      .get("_sp") match {
+      case Some("") => CrossDomainMap.empty.asRight
+      case Some(sp) => CrossDomainMap.makeCrossDomainMap(sp)
+      case None => CrossDomainMap.empty.asRight
     }
+
+  case class CrossDomainMap(domainMap: Map[String, Option[String]]) {
+
+    /**
+     * Gets the cross navigation parameters as self-describing JSON.
+     *
+     * @param cnMap The map of cross navigation data
+     * @return the cross navigation context wrapped in a List
+     */
+    def getCrossNavigationContext: List[SelfDescribingData[Json]] =
+      domainMap match {
+        case m: Map[String, Option[String]] if m.isEmpty => Nil
+        case _ =>
+          List(
+            SelfDescribingData(
+              CrossNavigationEnrichment.outputSchema,
+              finalizeCrossNavigationMap.asJson
+            )
+          )
+      }
+
+    def duid: Option[String] = domainMap.get(CrossDomainMap.domainUserIdFieldName).flatten
+
+    def tstamp: Option[String] = domainMap.get(CrossDomainMap.timestampFieldName).flatten
+
+    /**
+     * Finalizes the cross navigation map by reformatting its timestamp key
+     *
+     * @param inputMap A Map of cross navigation properties
+     * @return The finalized Map
+     */
+    private def finalizeCrossNavigationMap: Map[String, Option[String]] =
+      domainMap
+        .map {
+          case ("timestamp", t) => ("timestamp" -> CrossDomainMap.reformatTstamp(t))
+          case kvPair => kvPair
+        }
   }
 
-  /**
-   * Finalizes the cross navigation map by reformatting its timestamp key
-   *
-   * @param inputMap A Map of cross navigation properties
-   * @return The finalized Map
-   */
-  private def finalizeCrossNavigationMap(inputMap: Map[String, Option[String]]): Map[String, Option[String]] =
-    inputMap
-      .map({
-        case ("timestamp", t) => ("timestamp" -> reformatTstamp(t))
-        case kvPair => kvPair
-      })
-
-  /**
-   * Parses the QueryString into a Map
-   * @param sp QueryString
-   * @return either a map of query string parameters or enrichment failure
-   */
-  def makeCrossDomainMap(sp: String): Either[FailureDetails.EnrichmentFailure, Map[String, Option[String]]] =
-    sp.split("\\.", -1)
-      .padTo(
-        CrossNavProps.size,
-        ""
+  object CrossDomainMap {
+    val domainUserIdFieldName = "domain_user_id"
+    val timestampFieldName = "timestamp"
+    val CrossNavProps: List[(String, CrossNavTransformation)] =
+      List(
+        (domainUserIdFieldName, CU.makeTsvSafe(_).some.asRight),
+        (timestampFieldName, extractTstamp),
+        ("session_id", Option(_: String).filter(_.trim.nonEmpty).asRight),
+        ("user_id", decodeWithFailure),
+        ("source_id", decodeWithFailure),
+        ("source_platform", Option(_: String).filter(_.trim.nonEmpty).asRight),
+        ("reason", decodeWithFailure)
       )
-      .toList match {
-      case List(
-            duidElt,
-            tstampElt,
-            sessionIdElt,
-            userIdElt,
-            sourceIdElt,
-            sourcePlatformElt,
-            reasonElt
-          ) =>
-        for {
-          domainUserId <- CU.makeTsvSafe(duidElt).some.asRight
-          timestamp <- extractTstamp(tstampElt)
-          sessionId <- Option(sessionIdElt).filter(_.trim.nonEmpty).asRight
-          userId <- decodeWithFailure(userIdElt)
-          sourceId <- decodeWithFailure(sourceIdElt)
-          sourcePlatform <- Option(sourcePlatformElt).filter(_.trim.nonEmpty).asRight
-          reason <- decodeWithFailure(reasonElt)
-        } yield (CrossNavProps zip List(
-          domainUserId,
-          timestamp,
-          sessionId,
-          userId,
-          sourceId,
-          sourcePlatform,
-          reason
-        )).filterNot(t => t._1 != "timestamp" && t._2 == None).toMap
-      case _ => Map.empty[String, Option[String]].asRight
+
+    /**
+     * Parses the QueryString into a Map
+     * @param sp QueryString
+     * @return either a map of query string parameters or enrichment failure
+     */
+    def makeCrossDomainMap(sp: String): Either[FailureDetails.EnrichmentFailure, CrossDomainMap] = {
+      val values = sp.split("\\.", -1)
+        .padTo(
+          CrossNavProps.size,
+          ""
+        ).toList
+      val result = if (values.size == CrossNavProps.size)
+        values.zip(CrossNavProps).map {
+          case (value, (propName, f)) => f(value).map(propName -> _)
+        }.sequence
+          .map(_.filterNot { case (key, value) => key != timestampFieldName && value.isEmpty }.toMap)
+      else Map.empty[String, Option[String]].asRight
+      result.map(CrossDomainMap(_))
     }
+
+    def empty: CrossDomainMap = CrossDomainMap(Map.empty)
+
+    /**
+     * Wrapper around CU.decodeBase64Url.
+     * If passed an empty string returns Right(None).
+     *
+     * @param str The string to decode
+     * @return either the decoded string or enrichment failure
+     */
+    private def decodeWithFailure(str: String): Either[FailureDetails.EnrichmentFailure, Option[String]] =
+      CU.decodeBase64Url(str) match {
+        case Right(r) => Option(r).filter(_.trim.nonEmpty).asRight
+        case Left(msg) =>
+          FailureDetails
+            .EnrichmentFailure(
+              None,
+              FailureDetails.EnrichmentFailureMessage.Simple(msg)
+            )
+            .asLeft
+      }
+
+    /**
+     * Wrapper around EE.extractTimestamp
+     * If passed an empty string returns Right(None).
+     *
+     * @param str The string to extract the timestamp from
+     * @return either the extracted timestamp or enrichment failure
+     */
+    private def extractTstamp(str: String): Either[FailureDetails.EnrichmentFailure, Option[String]] =
+      str match {
+        case "" => None.asRight
+        case s => EE.extractTimestamp("sp_dtm", s).map(_.some)
+      }
+
+    /**
+     * Converts a timestamp to an ISO-8601 format
+     *
+     * @param tstamp The timestamp expected as output of EE.extractTimestamp
+     * @return ISO-8601 timestamp
+     */
+    private def reformatTstamp(tstamp: Option[String]): Option[String] = {
+      val pFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
+      val formatter = DateTimeFormatter.ISO_DATE_TIME
+      tstamp.map(t => formatter.format(pFormatter.parse(t)).replaceAll(" ", "T") + "Z")
+    }
+  }
 }
 
 /**
@@ -182,32 +211,12 @@ final case class CrossNavigationEnrichment(schemaKey: SchemaKey) extends Enrichm
     FailureDetails.EnrichmentInformation(schemaKey, "cross-navigation").some
 
   /**
-   * Gets the cross navigation parameters as self-describing JSON.
-   * @param cnMap The map of cross navigation data
-   * @return the cross navigation context wrapped in a List
-   */
-  def getCrossNavigationContext(cnMap: Map[String, Option[String]]): List[SelfDescribingData[Json]] =
-    cnMap match {
-      case m: Map[String, Option[String]] if m.isEmpty => Nil
-      case _ =>
-        List(
-          SelfDescribingData(
-            CrossNavigationEnrichment.outputSchema,
-            CrossNavigationEnrichment.finalizeCrossNavigationMap(cnMap).asJson
-          )
-        )
-    }
-
-  /**
    * Given an EnrichmentFailure, returns one with the cross-navigation
    *  enrichment information added.
    * @param failure The input enrichment failure
    * @return the EnrichmentFailure with cross-navigation enrichment information
    */
   def addEnrichmentInfo(failure: FailureDetails.EnrichmentFailure): FailureDetails.EnrichmentFailure =
-    failure match {
-      case FailureDetails.EnrichmentFailure(_, msg) => FailureDetails.EnrichmentFailure(enrichmentInfo, msg)
-      case _ => failure
-    }
+    failure.copy(enrichment = enrichmentInfo)
 
 }

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/EnrichmentConf.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/EnrichmentConf.scala
@@ -211,4 +211,8 @@ object EnrichmentConf {
   ) extends EnrichmentConf {
     def enrichment: YauaaEnrichment = YauaaEnrichment(cacheSize)
   }
+
+  final case class CrossNavigationConf(schemaKey: SchemaKey) extends EnrichmentConf {
+    def enrichment: CrossNavigationEnrichment = CrossNavigationEnrichment(schemaKey)
+  }
 }

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/web/PageEnrichments.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/web/PageEnrichments.scala
@@ -18,7 +18,6 @@ import java.net.URI
 
 import cats.syntax.either._
 
-import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.{CrossNavigationEnrichment => CNE}
 import com.snowplowanalytics.snowplow.badrows.FailureDetails
 
 import utils.{ConversionUtils => CU}
@@ -46,19 +45,4 @@ object PageEnrichments {
         FailureDetails.EnrichmentFailureMessage.Simple(f)
       )
     )
-
-  /**
-   * Extract the referrer domain user ID and timestamp from the "_sp={{DUID}}.{{TSTAMP}}"
-   * portion of the querystring
-   * @param qsMap The querystring parameters
-   * @return Validation boxing a pair of optional strings corresponding to the two fields
-   */
-  def parseCrossDomain(qsMap: QueryStringParameters): Either[FailureDetails.EnrichmentFailure, Map[String, Option[String]]] =
-    qsMap.toMap
-      .map { case (k, v) => (k, v.getOrElse("")) }
-      .get("_sp") match {
-      case Some("") => Map.empty[String, Option[String]].asRight
-      case Some(sp) => CNE.makeCrossDomainMap(sp)
-      case None => Map.empty[String, Option[String]].asRight
-    }
 }

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/EnrichmentManagerSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/EnrichmentManagerSpec.scala
@@ -1093,7 +1093,12 @@ class EnrichmentManagerSpec extends Specification with EitherMatchers {
           CrossNavigationEnrichment.outputSchema,
           Map(
             "domain_user_id" -> Some("abc"),
-            "timestamp" -> Some("2023-10-13T05:44:03.762Z")
+            "timestamp" -> Some("2023-10-13T05:44:03.762Z"),
+            "session_id" -> None,
+            "user_id" -> None,
+            "source_id" -> None,
+            "source_platform" -> None,
+            "reason" -> None
           ).asJson
         )
       )

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/EnrichmentManagerSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/EnrichmentManagerSpec.scala
@@ -17,11 +17,13 @@ package enrichments
 import cats.Id
 import cats.implicits._
 import cats.data.NonEmptyList
+import io.circe.Json
 import io.circe.literal._
 import io.circe.parser.{parse => jparse}
+import io.circe.syntax._
 import org.joda.time.DateTime
 import com.snowplowanalytics.snowplow.badrows._
-import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey, SchemaVer}
+import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey, SchemaVer, SelfDescribingData}
 import loaders._
 import adapters.RawEvent
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.pii.{
@@ -33,7 +35,13 @@ import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.pii.{
 import com.snowplowanalytics.snowplow.enrich.common.outputs.EnrichedEvent
 import utils.Clock._
 import utils.ConversionUtils
-import enrichments.registry.{HttpHeaderExtractorEnrichment, IabEnrichment, JavascriptScriptEnrichment, YauaaEnrichment}
+import enrichments.registry.{
+  CrossNavigationEnrichment,
+  HttpHeaderExtractorEnrichment,
+  IabEnrichment,
+  JavascriptScriptEnrichment,
+  YauaaEnrichment
+}
 import org.apache.commons.codec.digest.DigestUtils
 import org.specs2.mutable.Specification
 import org.specs2.matcher.EitherMatchers
@@ -979,6 +987,289 @@ class EnrichmentManagerSpec extends Specification with EitherMatchers {
             (derivedContextsJson must beEqualTo(expectedDerivedContexts)) and
             (ueJson must beEqualTo(expectedUnstructEvent))
         case _ => ko
+      }
+    }
+  }
+
+  "getCrossDomain" should {
+    val schemaKey = SchemaKey(
+      CrossNavigationEnrichment.supportedSchema.vendor,
+      CrossNavigationEnrichment.supportedSchema.name,
+      CrossNavigationEnrichment.supportedSchema.format,
+      SchemaVer.Full(1, 0, 0)
+    )
+
+    "do nothing if none query string parameters - crossNavigation enabled" >> {
+      val crossNavigationEnabled = Some(new CrossNavigationEnrichment(schemaKey))
+      val qsMap: Option[QueryStringParameters] = None
+      val input = new EnrichedEvent()
+      val inputState = EnrichmentManager.Accumulation(input, Nil, Nil)
+      EnrichmentManager
+        .getCrossDomain[Id](
+          qsMap,
+          crossNavigationEnabled
+        )
+        .runS(inputState) must beLike {
+        case acc: EnrichmentManager.Accumulation =>
+          val p = EnrichedEvent.toPartiallyEnrichedEvent(acc.event)
+          (p.refr_domain_userid must beEqualTo(None)) and
+            (p.refr_dvce_tstamp must beEqualTo(None)) and
+            (acc.errors must beEmpty) and
+            (acc.contexts must beEmpty)
+      }
+    }
+
+    "do nothing if none query string parameters - crossNavigation disabled" >> {
+      val crossNavigationDisabled = None
+      val qsMap: Option[QueryStringParameters] = None
+      val input = new EnrichedEvent()
+      val inputState = EnrichmentManager.Accumulation(input, Nil, Nil)
+      EnrichmentManager
+        .getCrossDomain[Id](
+          qsMap,
+          crossNavigationDisabled
+        )
+        .runS(inputState) must beLike {
+        case acc: EnrichmentManager.Accumulation =>
+          val p = EnrichedEvent.toPartiallyEnrichedEvent(acc.event)
+          (p.refr_domain_userid must beEqualTo(None)) and
+            (p.refr_dvce_tstamp must beEqualTo(None)) and
+            (acc.errors must beEmpty) and
+            (acc.contexts must beEmpty)
+      }
+    }
+
+    "do nothing if _sp is empty - crossNavigation enabled" >> {
+      val crossNavigationEnabled = Some(new CrossNavigationEnrichment(schemaKey))
+      val qsMap: Option[QueryStringParameters] = Some(List(("_sp" -> Some(""))))
+      val input = new EnrichedEvent()
+      val inputState = EnrichmentManager.Accumulation(input, Nil, Nil)
+      EnrichmentManager
+        .getCrossDomain[Id](
+          qsMap,
+          crossNavigationEnabled
+        )
+        .runS(inputState) must beLike {
+        case acc: EnrichmentManager.Accumulation =>
+          val p = EnrichedEvent.toPartiallyEnrichedEvent(acc.event)
+          (p.refr_domain_userid must beEqualTo(None)) and
+            (p.refr_dvce_tstamp must beEqualTo(None)) and
+            (acc.errors must beEmpty) and
+            (acc.contexts must beEmpty)
+      }
+    }
+
+    "do nothing if _sp is empty - crossNavigation disabled" >> {
+      val crossNavigationDisabled = None
+      val qsMap: Option[QueryStringParameters] = Some(List(("_sp" -> Some(""))))
+      val input = new EnrichedEvent()
+      val inputState = EnrichmentManager.Accumulation(input, Nil, Nil)
+      EnrichmentManager
+        .getCrossDomain[Id](
+          qsMap,
+          crossNavigationDisabled
+        )
+        .runS(inputState) must beLike {
+        case acc: EnrichmentManager.Accumulation =>
+          val p = EnrichedEvent.toPartiallyEnrichedEvent(acc.event)
+          (p.refr_domain_userid must beEqualTo(None)) and
+            (p.refr_dvce_tstamp must beEqualTo(None)) and
+            (acc.errors must beEmpty) and
+            (acc.contexts must beEmpty)
+      }
+    }
+
+    "add atomic props and ctx with original _sp format and cross navigation enabled" >> {
+      val crossNavigationEnabled = Some(new CrossNavigationEnrichment(schemaKey))
+      val qsMap: Option[QueryStringParameters] = Some(
+        List(
+          ("_sp" -> Some("abc.1697175843762"))
+        )
+      )
+      val expectedRefrDuid = Some("abc")
+      val expectedRefrTstamp = Some("2023-10-13 05:44:03.762")
+      val expectedCtx: List[SelfDescribingData[Json]] = List(
+        SelfDescribingData(
+          CrossNavigationEnrichment.outputSchema,
+          Map(
+            "domain_user_id" -> Some("abc"),
+            "timestamp" -> Some("2023-10-13T05:44:03.762Z")
+          ).asJson
+        )
+      )
+      val input = new EnrichedEvent()
+      val inputState = EnrichmentManager.Accumulation(input, Nil, Nil)
+      EnrichmentManager
+        .getCrossDomain[Id](
+          qsMap,
+          crossNavigationEnabled
+        )
+        .runS(inputState) must beLike {
+        case acc: EnrichmentManager.Accumulation =>
+          val p = EnrichedEvent.toPartiallyEnrichedEvent(acc.event)
+          (p.refr_domain_userid must beEqualTo(expectedRefrDuid)) and
+            (p.refr_dvce_tstamp must beEqualTo(expectedRefrTstamp)) and
+            (acc.errors must beEmpty) and
+            (acc.contexts must beEqualTo(expectedCtx))
+      }
+    }
+
+    "add atomic props but no ctx with original _sp format and cross navigation disabled" >> {
+      val crossNavigationDisabled = None
+      val qsMap: Option[QueryStringParameters] = Some(
+        List(
+          ("_sp" -> Some("abc.1697175843762"))
+        )
+      )
+      val expectedRefrDuid = Some("abc")
+      val expectedRefrTstamp = Some("2023-10-13 05:44:03.762")
+      val input = new EnrichedEvent()
+      val inputState = EnrichmentManager.Accumulation(input, Nil, Nil)
+      EnrichmentManager
+        .getCrossDomain[Id](
+          qsMap,
+          crossNavigationDisabled
+        )
+        .runS(inputState) must beLike {
+        case acc: EnrichmentManager.Accumulation =>
+          val p = EnrichedEvent.toPartiallyEnrichedEvent(acc.event)
+          (p.refr_domain_userid must beEqualTo(expectedRefrDuid)) and
+            (p.refr_dvce_tstamp must beEqualTo(expectedRefrTstamp)) and
+            (acc.errors must beEmpty) and
+            (acc.contexts must beEmpty)
+      }
+    }
+
+    "add atomic props and ctx with extended _sp format and cross navigation enabled" >> {
+      val crossNavigationEnabled = Some(new CrossNavigationEnrichment(schemaKey))
+      val qsMap: Option[QueryStringParameters] = Some(
+        List(
+          ("_sp" -> Some("abc.1697175843762.176ff68a-4769-4566-ad0e-3792c1c8148f.dGVzdGVy.c29tZVNvdXJjZUlk.web.dGVzdGluZ19yZWFzb24"))
+        )
+      )
+      val expectedRefrDuid = Some("abc")
+      val expectedRefrTstamp = Some("2023-10-13 05:44:03.762")
+      val expectedCtx: List[SelfDescribingData[Json]] = List(
+        SelfDescribingData(
+          CrossNavigationEnrichment.outputSchema,
+          Map(
+            "domain_user_id" -> Some("abc"),
+            "timestamp" -> Some("2023-10-13T05:44:03.762Z"),
+            "session_id" -> Some("176ff68a-4769-4566-ad0e-3792c1c8148f"),
+            "user_id" -> Some("tester"),
+            "source_id" -> Some("someSourceId"),
+            "source_platform" -> Some("web"),
+            "reason" -> Some("testing_reason")
+          ).asJson
+        )
+      )
+      val input = new EnrichedEvent()
+      val inputState = EnrichmentManager.Accumulation(input, Nil, Nil)
+      EnrichmentManager
+        .getCrossDomain[Id](
+          qsMap,
+          crossNavigationEnabled
+        )
+        .runS(inputState) must beLike {
+        case acc: EnrichmentManager.Accumulation =>
+          val p = EnrichedEvent.toPartiallyEnrichedEvent(acc.event)
+          (p.refr_domain_userid must beEqualTo(expectedRefrDuid)) and
+            (p.refr_dvce_tstamp must beEqualTo(expectedRefrTstamp)) and
+            (acc.errors must beEmpty) and
+            (acc.contexts must beEqualTo(expectedCtx))
+      }
+    }
+
+    "add atomic props but no ctx with extended _sp format and cross navigation disabled" >> {
+      val crossNavigationDisabled = None
+      val qsMap: Option[QueryStringParameters] = Some(
+        List(
+          ("_sp" -> Some("abc.1697175843762.176ff68a-4769-4566-ad0e-3792c1c8148f.dGVzdGVy.c29tZVNvdXJjZUlk.web.dGVzdGluZ19yZWFzb24"))
+        )
+      )
+      val expectedRefrDuid = Some("abc")
+      val expectedRefrTstamp = Some("2023-10-13 05:44:03.762")
+      val input = new EnrichedEvent()
+      val inputState = EnrichmentManager.Accumulation(input, Nil, Nil)
+      EnrichmentManager
+        .getCrossDomain[Id](
+          qsMap,
+          crossNavigationDisabled
+        )
+        .runS(inputState) must beLike {
+        case acc: EnrichmentManager.Accumulation =>
+          val p = EnrichedEvent.toPartiallyEnrichedEvent(acc.event)
+          (p.refr_domain_userid must beEqualTo(expectedRefrDuid)) and
+            (p.refr_dvce_tstamp must beEqualTo(expectedRefrTstamp)) and
+            (acc.errors must beEmpty) and
+            (acc.contexts must beEmpty)
+      }
+    }
+
+    "error with info if parsing failed and cross navigation is enabled" >> {
+      val crossNavigationEnabled = Some(new CrossNavigationEnrichment(schemaKey))
+      // causing a parsing failure by providing invalid tstamp
+      val qsMap: Option[QueryStringParameters] = Some(
+        List(
+          ("_sp" -> Some("abc.some_invalid_timestamp_value"))
+        )
+      )
+      val input = new EnrichedEvent()
+      val expectedFail = FailureDetails.EnrichmentFailure(
+        FailureDetails
+          .EnrichmentInformation(
+            schemaKey,
+            "cross-navigation"
+          )
+          .some,
+        FailureDetails.EnrichmentFailureMessage.InputData(
+          "sp_dtm",
+          "some_invalid_timestamp_value".some,
+          "not in the expected format: ms since epoch"
+        )
+      )
+      val inputState = EnrichmentManager.Accumulation(input, Nil, Nil)
+      EnrichmentManager
+        .getCrossDomain[Id](
+          qsMap,
+          crossNavigationEnabled
+        )
+        .runS(inputState) must beLike {
+        case acc: EnrichmentManager.Accumulation =>
+          (acc.errors must not beEmpty) and
+            (acc.errors must beEqualTo(List(expectedFail))) and
+            (acc.contexts must beEmpty)
+      }
+    }
+
+    "error without info if parsing failed and cross navigation is disabled" >> {
+      val crossNavigationDisabled = None
+      // causing a parsing failure by providing invalid tstamp
+      val qsMap: Option[QueryStringParameters] = Some(
+        List(
+          ("_sp" -> Some("abc.some_invalid_timestamp_value"))
+        )
+      )
+      val input = new EnrichedEvent()
+      val expectedFail = FailureDetails.EnrichmentFailure(
+        None,
+        FailureDetails.EnrichmentFailureMessage.InputData(
+          "sp_dtm",
+          "some_invalid_timestamp_value".some,
+          "not in the expected format: ms since epoch"
+        )
+      )
+      val inputState = EnrichmentManager.Accumulation(input, Nil, Nil)
+      EnrichmentManager
+        .getCrossDomain[Id](
+          qsMap,
+          crossNavigationDisabled
+        )
+        .runS(inputState) must beLike {
+        case acc: EnrichmentManager.Accumulation =>
+          (acc.errors must not beEmpty) and
+            (acc.errors must beEqualTo(List(expectedFail))) and
+            (acc.contexts must beEmpty)
       }
     }
   }

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/CrossNavigationEnrichmentSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/CrossNavigationEnrichmentSpec.scala
@@ -39,7 +39,12 @@ class CrossNavigationEnrichmentSpec extends Specification with EitherMatchers {
       val input = "abc.1697398398279"
       val expectedOut: Map[String, Option[String]] = Map(
         "domain_user_id" -> Some("abc"),
-        "timestamp" -> Some("2023-10-15 19:33:18.279")
+        "timestamp" -> Some("2023-10-15 19:33:18.279"),
+        "session_id" -> None,
+        "user_id" -> None,
+        "source_id" -> None,
+        "source_platform" -> None,
+        "reason" -> None
       )
       val result = CrossDomainMap.makeCrossDomainMap(input).map(_.domainMap)
       result must beEqualTo(expectedOut.asRight)
@@ -49,7 +54,12 @@ class CrossNavigationEnrichmentSpec extends Specification with EitherMatchers {
       val input = "abc"
       val expectedOut: Map[String, Option[String]] = Map(
         "domain_user_id" -> Some("abc"),
-        "timestamp" -> None
+        "timestamp" -> None,
+        "session_id" -> None,
+        "user_id" -> None,
+        "source_id" -> None,
+        "source_platform" -> None,
+        "reason" -> None
       )
       val result = CrossDomainMap.makeCrossDomainMap(input).map(_.domainMap)
       result must beEqualTo(expectedOut.asRight)
@@ -58,8 +68,13 @@ class CrossNavigationEnrichmentSpec extends Specification with EitherMatchers {
     "return expected Map on original format when missing duid" >> {
       val input = ".1697398398279"
       val expectedOut: Map[String, Option[String]] = Map(
-        "domain_user_id" -> Some(null),
-        "timestamp" -> Some("2023-10-15 19:33:18.279")
+        "domain_user_id" -> None,
+        "timestamp" -> Some("2023-10-15 19:33:18.279"),
+        "session_id" -> None,
+        "user_id" -> None,
+        "source_id" -> None,
+        "source_platform" -> None,
+        "reason" -> None
       )
       val result = CrossDomainMap.makeCrossDomainMap(input).map(_.domainMap)
       result must beEqualTo(expectedOut.asRight)
@@ -98,7 +113,7 @@ class CrossNavigationEnrichmentSpec extends Specification with EitherMatchers {
     "return expected Map on extended format when missing duid" >> {
       val input = "..176ff68a-4769-4566-ad0e-3792c1c8148f.dGVzdGVy.c29tZVNvdXJjZUlk.web.dGVzdGluZ19yZWFzb24"
       val expectedOut: Map[String, Option[String]] = Map(
-        "domain_user_id" -> Some(null),
+        "domain_user_id" -> None,
         "timestamp" -> None,
         "session_id" -> Some("176ff68a-4769-4566-ad0e-3792c1c8148f"),
         "user_id" -> Some("tester"),
@@ -115,8 +130,11 @@ class CrossNavigationEnrichmentSpec extends Specification with EitherMatchers {
       val expectedOut: Map[String, Option[String]] = Map(
         "domain_user_id" -> Some("abc"),
         "timestamp" -> Some("2023-10-13 05:44:03.762"),
+        "session_id" -> None,
         "user_id" -> Some("tester"),
-        "source_platform" -> Some("web")
+        "source_id" -> None,
+        "source_platform" -> Some("web"),
+        "reason" -> None
       )
       val result = CrossDomainMap.makeCrossDomainMap(input).map(_.domainMap)
       result must beEqualTo(expectedOut.asRight)
@@ -127,7 +145,11 @@ class CrossNavigationEnrichmentSpec extends Specification with EitherMatchers {
       val expectedOut: Map[String, Option[String]] = Map(
         "domain_user_id" -> Some("abc"),
         "timestamp" -> None,
-        "session_id" -> Some("176ff68a-4769-4566-ad0e-3792c1c8148f")
+        "session_id" -> Some("176ff68a-4769-4566-ad0e-3792c1c8148f"),
+        "user_id" -> None,
+        "source_id" -> None,
+        "source_platform" -> None,
+        "reason" -> None
       )
       val result = CrossDomainMap.makeCrossDomainMap(input).map(_.domainMap)
       result must beEqualTo(expectedOut.asRight)
@@ -137,7 +159,12 @@ class CrossNavigationEnrichmentSpec extends Specification with EitherMatchers {
       val input = "abc.1697175843762....."
       val expectedOut: Map[String, Option[String]] = Map(
         "domain_user_id" -> Some("abc"),
-        "timestamp" -> Some("2023-10-13 05:44:03.762")
+        "timestamp" -> Some("2023-10-13 05:44:03.762"),
+        "session_id" -> None,
+        "user_id" -> None,
+        "source_id" -> None,
+        "source_platform" -> None,
+        "reason" -> None
       )
       val result = CrossDomainMap.makeCrossDomainMap(input).map(_.domainMap)
       result must beEqualTo(expectedOut.asRight)
@@ -182,6 +209,24 @@ class CrossNavigationEnrichmentSpec extends Specification with EitherMatchers {
   "getCrossNavigationContext" should {
     "return Nil if input is empty Map" >> {
       val input = Map.empty[String, Option[String]]
+      val expectedOut: List[SelfDescribingData[Json]] = Nil
+      val result = CrossDomainMap(input).getCrossNavigationContext
+      result must beEqualTo(expectedOut)
+    }
+
+    "return Nil if missing domain_user_id (required)" >> {
+      val input: Map[String, Option[String]] = Map(
+        "timestamp" -> Some("2023-10-13 05:44:03.762")
+      )
+      val expectedOut: List[SelfDescribingData[Json]] = Nil
+      val result = CrossDomainMap(input).getCrossNavigationContext
+      result must beEqualTo(expectedOut)
+    }
+
+    "return Nil if missing timestamp (required)" >> {
+      val input: Map[String, Option[String]] = Map(
+        "domain_user_id" -> Some("abcd")
+      )
       val expectedOut: List[SelfDescribingData[Json]] = Nil
       val result = CrossDomainMap(input).getCrossNavigationContext
       result must beEqualTo(expectedOut)

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/CrossNavigationEnrichmentSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/CrossNavigationEnrichmentSpec.scala
@@ -1,0 +1,243 @@
+/**
+ * Copyright (c) 2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.enrich.common.enrichments.registry
+
+import cats.syntax.either._
+import cats.syntax.option._
+
+import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer, SelfDescribingData}
+import com.snowplowanalytics.snowplow.badrows._
+
+import io.circe.Json
+import io.circe.syntax._
+
+import org.specs2.mutable.Specification
+import org.specs2.matcher.EitherMatchers
+
+class CrossNavigationEnrichmentSpec extends Specification with EitherMatchers {
+  val schemaKey = SchemaKey(
+    CrossNavigationEnrichment.supportedSchema.vendor,
+    CrossNavigationEnrichment.supportedSchema.name,
+    CrossNavigationEnrichment.supportedSchema.format,
+    SchemaVer.Full(1, 0, 0)
+  )
+
+  "makeCrossDomainMap" should {
+    "return expected Map on original format" >> {
+      val input = "abc.1697398398279"
+      val expectedOut: Map[String, Option[String]] = Map(
+        "domain_user_id" -> Some("abc"),
+        "timestamp" -> Some("2023-10-15 19:33:18.279")
+      )
+      val result = CrossNavigationEnrichment.makeCrossDomainMap(input)
+      result must beEqualTo(expectedOut.asRight)
+    }
+
+    "return expected Map on original format when missing timestamp" >> {
+      val input = "abc"
+      val expectedOut: Map[String, Option[String]] = Map(
+        "domain_user_id" -> Some("abc"),
+        "timestamp" -> None
+      )
+      val result = CrossNavigationEnrichment.makeCrossDomainMap(input)
+      result must beEqualTo(expectedOut.asRight)
+    }
+
+    "return expected Map on original format when missing duid" >> {
+      val input = ".1697398398279"
+      val expectedOut: Map[String, Option[String]] = Map(
+        "domain_user_id" -> Some(null),
+        "timestamp" -> Some("2023-10-15 19:33:18.279")
+      )
+      val result = CrossNavigationEnrichment.makeCrossDomainMap(input)
+      result must beEqualTo(expectedOut.asRight)
+    }
+
+    "return expected Map on extended format" >> {
+      val input = "abc.1697175843762.176ff68a-4769-4566-ad0e-3792c1c8148f.dGVzdGVy.c29tZVNvdXJjZUlk.web.dGVzdGluZ19yZWFzb24"
+      val expectedOut: Map[String, Option[String]] = Map(
+        "domain_user_id" -> Some("abc"),
+        "timestamp" -> Some("2023-10-13 05:44:03.762"),
+        "session_id" -> Some("176ff68a-4769-4566-ad0e-3792c1c8148f"),
+        "user_id" -> Some("tester"),
+        "source_id" -> Some("someSourceId"),
+        "source_platform" -> Some("web"),
+        "reason" -> Some("testing_reason")
+      )
+      val result = CrossNavigationEnrichment.makeCrossDomainMap(input)
+      result must beEqualTo(expectedOut.asRight)
+    }
+
+    "return expected Map on extended format when missing timestamp" >> {
+      val input = "abc..176ff68a-4769-4566-ad0e-3792c1c8148f.dGVzdGVy.c29tZVNvdXJjZUlk.web.dGVzdGluZ19yZWFzb24"
+      val expectedOut: Map[String, Option[String]] = Map(
+        "domain_user_id" -> Some("abc"),
+        "timestamp" -> None,
+        "session_id" -> Some("176ff68a-4769-4566-ad0e-3792c1c8148f"),
+        "user_id" -> Some("tester"),
+        "source_id" -> Some("someSourceId"),
+        "source_platform" -> Some("web"),
+        "reason" -> Some("testing_reason")
+      )
+      val result = CrossNavigationEnrichment.makeCrossDomainMap(input)
+      result must beEqualTo(expectedOut.asRight)
+    }
+
+    "return expected Map on extended format when missing duid" >> {
+      val input = "..176ff68a-4769-4566-ad0e-3792c1c8148f.dGVzdGVy.c29tZVNvdXJjZUlk.web.dGVzdGluZ19yZWFzb24"
+      val expectedOut: Map[String, Option[String]] = Map(
+        "domain_user_id" -> Some(null),
+        "timestamp" -> None,
+        "session_id" -> Some("176ff68a-4769-4566-ad0e-3792c1c8148f"),
+        "user_id" -> Some("tester"),
+        "source_id" -> Some("someSourceId"),
+        "source_platform" -> Some("web"),
+        "reason" -> Some("testing_reason")
+      )
+      val result = CrossNavigationEnrichment.makeCrossDomainMap(input)
+      result must beEqualTo(expectedOut.asRight)
+    }
+
+    "handle variations of extended format 1" >> {
+      val input = "abc.1697175843762..dGVzdGVy..web"
+      val expectedOut: Map[String, Option[String]] = Map(
+        "domain_user_id" -> Some("abc"),
+        "timestamp" -> Some("2023-10-13 05:44:03.762"),
+        "user_id" -> Some("tester"),
+        "source_platform" -> Some("web")
+      )
+      val result = CrossNavigationEnrichment.makeCrossDomainMap(input)
+      result must beEqualTo(expectedOut.asRight)
+    }
+
+    "handle variations of extended format 2" >> {
+      val input = "abc..176ff68a-4769-4566-ad0e-3792c1c8148f.."
+      val expectedOut: Map[String, Option[String]] = Map(
+        "domain_user_id" -> Some("abc"),
+        "timestamp" -> None,
+        "session_id" -> Some("176ff68a-4769-4566-ad0e-3792c1c8148f")
+      )
+      val result = CrossNavigationEnrichment.makeCrossDomainMap(input)
+      result must beEqualTo(expectedOut.asRight)
+    }
+
+    "handle variations of extended format 3" >> {
+      val input = "abc.1697175843762....."
+      val expectedOut: Map[String, Option[String]] = Map(
+        "domain_user_id" -> Some("abc"),
+        "timestamp" -> Some("2023-10-13 05:44:03.762")
+      )
+      val result = CrossNavigationEnrichment.makeCrossDomainMap(input)
+      result must beEqualTo(expectedOut.asRight)
+    }
+
+    "return empty map on invalid format" >> {
+      val input = "abc.1697175843762.176ff68a-4769-4566-ad0e-3792c1c8148f.dGVzdGVy.c29tZVNvdXJjZUlk.web.dGVzdGluZ19yZWFzb24...foo..bar..."
+      val expectedOut = Map.empty[String, Option[String]]
+      val result = CrossNavigationEnrichment.makeCrossDomainMap(input)
+      result must beEqualTo(expectedOut.asRight)
+    }
+
+    "return failure on invalid timestamp" >> {
+      val input = "abc.not-timestamp.176ff68a-4769-4566-ad0e-3792c1c8148f."
+      val expectedOut = FailureDetails.EnrichmentFailure(
+        None,
+        FailureDetails.EnrichmentFailureMessage.InputData(
+          "sp_dtm",
+          "not-timestamp".some,
+          "not in the expected format: ms since epoch"
+        )
+      )
+      val result = CrossNavigationEnrichment.makeCrossDomainMap(input)
+      result must beEqualTo(expectedOut.asLeft)
+    }
+
+    "return failure on incompatible timestamp" >> {
+      val input = "abc.1111111111111111.176ff68a-4769-4566-ad0e-3792c1c8148f."
+      val expectedOut = FailureDetails.EnrichmentFailure(
+        None,
+        FailureDetails.EnrichmentFailureMessage.InputData(
+          "sp_dtm",
+          "1111111111111111".some,
+          "formatting as 37179-09-17 07:18:31.111 is not Redshift-compatible"
+        )
+      )
+      val result = CrossNavigationEnrichment.makeCrossDomainMap(input)
+      result must beEqualTo(expectedOut.asLeft)
+    }
+  }
+
+  "getCrossNavigationContext" should {
+    val cne = new CrossNavigationEnrichment(schemaKey)
+
+    "return Nil if input is empty Map" >> {
+      val input = Map.empty[String, Option[String]]
+      val expectedOut: List[SelfDescribingData[Json]] = Nil
+      val result = cne.getCrossNavigationContext(input)
+      result must beEqualTo(expectedOut)
+    }
+
+    "return List of SelfDescribingData" >> {
+      val input: Map[String, Option[String]] = Map(
+        "domain_user_id" -> Some("abc"),
+        "timestamp" -> Some("2023-10-13 05:44:03.762"),
+        "session_id" -> Some("176ff68a-4769-4566-ad0e-3792c1c8148f"),
+        "user_id" -> Some("tester"),
+        "source_id" -> Some("someSourceId"),
+        "source_platform" -> Some("web"),
+        "reason" -> Some("testing_reason")
+      )
+      val expectedOut: List[SelfDescribingData[Json]] = List(
+        SelfDescribingData(
+          CrossNavigationEnrichment.outputSchema,
+          Map(
+            "domain_user_id" -> Some("abc"),
+            "timestamp" -> Some("2023-10-13T05:44:03.762Z"),
+            "session_id" -> Some("176ff68a-4769-4566-ad0e-3792c1c8148f"),
+            "user_id" -> Some("tester"),
+            "source_id" -> Some("someSourceId"),
+            "source_platform" -> Some("web"),
+            "reason" -> Some("testing_reason")
+          ).asJson
+        )
+      )
+      val result = cne.getCrossNavigationContext(input)
+      result must beEqualTo(expectedOut)
+    }
+  }
+
+  "addEnrichmentInfo" should {
+    val cne = new CrossNavigationEnrichment(schemaKey)
+
+    "add the cross-navigation enrichment info" >> {
+      val input = FailureDetails.EnrichmentFailure(
+        None,
+        FailureDetails.EnrichmentFailureMessage.InputData(
+          "some_field",
+          Some("some_value"),
+          "some error message"
+        )
+      )
+      val expectedOut = FailureDetails.EnrichmentFailure(
+        FailureDetails.EnrichmentInformation(schemaKey, "cross-navigation").some,
+        FailureDetails.EnrichmentFailureMessage.InputData(
+          "some_field",
+          Some("some_value"),
+          "some error message"
+        )
+      )
+      val result = cne.addEnrichmentInfo(input)
+      result must beEqualTo(expectedOut)
+    }
+  }
+}

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/CrossNavigationEnrichmentSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/CrossNavigationEnrichmentSpec.scala
@@ -25,6 +25,8 @@ import org.specs2.mutable.Specification
 import org.specs2.matcher.EitherMatchers
 
 class CrossNavigationEnrichmentSpec extends Specification with EitherMatchers {
+  import CrossNavigationEnrichment._
+
   val schemaKey = SchemaKey(
     CrossNavigationEnrichment.supportedSchema.vendor,
     CrossNavigationEnrichment.supportedSchema.name,
@@ -39,7 +41,7 @@ class CrossNavigationEnrichmentSpec extends Specification with EitherMatchers {
         "domain_user_id" -> Some("abc"),
         "timestamp" -> Some("2023-10-15 19:33:18.279")
       )
-      val result = CrossNavigationEnrichment.makeCrossDomainMap(input)
+      val result = CrossDomainMap.makeCrossDomainMap(input).map(_.domainMap)
       result must beEqualTo(expectedOut.asRight)
     }
 
@@ -49,7 +51,7 @@ class CrossNavigationEnrichmentSpec extends Specification with EitherMatchers {
         "domain_user_id" -> Some("abc"),
         "timestamp" -> None
       )
-      val result = CrossNavigationEnrichment.makeCrossDomainMap(input)
+      val result = CrossDomainMap.makeCrossDomainMap(input).map(_.domainMap)
       result must beEqualTo(expectedOut.asRight)
     }
 
@@ -59,7 +61,7 @@ class CrossNavigationEnrichmentSpec extends Specification with EitherMatchers {
         "domain_user_id" -> Some(null),
         "timestamp" -> Some("2023-10-15 19:33:18.279")
       )
-      val result = CrossNavigationEnrichment.makeCrossDomainMap(input)
+      val result = CrossDomainMap.makeCrossDomainMap(input).map(_.domainMap)
       result must beEqualTo(expectedOut.asRight)
     }
 
@@ -74,7 +76,7 @@ class CrossNavigationEnrichmentSpec extends Specification with EitherMatchers {
         "source_platform" -> Some("web"),
         "reason" -> Some("testing_reason")
       )
-      val result = CrossNavigationEnrichment.makeCrossDomainMap(input)
+      val result = CrossDomainMap.makeCrossDomainMap(input).map(_.domainMap)
       result must beEqualTo(expectedOut.asRight)
     }
 
@@ -89,7 +91,7 @@ class CrossNavigationEnrichmentSpec extends Specification with EitherMatchers {
         "source_platform" -> Some("web"),
         "reason" -> Some("testing_reason")
       )
-      val result = CrossNavigationEnrichment.makeCrossDomainMap(input)
+      val result = CrossDomainMap.makeCrossDomainMap(input).map(_.domainMap)
       result must beEqualTo(expectedOut.asRight)
     }
 
@@ -104,7 +106,7 @@ class CrossNavigationEnrichmentSpec extends Specification with EitherMatchers {
         "source_platform" -> Some("web"),
         "reason" -> Some("testing_reason")
       )
-      val result = CrossNavigationEnrichment.makeCrossDomainMap(input)
+      val result = CrossDomainMap.makeCrossDomainMap(input).map(_.domainMap)
       result must beEqualTo(expectedOut.asRight)
     }
 
@@ -116,7 +118,7 @@ class CrossNavigationEnrichmentSpec extends Specification with EitherMatchers {
         "user_id" -> Some("tester"),
         "source_platform" -> Some("web")
       )
-      val result = CrossNavigationEnrichment.makeCrossDomainMap(input)
+      val result = CrossDomainMap.makeCrossDomainMap(input).map(_.domainMap)
       result must beEqualTo(expectedOut.asRight)
     }
 
@@ -127,7 +129,7 @@ class CrossNavigationEnrichmentSpec extends Specification with EitherMatchers {
         "timestamp" -> None,
         "session_id" -> Some("176ff68a-4769-4566-ad0e-3792c1c8148f")
       )
-      val result = CrossNavigationEnrichment.makeCrossDomainMap(input)
+      val result = CrossDomainMap.makeCrossDomainMap(input).map(_.domainMap)
       result must beEqualTo(expectedOut.asRight)
     }
 
@@ -137,14 +139,14 @@ class CrossNavigationEnrichmentSpec extends Specification with EitherMatchers {
         "domain_user_id" -> Some("abc"),
         "timestamp" -> Some("2023-10-13 05:44:03.762")
       )
-      val result = CrossNavigationEnrichment.makeCrossDomainMap(input)
+      val result = CrossDomainMap.makeCrossDomainMap(input).map(_.domainMap)
       result must beEqualTo(expectedOut.asRight)
     }
 
     "return empty map on invalid format" >> {
       val input = "abc.1697175843762.176ff68a-4769-4566-ad0e-3792c1c8148f.dGVzdGVy.c29tZVNvdXJjZUlk.web.dGVzdGluZ19yZWFzb24...foo..bar..."
       val expectedOut = Map.empty[String, Option[String]]
-      val result = CrossNavigationEnrichment.makeCrossDomainMap(input)
+      val result = CrossDomainMap.makeCrossDomainMap(input).map(_.domainMap)
       result must beEqualTo(expectedOut.asRight)
     }
 
@@ -158,7 +160,7 @@ class CrossNavigationEnrichmentSpec extends Specification with EitherMatchers {
           "not in the expected format: ms since epoch"
         )
       )
-      val result = CrossNavigationEnrichment.makeCrossDomainMap(input)
+      val result = CrossDomainMap.makeCrossDomainMap(input).map(_.domainMap)
       result must beEqualTo(expectedOut.asLeft)
     }
 
@@ -172,18 +174,16 @@ class CrossNavigationEnrichmentSpec extends Specification with EitherMatchers {
           "formatting as 37179-09-17 07:18:31.111 is not Redshift-compatible"
         )
       )
-      val result = CrossNavigationEnrichment.makeCrossDomainMap(input)
+      val result = CrossDomainMap.makeCrossDomainMap(input).map(_.domainMap)
       result must beEqualTo(expectedOut.asLeft)
     }
   }
 
   "getCrossNavigationContext" should {
-    val cne = new CrossNavigationEnrichment(schemaKey)
-
     "return Nil if input is empty Map" >> {
       val input = Map.empty[String, Option[String]]
       val expectedOut: List[SelfDescribingData[Json]] = Nil
-      val result = cne.getCrossNavigationContext(input)
+      val result = CrossDomainMap(input).getCrossNavigationContext
       result must beEqualTo(expectedOut)
     }
 
@@ -211,7 +211,7 @@ class CrossNavigationEnrichmentSpec extends Specification with EitherMatchers {
           ).asJson
         )
       )
-      val result = cne.getCrossNavigationContext(input)
+      val result = CrossDomainMap(input).getCrossNavigationContext
       result must beEqualTo(expectedOut)
     }
   }

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/EnrichmentConfigsSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/EnrichmentConfigsSpec.scala
@@ -475,4 +475,21 @@ class EnrichmentConfigsSpec extends Specification with ValidatedMatchers with Da
       result must beInvalid
     }
   }
+
+  "Parsing an cross_navigation_config JSON" should {
+    "successfully construct a CrossNavigationEnrichment" in {
+      val crossNavJson = json"""{
+        "enabled": true
+      }"""
+      val schemaKey = SchemaKey(
+        "com.snowplowanalytics.snowplow.enrichments",
+        "cross_navigation_config",
+        "jsonschema",
+        SchemaVer.Full(1, 0, 0)
+      )
+      val expected = CrossNavigationConf(schemaKey)
+      val result = CrossNavigationEnrichment.parse(crossNavJson, schemaKey, false)
+      result must beValid(expected)
+    }
+  }
 }

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/web/ParseCrossDomainSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/web/ParseCrossDomainSpec.scala
@@ -34,7 +34,9 @@ class ParseCrossDomainSpec extends Specification with DataTables {
     CrossNavigationEnrichment.parseCrossDomain(Nil).map(_.domainMap) must beRight(Map.empty[String, Option[String]])
 
   def e2 =
-    CrossNavigationEnrichment.parseCrossDomain(List(("foo" -> Some("bar")))).map(_.domainMap) must beRight(Map.empty[String, Option[String]])
+    CrossNavigationEnrichment.parseCrossDomain(List(("foo" -> Some("bar")))).map(_.domainMap) must beRight(
+      Map.empty[String, Option[String]]
+    )
 
   def e3 =
     CrossNavigationEnrichment.parseCrossDomain(List(("_sp" -> None))).map(_.domainMap) must beRight(Map.empty[String, Option[String]])
@@ -52,7 +54,9 @@ class ParseCrossDomainSpec extends Specification with DataTables {
   }
 
   def e5 =
-    CrossNavigationEnrichment.parseCrossDomain(List(("_sp" -> Some("abc")))).map(_.domainMap) must beRight(Map("domain_user_id" -> "abc".some, "timestamp" -> None))
+    CrossNavigationEnrichment.parseCrossDomain(List(("_sp" -> Some("abc")))).map(_.domainMap) must beRight(
+      Map("domain_user_id" -> "abc".some, "timestamp" -> None)
+    )
 
   def e6 =
     CrossNavigationEnrichment.parseCrossDomain(List(("_sp" -> Some("abc.1426245561368")))).map(_.domainMap) must beRight(

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/web/ParseCrossDomainSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/web/ParseCrossDomainSpec.scala
@@ -55,12 +55,28 @@ class ParseCrossDomainSpec extends Specification with DataTables {
 
   def e5 =
     CrossNavigationEnrichment.parseCrossDomain(List(("_sp" -> Some("abc")))).map(_.domainMap) must beRight(
-      Map("domain_user_id" -> "abc".some, "timestamp" -> None)
+      Map(
+        "domain_user_id" -> "abc".some,
+        "timestamp" -> None,
+        "session_id" -> None,
+        "user_id" -> None,
+        "source_id" -> None,
+        "source_platform" -> None,
+        "reason" -> None
+      )
     )
 
   def e6 =
     CrossNavigationEnrichment.parseCrossDomain(List(("_sp" -> Some("abc.1426245561368")))).map(_.domainMap) must beRight(
-      Map("domain_user_id" -> "abc".some, "timestamp" -> "2015-03-13 11:19:21.368".some)
+      Map(
+        "domain_user_id" -> "abc".some,
+        "timestamp" -> "2015-03-13 11:19:21.368".some,
+        "session_id" -> None,
+        "user_id" -> None,
+        "source_id" -> None,
+        "source_platform" -> None,
+        "reason" -> None
+      )
     )
 
   def e7 =

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/web/ParseCrossDomainSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/web/ParseCrossDomainSpec.scala
@@ -20,9 +20,9 @@ import org.specs2.matcher.DataTables
 
 class ParseCrossDomainSpec extends Specification with DataTables {
   def is = s2"""
-  parseCrossDomain should return None when the querystring is empty                             $e1
-  parseCrossDomain should return None when the querystring contains no _sp parameter            $e2
-  parseCrossDomain should return None when the querystring contains _sp parameter without value $e3
+  parseCrossDomain should return empty Map when the querystring is empty                             $e1
+  parseCrossDomain should return empty Map when the querystring contains no _sp parameter            $e2
+  parseCrossDomain should return empty Map when the querystring contains _sp parameter without value $e3
   parseCrossDomain should return a failure when the _sp timestamp is unparseable                $e4
   parseCrossDomain should successfully extract the domain user ID when available                $e5
   parseCrossDomain should successfully extract the domain user ID and timestamp when available  $e6
@@ -30,13 +30,13 @@ class ParseCrossDomainSpec extends Specification with DataTables {
   """
 
   def e1 =
-    PageEnrichments.parseCrossDomain(Nil) must beRight((None, None))
+    PageEnrichments.parseCrossDomain(Nil) must beRight(Map.empty[String, Option[String]])
 
   def e2 =
-    PageEnrichments.parseCrossDomain(List(("foo" -> Some("bar")))) must beRight((None, None))
+    PageEnrichments.parseCrossDomain(List(("foo" -> Some("bar")))) must beRight(Map.empty[String, Option[String]])
 
   def e3 =
-    PageEnrichments.parseCrossDomain(List(("_sp" -> None))) must beRight((None, None))
+    PageEnrichments.parseCrossDomain(List(("_sp" -> None))) must beRight(Map.empty[String, Option[String]])
 
   def e4 = {
     val expected = FailureDetails.EnrichmentFailure(
@@ -51,13 +51,13 @@ class ParseCrossDomainSpec extends Specification with DataTables {
   }
 
   def e5 =
-    PageEnrichments.parseCrossDomain(List(("_sp" -> Some("abc")))) must beRight(("abc".some, None))
+    PageEnrichments.parseCrossDomain(List(("_sp" -> Some("abc")))) must beRight(Map("domain_user_id" -> "abc".some, "timestamp" -> None))
 
   def e6 =
     PageEnrichments.parseCrossDomain(List(("_sp" -> Some("abc.1426245561368")))) must beRight(
-      ("abc".some, "2015-03-13 11:19:21.368".some)
+      Map("domain_user_id" -> "abc".some, "timestamp" -> "2015-03-13 11:19:21.368".some)
     )
 
   def e7 =
-    PageEnrichments.parseCrossDomain(List(("_sp" -> Some("")))) must beRight(None -> None)
+    PageEnrichments.parseCrossDomain(List(("_sp" -> Some("")))) must beRight(Map.empty[String, Option[String]])
 }

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/web/ParseCrossDomainSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/web/ParseCrossDomainSpec.scala
@@ -15,6 +15,7 @@ package enrichments.web
 
 import cats.syntax.option._
 import com.snowplowanalytics.snowplow.badrows._
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.CrossNavigationEnrichment
 import org.specs2.Specification
 import org.specs2.matcher.DataTables
 
@@ -30,13 +31,13 @@ class ParseCrossDomainSpec extends Specification with DataTables {
   """
 
   def e1 =
-    PageEnrichments.parseCrossDomain(Nil) must beRight(Map.empty[String, Option[String]])
+    CrossNavigationEnrichment.parseCrossDomain(Nil).map(_.domainMap) must beRight(Map.empty[String, Option[String]])
 
   def e2 =
-    PageEnrichments.parseCrossDomain(List(("foo" -> Some("bar")))) must beRight(Map.empty[String, Option[String]])
+    CrossNavigationEnrichment.parseCrossDomain(List(("foo" -> Some("bar")))).map(_.domainMap) must beRight(Map.empty[String, Option[String]])
 
   def e3 =
-    PageEnrichments.parseCrossDomain(List(("_sp" -> None))) must beRight(Map.empty[String, Option[String]])
+    CrossNavigationEnrichment.parseCrossDomain(List(("_sp" -> None))).map(_.domainMap) must beRight(Map.empty[String, Option[String]])
 
   def e4 = {
     val expected = FailureDetails.EnrichmentFailure(
@@ -47,17 +48,17 @@ class ParseCrossDomainSpec extends Specification with DataTables {
         "not in the expected format: ms since epoch"
       )
     )
-    PageEnrichments.parseCrossDomain(List(("_sp" -> Some("abc.not-a-timestamp")))) must beLeft(expected)
+    CrossNavigationEnrichment.parseCrossDomain(List(("_sp" -> Some("abc.not-a-timestamp")))).map(_.domainMap) must beLeft(expected)
   }
 
   def e5 =
-    PageEnrichments.parseCrossDomain(List(("_sp" -> Some("abc")))) must beRight(Map("domain_user_id" -> "abc".some, "timestamp" -> None))
+    CrossNavigationEnrichment.parseCrossDomain(List(("_sp" -> Some("abc")))).map(_.domainMap) must beRight(Map("domain_user_id" -> "abc".some, "timestamp" -> None))
 
   def e6 =
-    PageEnrichments.parseCrossDomain(List(("_sp" -> Some("abc.1426245561368")))) must beRight(
+    CrossNavigationEnrichment.parseCrossDomain(List(("_sp" -> Some("abc.1426245561368")))).map(_.domainMap) must beRight(
       Map("domain_user_id" -> "abc".some, "timestamp" -> "2015-03-13 11:19:21.368".some)
     )
 
   def e7 =
-    PageEnrichments.parseCrossDomain(List(("_sp" -> Some("")))) must beRight(Map.empty[String, Option[String]])
+    CrossNavigationEnrichment.parseCrossDomain(List(("_sp" -> Some("")))).map(_.domainMap) must beRight(Map.empty[String, Option[String]])
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Snowplow Enrich!

You'll find a small checklist below which should help speed up the review process:

- [x] Have you signed the [contributor license agreement](https://github.com/snowplow/snowplow/wiki/CLA)?
- [x] Have you read the [contributing guide](https://github.com/snowplow/enrich/blob/master/CONTRIBUTING.md)?
- [x] Have you added the appropriate unit tests?
- [x] Have you run the tests through `sbt test`?
- [x] Is your pull request against the `master` branch?
-->

This pull request adds an enrichment that can parse the extended cross navigation format in `_sp` querystring parameter and attach the `cross_navigation` context to an event.

The extended cross navigation format can be described by `_sp={domainUserId}.{timestamp}.{sessionId}.{subjectUserId}.{sourceId}.{platform}.{reason}`

The changes in the trackers to allow this extended format can be seen in:

- [Android tracker](https://github.com/snowplow/snowplow-android-tracker/pull/640) 
- [JavaScript tracker](https://github.com/snowplow/snowplow-javascript-tracker/pull/1233) 

The corresponding iglu-central pull requests are:

- [to add the `cross_navigation` context schema](https://github.com/snowplow/iglu-central/pull/1327)
- [to add the `cross_navigation_config` enrichment schema](https://github.com/snowplow/iglu-central/pull/1347)

cc @greg-el @igneel64 @matus-tomlein 
