### PR TITLE
enrich-nsq: use default aws provider chain

### DIFF
--- a/modules/nsq/src/main/scala/com/snowplowanalytics/snowplow/enrich/nsq/S3Client.scala
+++ b/modules/nsq/src/main/scala/com/snowplowanalytics/snowplow/enrich/nsq/S3Client.scala
@@ -24,7 +24,7 @@ import blobstore.s3.S3Store
 
 import software.amazon.awssdk.services.s3.S3AsyncClient
 import software.amazon.awssdk.core.exception.SdkException
-import software.amazon.awssdk.regions.providers.AwsRegionProviderChain
+import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain
 import software.amazon.awssdk.regions.Region
 
 import com.snowplowanalytics.snowplow.enrich.common.fs2.io.Clients.{Client, RetryableFailure}
@@ -57,7 +57,7 @@ object S3Client {
     }
 
   private def getRegion(): Region =
-    Either.catchNonFatal(new AwsRegionProviderChain().getRegion) match {
+    Either.catchNonFatal(DefaultAwsRegionProviderChain.builder.build.getRegion) match {
       case Right(region) =>
         region
       case _ =>


### PR DESCRIPTION
Previously, enrich-nsq was using the `AwsRegionProviderChain` ([documented here](https://sdk.amazonaws.com/java/api/2.0.0/software/amazon/awssdk/regions/providers/AwsRegionProviderChain.html)) but not passing in any providers in the constructor.  This is the same as not using any provider at all, which means the s3 downloader only works in eu-central-1.

The original intention was to use AWS's default chain for resolving the region, which means it should be using the `DefaultAWsRegionProviderChain` instead ([documented here](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/regions/providers/DefaultAwsRegionProviderChain.html))