### PR TITLE
Add different types of authentication for azure blob storage

### DIFF
--- a/config/config.kafka.extended.hocon
+++ b/config/config.kafka.extended.hocon
@@ -235,8 +235,16 @@
     # Optional. Azure blob storage client configuration.
     # ABS client won't be enabled if it isn't given.
     "azureStorage": {
-      # Azure blob storage account names
-      "storageAccountNames": ["storageAccount1", "storageAccount2"]
+      "accounts": [
+        # Example public account with no auth
+        { "name": "storageAccount1"},
+        
+        # Example private account using default auth chain -> https://learn.microsoft.com/en-us/java/api/com.azure.identity.defaultazurecredential?view=azure-java-stable
+        { "name": "storageAccount2", "auth": { "type": "default"} },
+        
+        # Example private account using SAS token auth
+        { "name": "storageAccount3",  "auth": { "type": "sas", "value": "tokenValue"}}
+      ]
     }
   }
 

--- a/config/config.nsq.extended.hocon
+++ b/config/config.nsq.extended.hocon
@@ -237,8 +237,16 @@
     # Optional. Azure blob storage client configuration.
     # ABS client won't be enabled if it isn't given.
     "azureStorage": {
-      # Azure blob storage account names
-      "storageAccountNames": ["storageAccount1", "storageAccount2"]
+      "accounts": [
+        # Example public account with no auth
+        { "name": "storageAccount1"},
+        
+        # Example private account using default auth chain -> https://learn.microsoft.com/en-us/java/api/com.azure.identity.defaultazurecredential?view=azure-java-stable
+        { "name": "storageAccount2", "auth": { "type": "default"} },
+        
+        # Example private account using SAS token auth
+        { "name": "storageAccount3",  "auth": { "type": "sas", "value": "tokenValue"}}
+      ]
     }
   }
 

--- a/modules/kafka/src/main/scala/com.snowplowanalytics.snowplow.enrich.kafka/Main.scala
+++ b/modules/kafka/src/main/scala/com.snowplowanalytics.snowplow.enrich.kafka/Main.scala
@@ -82,7 +82,7 @@ object Main extends IOApp.WithContext {
   private def createBlobStorageClient(conf: BlobStorageClientsConfig): List[Blocker => Resource[IO, Client[IO]]] = {
     val gcs = if (conf.gcs) Some((b: Blocker) => Resource.eval(GcsClient.mk[IO](b))) else None
     val aws = if (conf.s3) Some((_: Blocker) => S3Client.mk[IO]) else None
-    val azure = conf.azureStorage.map(s => (_: Blocker) => AzureStorageClient.mk[IO](s.storageAccountNames))
+    val azure = conf.azureStorage.map(s => (_: Blocker) => AzureStorageClient.mk[IO](s))
     List(gcs, aws, azure).flatten
   }
 }

--- a/modules/kafka/src/test/scala/com/snowplowanalytics/snowplow/enrich/kafka/ConfigSpec.scala
+++ b/modules/kafka/src/test/scala/com/snowplowanalytics/snowplow/enrich/kafka/ConfigSpec.scala
@@ -28,7 +28,7 @@ import cats.effect.testing.specs2.CatsIO
 import com.snowplowanalytics.snowplow.enrich.common.fs2.config.io
 import com.snowplowanalytics.snowplow.enrich.common.fs2.config.{ConfigFile, Sentry}
 import com.snowplowanalytics.snowplow.enrich.common.SpecHelpers.adaptersSchemas
