### PR TITLE
common: update AWS SDK versions to support Pod Identity credential chain

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -69,10 +69,10 @@ object Dependencies {
     val collectorPayload = "0.0.0"
     val schemaSniffer    = "0.0.0"
 
-    val awsSdk           = "1.12.506"
+    val awsSdk           = "1.12.604"
     val gcpSdk           = "2.14.0"
     val kinesisClient    = "1.14.5"
-    val awsSdk2          = "2.18.7"
+    val awsSdk2          = "2.21.37"
     val kinesisClient2   = "2.4.3"
     val kafka            = "2.8.2"
     val mskAuth          = "1.1.4"


### PR DESCRIPTION
<!--
Thank you for contributing to Snowplow Enrich!

You'll find a small checklist below which should help speed up the review process:

- [x] Have you signed the [contributor license agreement](https://github.com/snowplow/snowplow/wiki/CLA)?
- [x] Have you read the [contributing guide](https://github.com/snowplow/enrich/blob/master/CONTRIBUTING.md)?
- [ ] Have you added the appropriate unit tests?
- [ ] Have you run the tests through `sbt test`?
- [x] Is your pull request against the `master` branch?
-->

This PR should make it possible to use Pod Identities in AWS EKS clusters.

AWS recently released the [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) capabilities, that simplify permission management for Kubernetes pods.
The v1 and v2 AWS SDKs both support the new credential chains:
* v1 since [1.12.596](https://github.com/aws/aws-sdk-java/releases/tag/1.12.596)
* v2 since [2.21.30](https://github.com/aws/aws-sdk-java-v2/releases/tag/2.21.30)



