### PR TITLE
Make cookie extractor enrichment case insensitive

### DIFF
--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/CookieExtractorEnrichment.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/CookieExtractorEnrichment.scala
@@ -55,7 +55,7 @@ final case class CookieExtractorEnrichment(cookieNames: List[String]) extends En
     // rfc6265 - sections 4.2.1 and 4.2.2
     val cookies = headers.flatMap { header =>
       header.split(":", 2) match {
-        case Array("Cookie", value) =>
+        case Array(cookieStr, value) if cookieStr.toLowerCase == "cookie" =>
           val nameValuePairs =
             BasicHeaderValueParser.parseParameters(value, BasicHeaderValueParser.INSTANCE)
 

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/CookieExtractorEnrichmentSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/CookieExtractorEnrichmentSpec.scala
@@ -35,7 +35,8 @@ class CookieExtractorEnrichmentSpec extends Specification {
   }
 
   def e3 = {
-    val cookies = List("ck1", "=cv2", "ck3=", "ck4=cv4", "ck5=\"cv5\"")
+    val cookies = List("ck1", "=cv2", "ck3=")
+    val cookies2 = List("ck4=cv4", "ck5=\"cv5\"")
     val cookieKeys = List("ck1", "", "ck3", "ck4", "ck5")
 
     val expected =
@@ -63,7 +64,7 @@ class CookieExtractorEnrichmentSpec extends Specification {
       )
 
     val actual = CookieExtractorEnrichment(cookieKeys)
-      .extract(List("Cookie: " + cookies.mkString(";")))
+      .extract(List("cookie: " + cookies.mkString(";"), "Cookie:" + cookies2.mkString(";")))
 
     actual must beLike {
       case cookies @ _ :: _ :: _ :: _ :: _ :: Nil => cookies must_== expected


### PR DESCRIPTION
Previously, cookie extractor enrichment was only looking for `Cookie` header ignoring when the header has been supplied as a lower case `cookie`. This caused issues with Collector 3 that follows a case-insensitive header names.
Now, both `cookie` and `Cookie` headers are matched as containing user-agent's cookie.

1 - https://www.rfc-editor.org/rfc/rfc7230#section-3.2