-
+import com.snowplowanalytics.snowplow.enrich.common.fs2.config.io.BlobStorageClients.AzureStorage
 import org.specs2.mutable.Specification
 
 class ConfigSpec extends Specification with CatsIO {
@@ -124,7 +124,15 @@ class ConfigSpec extends Specification with CatsIO {
         io.BlobStorageClients(
           gcs = true,
           s3 = true,
-          azureStorage = Some(io.BlobStorageClients.AzureStorage(List("storageAccount1", "storageAccount2")))
+          azureStorage = Some(
+            io.BlobStorageClients.AzureStorage(
+              List(
+                AzureStorage.Account(name = "storageAccount1", auth = None),
+                AzureStorage.Account(name = "storageAccount2", auth = Some(AzureStorage.Account.Auth.DefaultCredentialsChain)),
+                AzureStorage.Account(name = "storageAccount3", auth = Some(AzureStorage.Account.Auth.SasToken("tokenValue")))
+              )
+            )
+          )
         )
       )
       ConfigFile.parse[IO](configPath.asRight).value.map(result => result must beRight(expected))

--- a/modules/nsq/src/it/scala/com/snowplowanalytics/snowplow/enrich/nsq/test/Containers.scala
+++ b/modules/nsq/src/it/scala/com/snowplowanalytics/snowplow/enrich/nsq/test/Containers.scala
@@ -32,6 +32,9 @@ import com.snowplowanalytics.snowplow.enrich.nsq.generated.BuildInfo
 
 object Containers {
 
+  //TODO Tests fail with the latest 1.3.0 version!
+  private val nsqVersion = "v1.2.1"
+  
   case class NetworkInfo(
     networkAlias: String,
     broadcastAddress: String,
@@ -135,7 +138,7 @@ object Containers {
     Resource.make (
       Sync[F].delay {
         val container = FixedHostPortGenericContainer(
-          imageName = "nsqio/nsq:latest",
+          imageName = s"nsqio/nsq:$nsqVersion",
           command = Seq(
             "/nsqlookupd",
             s"--broadcast-address=${networkInfo.broadcastAddress}",
@@ -163,7 +166,7 @@ object Containers {
     Resource.make(
       Sync[F].delay {
         val container = FixedHostPortGenericContainer(
-          imageName = "nsqio/nsq:latest",
+          imageName = s"nsqio/nsq:$nsqVersion",
           command = Seq(
             "/nsqd",
             s"--broadcast-address=${networkInfo.broadcastAddress}",
@@ -196,7 +199,7 @@ object Containers {
     Resource.make(
       Sync[F].delay {
         val container = GenericContainer(
-          dockerImage = "nsqio/nsq:latest",
+          dockerImage = s"nsqio/nsq:$nsqVersion",
           command = Seq(
             "/nsq_to_nsq",
             s"--nsqd-tcp-address=$sourceAddress",

--- a/modules/nsq/src/main/scala/com/snowplowanalytics/snowplow/enrich/nsq/Main.scala
+++ b/modules/nsq/src/main/scala/com/snowplowanalytics/snowplow/enrich/nsq/Main.scala
@@ -80,7 +80,7 @@ object Main extends IOApp.WithContext {
   private def createBlobStorageClient(conf: BlobStorageClientsConfig): List[Blocker => Resource[IO, Client[IO]]] = {
     val gcs = if (conf.gcs) Some((b: Blocker) => Resource.eval(GcsClient.mk[IO](b))) else None
     val aws = if (conf.s3) Some((_: Blocker) => S3Client.mk[IO]) else None
-    val azure = conf.azureStorage.map(s => (_: Blocker) => AzureStorageClient.mk[IO](s.storageAccountNames))
+    val azure = conf.azureStorage.map(s => (_: Blocker) => AzureStorageClient.mk[IO](s))
     List(gcs, aws, azure).flatten
   }
 }

--- a/modules/nsq/src/test/scala/com/snowplowanalytics/snowplow/enrich/nsq/ConfigSpec.scala
+++ b/modules/nsq/src/test/scala/com/snowplowanalytics/snowplow/enrich/nsq/ConfigSpec.scala
@@ -29,7 +29,7 @@ import com.snowplowanalytics.snowplow.enrich.common.fs2.config.io
 import com.snowplowanalytics.snowplow.enrich.common.fs2.config.io.BackoffPolicy
 import com.snowplowanalytics.snowplow.enrich.common.fs2.config.{ConfigFile, Sentry}
 import com.snowplowanalytics.snowplow.enrich.common.SpecHelpers.adaptersSchemas
-
+import com.snowplowanalytics.snowplow.enrich.common.fs2.config.io.BlobStorageClients.AzureStorage
 import org.specs2.mutable.Specification
 
 class ConfigSpec extends Specification with CatsIO {
@@ -136,7 +136,15 @@ class ConfigSpec extends Specification with CatsIO {
         io.BlobStorageClients(
           gcs = true,
           s3 = true,
-          azureStorage = Some(io.BlobStorageClients.AzureStorage(List("storageAccount1", "storageAccount2")))
+          azureStorage = Some(
+            io.BlobStorageClients.AzureStorage(
+              List(
+                AzureStorage.Account(name = "storageAccount1", auth = None),
+                AzureStorage.Account(name = "storageAccount2", auth = Some(AzureStorage.Account.Auth.DefaultCredentialsChain)),
+                AzureStorage.Account(name = "storageAccount3", auth = Some(AzureStorage.Account.Auth.SasToken("tokenValue")))
+              )
+            )
+          )
         )
       )
       ConfigFile.parse[IO](configPath.asRight).value.map(result => result must beRight(expected))


### PR DESCRIPTION
This PR makes azure blob storage more flexible regarding authentication methods. Now t's possible to configure multiple storage accounts (like before), but with: 

* no authentication at all. No credentials are used when accessing storage. Useful for public accounts.
* authentication using default credentials [chain](https://learn.microsoft.com/en-us/java/api/com.azure.identity.defaultazurecredential?view=azure-java-stable). That's the method Enrich used previously for all configured accounts.
* authentication using SAS token. Token is provided in configuration and NOT generated dynamically in application. 

New configuration looks like: 


```
    "azureStorage": {
      "accounts": [
        # Example public account with no auth
        { "name": "storageAccount1"},

        # Example private account using default auth chain -> https://learn.microsoft.com/en-us/java/api/com.azure.identity.defaultazurecredential?view=azure-java-stable
        { "name": "storageAccount2", "auth": { "type": "default"} },

        # Example private account using SAS token auth
        { "name": "storageAccount3",  "auth": { "type": "sas", "value": "tokenValue"}}
      ]
    }
```

Comparing to the old one:

```
    "azureStorage": {
      # Azure blob storage account names
      "storageAccountNames": ["storageAccount1", "storageAccount2"]
    }
```