### PR TITLE
Add headset to the list of valid platform codes (close #851)

### DIFF
--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/MiscEnrichments.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/MiscEnrichments.scala
@@ -58,6 +58,7 @@ object MiscEnrichments {
         case "cnsl" => "cnsl".asRight // Games Console
         case "tv" => "tv".asRight // Connected TV
         case "srv" => "srv".asRight // Server-side App
+        case "headset" => "headset".asRight // AR/VR Headset
         case _ =>
           val msg = "not recognized as a tracking platform"
           val f = FailureDetails.EnrichmentFailureMessage.InputData(

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/miscEnrichmentSpecs.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/miscEnrichmentSpecs.scala
@@ -62,6 +62,7 @@ class ExtractPlatformSpec extends Specification with DataTables {
       "valid connected TV" !! "tv" ! "tv".asRight |
       "valid games console" !! "cnsl" ! "cnsl".asRight |
       "valid iot (internet of things)" !! "iot" ! "iot".asRight |
+      "valid headset" !! "headset" ! "headset".asRight |
       "invalid empty" !! "" ! err("").asLeft |
       "invalid null" !! null ! err(null).asLeft |
       "invalid platform" !! "ma" ! err("ma").asLeft |> { (_, input, expected) =>


### PR DESCRIPTION
Issue #851 

This PR adds the `headset` platform key to the list of recognized platform keys ahead of the iOS tracker 6 with support visionOS release.