### PR TITLE
Switch bad row type from EnrichmentFailures to SchemaViolations for s…

### DIFF
--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/EtlPipeline.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/EtlPipeline.scala
@@ -10,9 +10,8 @@
  */
 package com.snowplowanalytics.snowplow.enrich.common
 
-import cats.Monad
 import cats.data.{Validated, ValidatedNel}
-import cats.effect.Clock
+import cats.effect.kernel.Sync
 import cats.implicits._
 
 import org.joda.time.DateTime
@@ -56,7 +55,7 @@ object EtlPipeline {
    * @return the ValidatedMaybeCanonicalOutput. Thanks to flatMap, will include any validation
    * errors contained within the ValidatedMaybeCanonicalInput
    */
-  def processEvents[F[_]: Clock: Monad](
+  def processEvents[F[_]: Sync](
     adapterRegistry: AdapterRegistry[F],
     enrichmentRegistry: EnrichmentRegistry[F],
     client: IgluCirceClient[F],
@@ -90,11 +89,11 @@ object EtlPipeline {
                   .toValidated
               }
             case Validated.Invalid(badRow) =>
-              Monad[F].pure(List(badRow.invalid[EnrichedEvent]))
+              Sync[F].pure(List(badRow.invalid[EnrichedEvent]))
           }
       case Validated.Invalid(badRows) =>
-        Monad[F].pure(badRows.map(_.invalid[EnrichedEvent])).map(_.toList)
+        Sync[F].pure(badRows.map(_.invalid[EnrichedEvent])).map(_.toList)
       case Validated.Valid(None) =>
-        Monad[F].pure(List.empty[Validated[BadRow, EnrichedEvent]])
+        Sync[F].pure(List.empty[Validated[BadRow, EnrichedEvent]])
     }
 }

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/AtomicFieldsLengthValidator.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/AtomicFieldsLengthValidator.scala
@@ -14,14 +14,14 @@ import org.slf4j.LoggerFactory
 
 import cats.Monad
 import cats.data.Validated.{Invalid, Valid}
-import cats.data.{NonEmptyList, ValidatedNel}
+import cats.data.NonEmptyList
 
 import cats.implicits._
 
-import com.snowplowanalytics.snowplow.badrows.FailureDetails.EnrichmentFailure
-import com.snowplowanalytics.snowplow.badrows.{BadRow, FailureDetails, Processor}
+import com.snowplowanalytics.iglu.client.validator.ValidatorReport
 
-import com.snowplowanalytics.snowplow.enrich.common.adapters.RawEvent
+import com.snowplowanalytics.snowplow.badrows.FailureDetails
+
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.AtomicFields.LimitedAtomicField
 import com.snowplowanalytics.snowplow.enrich.common.outputs.EnrichedEvent
 
@@ -35,66 +35,47 @@ object AtomicFieldsLengthValidator {
 
   def validate[F[_]: Monad](
     event: EnrichedEvent,
-    rawEvent: RawEvent,
-    processor: Processor,
     acceptInvalid: Boolean,
     invalidCount: F[Unit],
     atomicFields: AtomicFields
-  ): F[Either[BadRow, Unit]] =
+  ): F[Either[FailureDetails.SchemaViolation, Unit]] =
     atomicFields.value
-      .map(validateField(event))
+      .map(field => validateField(event, field).toValidatedNel)
       .combineAll match {
       case Invalid(errors) if acceptInvalid =>
-        handleAcceptableBadRow(invalidCount, event, errors) *> Monad[F].pure(Right(()))
+        handleAcceptableErrors(invalidCount, event, errors) *> Monad[F].pure(Right(()))
       case Invalid(errors) =>
-        Monad[F].pure(buildBadRow(event, rawEvent, processor, errors).asLeft)
+        Monad[F].pure(AtomicFields.errorsToSchemaViolation(errors).asLeft)
       case Valid(()) =>
         Monad[F].pure(Right(()))
     }
 
   private def validateField(
-    event: EnrichedEvent
-  )(
+    event: EnrichedEvent,
     atomicField: LimitedAtomicField
-  ): ValidatedNel[String, Unit] = {
+  ): Either[ValidatorReport, Unit] = {
     val actualValue = atomicField.value.enrichedValueExtractor(event)
     if (actualValue != null && actualValue.length > atomicField.limit)
-      s"Field ${atomicField.value.name} longer than maximum allowed size ${atomicField.limit}".invalidNel
+      ValidatorReport(
+        s"Field is longer than maximum allowed size ${atomicField.limit}",
+        Some(atomicField.value.name),
+        Nil,
+        Some(actualValue)
+      ).asLeft
     else
-      Valid(())
+      Right(())
   }
 
-  private def buildBadRow(
-    event: EnrichedEvent,
-    rawEvent: RawEvent,
-    processor: Processor,
-    errors: NonEmptyList[String]
-  ): BadRow.EnrichmentFailures =
-    EnrichmentManager.buildEnrichmentFailuresBadRow(
-      NonEmptyList(
-        asEnrichmentFailure("Enriched event does not conform to atomic schema field's length restrictions"),
-        errors.toList.map(asEnrichmentFailure)
-      ),
-      EnrichedEvent.toPartiallyEnrichedEvent(event),
-      RawEvent.toRawEvent(rawEvent),
-      processor
-    )
-
-  private def handleAcceptableBadRow[F[_]: Monad](
+  private def handleAcceptableErrors[F[_]: Monad](
     invalidCount: F[Unit],
     event: EnrichedEvent,
-    errors: NonEmptyList[String]
+    errors: NonEmptyList[ValidatorReport]
   ): F[Unit] =
     invalidCount *>
       Monad[F].pure(
         logger.debug(
-          s"Enriched event not valid against atomic schema. Event id: ${event.event_id}. Invalid fields: ${errors.toList.mkString(",")}"
+          s"Enriched event not valid against atomic schema. Event id: ${event.event_id}. Invalid fields: ${errors.map(_.path).toList.flatten.mkString(", ")}"
         )
       )
 
-  private def asEnrichmentFailure(errorMessage: String): EnrichmentFailure =
-    EnrichmentFailure(
-      enrichment = None,
-      FailureDetails.EnrichmentFailureMessage.Simple(errorMessage)
-    )
 }

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/ClientEnrichments.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/ClientEnrichments.scala
@@ -14,7 +14,7 @@ import java.lang.{Integer => JInteger}
 
 import cats.syntax.either._
 
-import com.snowplowanalytics.snowplow.badrows._
+import com.snowplowanalytics.iglu.client.validator.ValidatorReport
 
 /**
  * Contains enrichments related to the client - where the client is the software which is using the
@@ -36,21 +36,16 @@ object ClientEnrichments {
    * @param res The packed string holding the screen dimensions
    * @return the ResolutionTuple or an error message, boxed in a Scalaz Validation
    */
-  val extractViewDimensions: (String, String) => Either[FailureDetails.EnrichmentFailure, (JInteger, JInteger)] =
+  val extractViewDimensions: (String, String) => Either[ValidatorReport, (JInteger, JInteger)] =
     (field, res) =>
       (res match {
         case ResRegex(width, height) =>
           Either
             .catchNonFatal((width.toInt: JInteger, height.toInt: JInteger))
-            .leftMap(_ => "could not be converted to java.lang.Integer s")
-        case _ => s"does not conform to regex ${ResRegex.toString}".asLeft
+            .leftMap(_ => "Could not be converted to java.lang.Integer s")
+        case _ => s"Does not conform to regex ${ResRegex.toString}".asLeft
       }).leftMap { msg =>
-        val f = FailureDetails.EnrichmentFailureMessage.InputData(
-          field,
-          Option(res),
-          msg
-        )
-        FailureDetails.EnrichmentFailure(None, f)
+        ValidatorReport(msg, Some(field), Nil, Option(res))
       }
 
 }

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/EnrichmentManager.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/EnrichmentManager.scala
@@ -17,13 +17,14 @@ import org.joda.time.DateTime
 import io.circe.Json
 import cats.{Applicative, Monad}
 import cats.data.{EitherT, NonEmptyList, OptionT, StateT}
-import cats.effect.Clock
+import cats.effect.kernel.{Clock, Sync}
 import cats.implicits._
 
 import com.snowplowanalytics.refererparser._
 
 import com.snowplowanalytics.iglu.client.IgluCirceClient
 import com.snowplowanalytics.iglu.client.resolver.registries.RegistryLookup
+import com.snowplowanalytics.iglu.client.validator.ValidatorReport
 
 import com.snowplowanalytics.iglu.core.SelfDescribingData
 import com.snowplowanalytics.iglu.core.circe.implicits._
@@ -42,6 +43,8 @@ import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.sqlquer
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.web.{PageEnrichments => WPE}
 import com.snowplowanalytics.snowplow.enrich.common.outputs.EnrichedEvent
 import com.snowplowanalytics.snowplow.enrich.common.utils.{IgluUtils, ConversionUtils => CU}
+import _root_.com.snowplowanalytics.iglu.core.SchemaKey
+import com.snowplowanalytics.iglu.core.SchemaVer
 
 object EnrichmentManager {
 
@@ -56,7 +59,7 @@ object EnrichmentManager {
    * @param invalidCount Function to increment the count of invalid events
    * @return Enriched event or bad row if a problem occured
    */
-  def enrichEvent[F[_]: Monad: Clock](
+  def enrichEvent[F[_]: Sync](
     registry: EnrichmentRegistry[F],
     client: IgluCirceClient[F],
     processor: Processor,
@@ -68,8 +71,15 @@ object EnrichmentManager {
     atomicFields: AtomicFields
   ): EitherT[F, BadRow, EnrichedEvent] =
     for {
-      enriched <- EitherT.fromEither[F](setupEnrichedEvent(raw, etlTstamp, processor))
-      extractResult <- IgluUtils.extractAndValidateInputJsons(enriched, client, raw, processor, registryLookup)
+      enriched <- EitherT.rightT[F, BadRow](new EnrichedEvent)
+      extractResult <- mapAndValidateInput(
+                         raw,
+                         enriched,
+                         etlTstamp,
+                         processor,
+                         client,
+                         registryLookup
+                       )
       _ = {
         ME.formatUnstructEvent(extractResult.unstructEvent).foreach(e => enriched.unstruct_event = e)
         ME.formatContexts(extractResult.contexts).foreach(c => enriched.contexts = c)
@@ -84,18 +94,40 @@ object EnrichmentManager {
                                featureFlags.legacyEnrichmentOrder
                              )
       _ = ME.formatContexts(enrichmentsContexts ::: extractResult.validationInfoContexts).foreach(c => enriched.derived_contexts = c)
-      _ <- IgluUtils
-             .validateEnrichmentsContexts[F](client, enrichmentsContexts, raw, processor, enriched, registryLookup)
-      _ <- EitherT.rightT[F, BadRow](
-             anonIp(enriched, registry.anonIp).foreach(enriched.user_ipaddress = _)
+      _ <- validateEnriched(
+             enriched,
+             raw,
+             enrichmentsContexts,
+             client,
+             processor,
+             registryLookup,
+             featureFlags.acceptInvalid,
+             invalidCount,
+             atomicFields
            )
-      _ <- EitherT.rightT[F, BadRow] {
-             piiTransform(enriched, registry.piiPseudonymizer).foreach { pii =>
-               enriched.pii = pii.asString
-             }
-           }
-      _ <- validateEnriched(enriched, raw, processor, featureFlags.acceptInvalid, invalidCount, atomicFields)
     } yield enriched
+
+  private def mapAndValidateInput[F[_]: Sync](
+    raw: RawEvent,
+    enrichedEvent: EnrichedEvent,
+    etlTstamp: DateTime,
+    processor: Processor,
+    client: IgluCirceClient[F],
+    registryLookup: RegistryLookup[F]
+  ): EitherT[F, BadRow, IgluUtils.EventExtractResult] =
+    EitherT {
+      for {
+        setup <- setupEnrichedEvent[F](raw, enrichedEvent, etlTstamp, processor).map(_.toValidatedNel)
+        iglu <- IgluUtils.extractAndValidateInputJsons(enrichedEvent, client, registryLookup)
+      } yield (iglu <* setup).leftMap { violations =>
+        buildSchemaViolationsBadRow(
+          violations,
+          EnrichedEvent.toPartiallyEnrichedEvent(enrichedEvent),
+          RawEvent.toRawEvent(raw),
+          processor
+        )
+      }.toEither
+    }
 
   /**
    * Run all the enrichments and aggregate the errors if any
@@ -112,7 +144,7 @@ object EnrichmentManager {
     inputContexts: List[SelfDescribingData[Json]],
     unstructEvent: Option[SelfDescribingData[Json]],
     legacyOrder: Boolean
-  ): EitherT[F, BadRow.EnrichmentFailures, List[SelfDescribingData[Json]]] =
+  ): EitherT[F, BadRow, List[SelfDescribingData[Json]]] =
     EitherT {
       accState(registry, raw, inputContexts, unstructEvent, legacyOrder)
         .runS(Accumulation(enriched, Nil, Nil))
@@ -130,6 +162,31 @@ object EnrichmentManager {
                 contexts.asRight
             }
         }
+    }
+
+  private def validateEnriched[F[_]: Clock: Monad](
+    enriched: EnrichedEvent,
+    raw: RawEvent,
+    enrichmentsContexts: List[SelfDescribingData[Json]],
+    client: IgluCirceClient[F],
+    processor: Processor,
+    registryLookup: RegistryLookup[F],
+    acceptInvalid: Boolean,
+    invalidCount: F[Unit],
+    atomicFields: AtomicFields
+  ): EitherT[F, BadRow, Unit] =
+    EitherT {
+      for {
+        atomic <- AtomicFieldsLengthValidator.validate[F](enriched, acceptInvalid, invalidCount, atomicFields).map(_.toValidatedNel)
+        contexts <- IgluUtils.validateEnrichmentsContexts[F](client, enrichmentsContexts, registryLookup)
+      } yield (atomic |+| contexts).void.leftMap { violations =>
+        buildSchemaViolationsBadRow(
+          violations,
+          EnrichedEvent.toPartiallyEnrichedEvent(enriched),
+          RawEvent.toRawEvent(raw),
+          processor
+        )
+      }.toEither
     }
 
   private[enrichments] case class Accumulation(
@@ -217,6 +274,8 @@ object EnrichmentManager {
         _       <- geoLocation[F](registry.ipLookups)                                 // Execute IP lookup enrichment
         _       <- sqlContexts                                                        // Derive some contexts with custom SQL Query enrichment
         _       <- apiContexts                                                        // Derive some contexts with custom API Request enrichment
+        _       <- anonIp[F](registry.anonIp)                                         // Anonymize the IP
+        _       <- piiTransform[F](registry.piiPseudonymizer)                         // Run PII pseudonymization
         // format: on
       } yield ()
     else
@@ -243,48 +302,43 @@ object EnrichmentManager {
         _       <- registry.javascriptScript.traverse(getJsScript[F](_))              // Execute the JavaScript scripting enrichment
         _       <- sqlContexts                                                        // Derive some contexts with custom SQL Query enrichment
         _       <- apiContexts                                                        // Derive some contexts with custom API Request enrichment
+        _       <- anonIp[F](registry.anonIp)                                         // Anonymize the IP
+        _       <- piiTransform[F](registry.piiPseudonymizer)                         // Run PII pseudonymization
         // format: on
       } yield ()
 
   }
 
-  /** Create the mutable [[EnrichedEvent]] and initialize it. */
-  private def setupEnrichedEvent(
+  /** Initialize the mutable [[EnrichedEvent]]. */
+  private def setupEnrichedEvent[F[_]: Sync](
     raw: RawEvent,
+    e: EnrichedEvent,
     etlTstamp: DateTime,
     processor: Processor
-  ): Either[BadRow.EnrichmentFailures, EnrichedEvent] = {
-    val e = new EnrichedEvent()
-    e.event_id = EE.generateEventId() // May be updated later if we have an `eid` parameter
-    e.v_collector = raw.source.name // May be updated later if we have a `cv` parameter
-    e.v_etl = ME.etlVersion(processor)
-    e.etl_tstamp = EE.toTimestamp(etlTstamp)
-    e.network_userid = raw.context.userId.map(_.toString).orNull // May be updated later by 'nuid'
-    e.user_ipaddress = ME
-      .extractIp("user_ipaddress", raw.context.ipAddress.orNull)
-      .toOption
-      .orNull // May be updated later by 'ip'
-    // May be updated later if we have a `ua` parameter
-    setUseragent(e, raw.context.useragent)
-    // Validate that the collectorTstamp exists and is Redshift-compatible
-    val collectorTstamp = setCollectorTstamp(e, raw.context.timestamp).toValidatedNel
-    // Map/validate/transform input fields to enriched event fields
-    val transformed = Transform.transform(raw, e)
+  ): F[Either[FailureDetails.SchemaViolation, Unit]] =
+    Sync[F].delay {
+      e.event_id = EE.generateEventId() // May be updated later if we have an `eid` parameter
+      e.v_collector = raw.source.name // May be updated later if we have a `cv` parameter
+      e.v_etl = ME.etlVersion(processor)
+      e.etl_tstamp = EE.toTimestamp(etlTstamp)
+      e.network_userid = raw.context.userId.map(_.toString).orNull // May be updated later by 'nuid'
+      e.user_ipaddress = ME
+        .extractIp("user_ipaddress", raw.context.ipAddress.orNull)
+        .toOption
+        .orNull // May be updated later by 'ip'
+      // May be updated later if we have a `ua` parameter
+      setUseragent(e, raw.context.useragent)
+      // Validate that the collectorTstamp exists and is Redshift-compatible
+      val collectorTstamp = setCollectorTstamp(e, raw.context.timestamp).toValidatedNel
+      // Map/validate/transform input fields to enriched event fields
+      val transformed = Transform.transform(raw, e)
 
-    (collectorTstamp |+| transformed)
-      .leftMap { enrichmentFailures =>
-        EnrichmentManager.buildEnrichmentFailuresBadRow(
-          enrichmentFailures,
-          EnrichedEvent.toPartiallyEnrichedEvent(e),
-          RawEvent.toRawEvent(raw),
-          processor
-        )
-      }
-      .as(e)
-      .toEither
-  }
+      (collectorTstamp |+| transformed)
+        .leftMap(AtomicFields.errorsToSchemaViolation)
+        .toEither
+    }
 
-  def setCollectorTstamp(event: EnrichedEvent, timestamp: Option[DateTime]): Either[FailureDetails.EnrichmentFailure, Unit] =
+  def setCollectorTstamp(event: EnrichedEvent, timestamp: Option[DateTime]): Either[ValidatorReport, Unit] =
     EE.formatCollectorTstamp(timestamp).map { t =>
       event.collector_tstamp = t
       ().asRight
@@ -418,12 +472,21 @@ object EnrichmentManager {
         result.sequence.bimap(NonEmptyList.one(_), _.toList)
     }
 
-  def anonIp(event: EnrichedEvent, anonIp: Option[AnonIpEnrichment]): Option[String] =
-    Option(event.user_ipaddress).map { ip =>
-      anonIp match {
-        case Some(anon) => anon.anonymizeIp(ip)
-        case None => ip
-      }
+  def anonIp[F[_]: Applicative](anonIp: Option[AnonIpEnrichment]): EStateT[F, Unit] =
+    EStateT.fromEither {
+      case (event, _) =>
+        anonIp match {
+          case Some(anon) =>
+            Option(event.user_ipaddress) match {
+              case Some(ip) =>
+                Option(anon.anonymizeIp(ip)).foreach(event.user_ipaddress = _)
+                Nil.asRight
+              case None =>
+                Nil.asRight
+            }
+          case None =>
+            Nil.asRight
+        }
     }
 
   def getUaUtils[F[_]: Applicative](userAgentUtils: Option[UserAgentUtilsEnrichment]): EStateT[F, Unit] =
@@ -481,10 +544,14 @@ object EnrichmentManager {
             event.base_currency = currency.baseCurrency.getCode
             // Note that jBigDecimalToDouble is applied to either-valid-or-null event POJO
             // properties, so we don't expect any of these four vals to be a Failure
-            val trTax = CU.jBigDecimalToDouble("tr_tx", event.tr_tax).toValidatedNel
-            val tiPrice = CU.jBigDecimalToDouble("ti_pr", event.ti_price).toValidatedNel
-            val trTotal = CU.jBigDecimalToDouble("tr_tt", event.tr_total).toValidatedNel
-            val trShipping = CU.jBigDecimalToDouble("tr_sh", event.tr_shipping).toValidatedNel
+            val enrichmentInfo = FailureDetails.EnrichmentInformation(
+              SchemaKey("com.snowplowanalytics.snowplow", "currency_conversion_config", "jsonschema", SchemaVer.Full(1, 0, 0)),
+              "currency_conversion"
+            )
+            val trTax = CU.jBigDecimalToDouble("tr_tx", event.tr_tax, enrichmentInfo).toValidatedNel
+            val tiPrice = CU.jBigDecimalToDouble("ti_pr", event.ti_price, enrichmentInfo).toValidatedNel
+            val trTotal = CU.jBigDecimalToDouble("tr_tt", event.tr_total, enrichmentInfo).toValidatedNel
+            val trShipping = CU.jBigDecimalToDouble("tr_sh", event.tr_shipping, enrichmentInfo).toValidatedNel
             EitherT(
               (trTotal, trTax, trShipping, tiPrice)
                 .mapN {
@@ -745,11 +812,31 @@ object EnrichmentManager {
         }
     }
 
-  def piiTransform(event: EnrichedEvent, piiPseudonymizer: Option[PiiPseudonymizerEnrichment]): Option[SelfDescribingData[Json]] =
-    piiPseudonymizer.flatMap(_.transformer(event))
+  def piiTransform[F[_]: Applicative](piiPseudonymizer: Option[PiiPseudonymizerEnrichment]): EStateT[F, Unit] =
+    EStateT.fromEither {
+      case (event, _) =>
+        piiPseudonymizer match {
+          case Some(pseudonymizer) =>
+            pseudonymizer.transformer(event).foreach(p => event.pii = p.asString)
+            Nil.asRight
+          case None =>
+            Nil.asRight
+        }
+    }
 
-  /** Build `BadRow.EnrichmentFailures` from a list of `FailureDetails.EnrichmentFailure`s */
-  def buildEnrichmentFailuresBadRow(
+  private def buildSchemaViolationsBadRow(
+    vs: NonEmptyList[FailureDetails.SchemaViolation],
+    pee: Payload.PartiallyEnrichedEvent,
+    re: Payload.RawEvent,
+    processor: Processor
+  ): BadRow.SchemaViolations =
+    BadRow.SchemaViolations(
+      processor,
+      Failure.SchemaViolations(Instant.now(), vs),
+      Payload.EnrichmentPayload(pee, re)
+    )
+
+  private def buildEnrichmentFailuresBadRow(
     fs: NonEmptyList[FailureDetails.EnrichmentFailure],
     pee: Payload.PartiallyEnrichedEvent,
     re: Payload.RawEvent,
@@ -761,21 +848,4 @@ object EnrichmentManager {
       Payload.EnrichmentPayload(pee, re)
     )
 
-  /**
-   * Validates enriched events against atomic schema.
-   * For now it's possible to accept enriched events that are not valid.
-   * See https://github.com/snowplow/enrich/issues/517#issuecomment-1033910690
-   */
-  private def validateEnriched[F[_]: Monad](
-    enriched: EnrichedEvent,
-    raw: RawEvent,
-    processor: Processor,
-    acceptInvalid: Boolean,
-    invalidCount: F[Unit],
-    atomicFields: AtomicFields
-  ): EitherT[F, BadRow, Unit] =
-    EitherT {
-      //We're using static field's length validation. See more in https://github.com/snowplow/enrich/issues/608
-      AtomicFieldsLengthValidator.validate[F](enriched, raw, processor, acceptInvalid, invalidCount, atomicFields)
-    }
 }

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/EventEnrichments.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/EventEnrichments.scala
@@ -19,6 +19,8 @@ import cats.syntax.option._
 import org.joda.time.{DateTime, DateTimeZone, Period}
 import org.joda.time.format.DateTimeFormat
 
+import com.snowplowanalytics.iglu.client.validator.ValidatorReport
+
 import com.snowplowanalytics.snowplow.badrows._
 
 /** Holds the enrichments related to events. */
@@ -47,22 +49,17 @@ object EventEnrichments {
    * @param Optional collectorTstamp
    * @return Validation boxing the result of making the timestamp Redshift-compatible
    */
-  def formatCollectorTstamp(collectorTstamp: Option[DateTime]): Either[FailureDetails.EnrichmentFailure, String] =
-    (collectorTstamp match {
-      case None =>
-        FailureDetails.EnrichmentFailureMessage
-          .InputData("collector_tstamp", None, "should be set")
-          .asLeft
+  def formatCollectorTstamp(collectorTstamp: Option[DateTime]): Either[ValidatorReport, String] =
+    collectorTstamp match {
+      case None => ValidatorReport("Field not set", Some("collector_tstamp"), Nil, None).asLeft
       case Some(t) =>
         val formattedTimestamp = toTimestamp(t)
         if (formattedTimestamp.startsWith("-") || t.getYear > 9999 || t.getYear < 0) {
-          val msg = s"formatted as $formattedTimestamp is not Redshift-compatible"
-          FailureDetails.EnrichmentFailureMessage
-            .InputData("collector_tstamp", t.toString.some, msg)
-            .asLeft
+          val msg = s"Formatted as $formattedTimestamp is not Redshift-compatible"
+          ValidatorReport(msg, Some("collector_tstamp"), Nil, Some(t.toString)).asLeft
         } else
           formattedTimestamp.asRight
-    }).leftMap(FailureDetails.EnrichmentFailure(None, _))
+    }
 
   /**
    * Calculate the derived timestamp
@@ -103,7 +100,7 @@ object EventEnrichments {
               .EnrichmentFailure(
                 None,
                 FailureDetails.EnrichmentFailureMessage.Simple(
-                  s"exception calculating derived timestamp: ${e.getMessage}"
+                  s"Exception calculating derived timestamp: ${e.getMessage}"
                 )
               )
               .asLeft
@@ -116,30 +113,28 @@ object EventEnrichments {
    * @param tstamp The timestamp as stored in the Tracker Protocol
    * @return a Tuple of two Strings (date and time), or an error message if the format was invalid
    */
-  val extractTimestamp: (String, String) => Either[FailureDetails.EnrichmentFailure, String] =
+  val extractTimestamp: (String, String) => Either[ValidatorReport, String] =
     (field, tstamp) =>
       try {
         val dt = new DateTime(tstamp.toLong)
         val timestampString = toTimestamp(dt)
-        if (timestampString.startsWith("-") || dt.getYear > 9999 || dt.getYear < 0) {
-          val msg = s"formatting as $timestampString is not Redshift-compatible"
-          val f = FailureDetails.EnrichmentFailureMessage.InputData(
-            field,
-            Option(tstamp),
-            msg
-          )
-          FailureDetails.EnrichmentFailure(None, f).asLeft
-        } else
+        if (timestampString.startsWith("-") || dt.getYear > 9999 || dt.getYear < 0)
+          ValidatorReport(
+            s"Formatting as $timestampString is not Redshift-compatible",
+            Some(field),
+            Nil,
+            Option(tstamp)
+          ).asLeft
+        else
           timestampString.asRight
       } catch {
         case _: NumberFormatException =>
-          val msg = "not in the expected format: ms since epoch"
-          val f = FailureDetails.EnrichmentFailureMessage.InputData(
-            field,
-            Option(tstamp),
-            msg
-          )
-          FailureDetails.EnrichmentFailure(None, f).asLeft
+          ValidatorReport(
+            "Not in the expected format: ms since epoch",
+            Some(field),
+            Nil,
+            Option(tstamp)
+          ).asLeft
       }
 
   /**
@@ -149,7 +144,7 @@ object EventEnrichments {
    * @param eventCode The event code
    * @return the event type, or an error message if not recognised, boxed in a Scalaz Validation
    */
-  val extractEventType: (String, String) => Either[FailureDetails.EnrichmentFailure, String] =
+  val extractEventType: (String, String) => Either[ValidatorReport, String] =
     (field, code) =>
       code match {
         case "se" => "struct".asRight
@@ -161,13 +156,8 @@ object EventEnrichments {
         case "pv" => "page_view".asRight
         case "pp" => "page_ping".asRight
         case _ =>
-          val msg = "not recognized as an event type"
-          val f = FailureDetails.EnrichmentFailureMessage.InputData(
-            field,
-            Option(code),
-            msg
-          )
-          FailureDetails.EnrichmentFailure(None, f).asLeft
+          val msg = "Not a valid event type"
+          ValidatorReport(msg, Some(field), Nil, Option(code)).asLeft
       }
 
   /**

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/MiscEnrichments.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/MiscEnrichments.scala
@@ -14,7 +14,9 @@ import cats.syntax.either._
 
 import io.circe._
 
-import com.snowplowanalytics.snowplow.badrows.{FailureDetails, Processor}
+import com.snowplowanalytics.snowplow.badrows.Processor
+
+import com.snowplowanalytics.iglu.client.validator.ValidatorReport
 
 import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer, SelfDescribingData}
 import com.snowplowanalytics.iglu.core.circe.implicits._
@@ -44,7 +46,7 @@ object MiscEnrichments {
    * @param platform The code for the platform generating this event.
    * @return a Scalaz ValidatedString.
    */
-  val extractPlatform: (String, String) => Either[FailureDetails.EnrichmentFailure, String] =
+  val extractPlatform: (String, String) => Either[ValidatorReport, String] =
     (field, platform) =>
       platform match {
         case "web" => "web".asRight // Web, including Mobile Web
@@ -57,17 +59,12 @@ object MiscEnrichments {
         case "srv" => "srv".asRight // Server-side App
         case "headset" => "headset".asRight // AR/VR Headset
         case _ =>
-          val msg = "not recognized as a tracking platform"
-          val f = FailureDetails.EnrichmentFailureMessage.InputData(
-            field,
-            Option(platform),
-            msg
-          )
-          FailureDetails.EnrichmentFailure(None, f).asLeft
+          val msg = "Not a valid platform"
+          ValidatorReport(msg, Some(field), Nil, Option(platform)).asLeft
       }
 
   /** Make a String TSV safe */
-  val toTsvSafe: (String, String) => Either[FailureDetails.EnrichmentFailure, String] =
+  val toTsvSafe: (String, String) => Either[ValidatorReport, String] =
     (_, value) => CU.makeTsvSafe(value).asRight
 
   /**
@@ -76,7 +73,7 @@ object MiscEnrichments {
    * Here we retrieve the first one as it is supposed to be the client one, c.f.
    * https://en.m.wikipedia.org/wiki/X-Forwarded-For#Format
    */
-  val extractIp: (String, String) => Either[FailureDetails.EnrichmentFailure, String] =
+  val extractIp: (String, String) => Either[ValidatorReport, String] =
     (_, value) => {
       val lastIp = Option(value).map(_.split("[,|, ]").head).orNull
       CU.makeTsvSafe(lastIp).asRight

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/Transform.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/Transform.scala
@@ -13,7 +13,7 @@ package com.snowplowanalytics.snowplow.enrich.common.enrichments
 import cats.implicits._
 import cats.data.ValidatedNel
 
-import com.snowplowanalytics.snowplow.badrows._
+import com.snowplowanalytics.iglu.client.validator.ValidatorReport
 
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.{EventEnrichments => EE}
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.{MiscEnrichments => ME}
@@ -31,7 +31,7 @@ object Transform {
    * to "user_ipaddress" in the enriched event
    * @param enriched /!\ MUTABLE enriched event, mutated IN-PLACE /!\
    */
-  private[enrichments] def transform(raw: RawEvent, enriched: EnrichedEvent): ValidatedNel[FailureDetails.EnrichmentFailure, Unit] = {
+  private[enrichments] def transform(raw: RawEvent, enriched: EnrichedEvent): ValidatedNel[ValidatorReport, Unit] = {
     val sourceMap: SourceMap = raw.parameters.collect { case (k, Some(v)) => (k, v) }
     val firstPassTransform = enriched.transform(sourceMap, firstPassTransformMap)
     val secondPassTransform = enriched.transform(sourceMap, secondPassTransformMap)

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/CrossNavigationEnrichment.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/CrossNavigationEnrichment.scala
@@ -192,7 +192,17 @@ object CrossNavigationEnrichment extends ParseableEnrichment {
     private def extractTstamp(str: String): Either[FailureDetails.EnrichmentFailure, Option[String]] =
       str match {
         case "" => None.asRight
-        case s => EE.extractTimestamp("sp_dtm", s).map(_.some)
+        case s =>
+          EE.extractTimestamp("sp_dtm", s)
+            .leftMap { error =>
+              val f = FailureDetails.EnrichmentFailureMessage.InputData(
+                error.path.getOrElse(""),
+                error.keyword,
+                error.message
+              )
+              FailureDetails.EnrichmentFailure(None, f)
+            }
+            .map(_.some)
       }
 
     /**

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/utils/JsonUtils.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/utils/JsonUtils.scala
@@ -20,7 +20,7 @@ import io.circe.Json
 import org.joda.time.{DateTime, DateTimeZone}
 import org.joda.time.format.{DateTimeFormat, DateTimeFormatter}
 
-import com.snowplowanalytics.snowplow.badrows.FailureDetails
+import com.snowplowanalytics.iglu.client.validator.ValidatorReport
 
 /** Contains general purpose extractors and other utilities for JSONs. Jackson-based. */
 object JsonUtils {
@@ -32,29 +32,21 @@ object JsonUtils {
     DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(DateTimeZone.UTC)
 
   /** Validates a String as correct JSON. */
-  val extractUnencJson: (String, String) => Either[FailureDetails.EnrichmentFailure, String] =
+  val extractUnencJson: (String, String) => Either[ValidatorReport, String] =
     (field, str) =>
       validateAndReformatJson(str)
         .leftMap { e =>
-          FailureDetails.EnrichmentFailure(
-            None,
-            FailureDetails.EnrichmentFailureMessage
-              .InputData(field, Option(str), e)
-          )
+          ValidatorReport(e, Some(field), Nil, Option(str))
         }
 
   /** Decodes a Base64 (URL safe)-encoded String then validates it as correct JSON. */
-  val extractBase64EncJson: (String, String) => Either[FailureDetails.EnrichmentFailure, String] =
+  val extractBase64EncJson: (String, String) => Either[ValidatorReport, String] =
     (field, str) =>
       ConversionUtils
         .decodeBase64Url(str)
         .flatMap(validateAndReformatJson)
         .leftMap { e =>
-          FailureDetails.EnrichmentFailure(
-            None,
-            FailureDetails.EnrichmentFailureMessage
-              .InputData(field, Option(str), e)
-          )
+          ValidatorReport(e, Some(field), Nil, Option(str))
         }
 
   /**

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/clientEnrichmentSpecs.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/clientEnrichmentSpecs.scala
@@ -14,31 +14,16 @@ import cats.syntax.either._
 import org.specs2.Specification
 import org.specs2.matcher.DataTables
 
-import com.snowplowanalytics.snowplow.badrows._
+import com.snowplowanalytics.iglu.client.validator.ValidatorReport
 
 class ExtractViewDimensionsSpec extends Specification with DataTables {
 
   val FieldName = "res"
-  def err: String => FailureDetails.EnrichmentFailure =
-    input =>
-      FailureDetails.EnrichmentFailure(
-        None,
-        FailureDetails.EnrichmentFailureMessage.InputData(
-          FieldName,
-          Option(input),
-          """does not conform to regex (\d+)x(\d+)"""
-        )
-      )
-  def err2: String => FailureDetails.EnrichmentFailure =
-    input =>
-      FailureDetails.EnrichmentFailure(
-        None,
-        FailureDetails.EnrichmentFailureMessage.InputData(
-          FieldName,
-          Option(input),
-          "could not be converted to java.lang.Integer s"
-        )
-      )
+  def err: String => ValidatorReport =
+    input => ValidatorReport("""Does not conform to regex (\d+)x(\d+)""", Some(FieldName), Nil, Option(input))
+
+  def err2: String => ValidatorReport =
+    input => ValidatorReport("Could not be converted to java.lang.Integer s", Some(FieldName), Nil, Option(input))
 
   def is = s2"""
   Extracting screen dimensions (viewports, screen resolution etc) with extractViewDimensions should work $e1"""

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/miscEnrichmentSpecs.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/miscEnrichmentSpecs.scala
@@ -18,7 +18,9 @@ import org.specs2.mutable.{Specification => MutSpecification}
 import org.specs2.Specification
 import org.specs2.matcher.DataTables
 
-import com.snowplowanalytics.snowplow.badrows.{FailureDetails, Processor}
+import com.snowplowanalytics.snowplow.badrows.Processor
+
+import com.snowplowanalytics.iglu.client.validator.ValidatorReport
 
 import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer, SelfDescribingData}
 
@@ -35,16 +37,8 @@ class EtlVersionSpec extends MutSpecification {
 /** Tests the extractPlatform function. Uses DataTables. */
 class ExtractPlatformSpec extends Specification with DataTables {
   val FieldName = "p"
-  def err: String => FailureDetails.EnrichmentFailure =
-    input =>
-      FailureDetails.EnrichmentFailure(
-        None,
-        FailureDetails.EnrichmentFailureMessage.InputData(
-          FieldName,
-          Option(input),
-          "not recognized as a tracking platform"
-        )
-      )
+  def err: String => ValidatorReport =
+    input => ValidatorReport("Not a valid platform", Some(FieldName), Nil, Option(input))
 
   def is = s2"""
   Extracting platforms with extractPlatform should work $e1

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/CrossNavigationEnrichmentSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/CrossNavigationEnrichmentSpec.scala
@@ -182,7 +182,7 @@ class CrossNavigationEnrichmentSpec extends Specification with EitherMatchers {
         FailureDetails.EnrichmentFailureMessage.InputData(
           "sp_dtm",
           "not-timestamp".some,
-          "not in the expected format: ms since epoch"
+          "Not in the expected format: ms since epoch"
         )
       )
       val result = CrossDomainMap.makeCrossDomainMap(input).map(_.domainMap)
@@ -196,7 +196,7 @@ class CrossNavigationEnrichmentSpec extends Specification with EitherMatchers {
         FailureDetails.EnrichmentFailureMessage.InputData(
           "sp_dtm",
           "1111111111111111".some,
-          "formatting as 37179-09-17 07:18:31.111 is not Redshift-compatible"
+          "Formatting as 37179-09-17 07:18:31.111 is not Redshift-compatible"
         )
       )
       val result = CrossDomainMap.makeCrossDomainMap(input).map(_.domainMap)

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/web/ParseCrossDomainSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/web/ParseCrossDomainSpec.scala
@@ -46,7 +46,7 @@ class ParseCrossDomainSpec extends Specification with DataTables {
       FailureDetails.EnrichmentFailureMessage.InputData(
         "sp_dtm",
         "not-a-timestamp".some,
-        "not in the expected format: ms since epoch"
+        "Not in the expected format: ms since epoch"
       )
     )
     CrossNavigationEnrichment.parseCrossDomain(List(("_sp" -> Some("abc.not-a-timestamp")))).map(_.domainMap) must beLeft(expected)

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/utils/MapTransformerSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/utils/MapTransformerSpec.scala
@@ -18,7 +18,7 @@ import org.apache.commons.lang3.builder.HashCodeBuilder
 import org.specs2.matcher.ValidatedMatchers
 import org.specs2.mutable.Specification
 
-import com.snowplowanalytics.snowplow.badrows._
+import com.snowplowanalytics.iglu.client.validator.ValidatorReport
 
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.{ClientEnrichments, MiscEnrichments}
 import com.snowplowanalytics.snowplow.enrich.common.utils.MapTransformer._
@@ -52,7 +52,7 @@ final class TargetBean {
 
 class MapTransformerSpec extends Specification with ValidatedMatchers {
 
-  val identity: (String, String) => Either[FailureDetails.EnrichmentFailure, String] =
+  val identity: (String, String) => Either[ValidatorReport, String] =
     (_, value) => value.asRight
 
   val sourceMap = Map(

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/utils/conversionUtilsSpecs.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/utils/conversionUtilsSpecs.scala
@@ -26,6 +26,8 @@ import org.specs2.matcher.DataTables
 
 import com.snowplowanalytics.snowplow.badrows._
 
+import com.snowplowanalytics.iglu.client.validator.ValidatorReport
+
 import com.snowplowanalytics.snowplow.enrich.common.outputs.EnrichedEvent
 
 class StringToUriSpec extends MSpecification with DataTables {
@@ -210,7 +212,7 @@ class DecodeBase64UrlSpec extends Specification with DataTables with ScalaCheck 
   """
 
   // Only way of getting a failure currently
-  def e1 = ConversionUtils.decodeBase64Url(null) must beLeft("could not base64 decode: null")
+  def e1 = ConversionUtils.decodeBase64Url(null) must beLeft("Could not base64 decode: null")
 
   // No string creates a failure
   def e2 =
@@ -263,14 +265,7 @@ class ValidateUuidSpec extends Specification with DataTables with ScalaCheck {
   def e2 =
     prop { (str: String) =>
       ConversionUtils.validateUuid(FieldName, str) must beLeft(
-        FailureDetails.EnrichmentFailure(
-          None,
-          FailureDetails.EnrichmentFailureMessage.InputData(
-            FieldName,
-            Option(str),
-            "not a valid UUID"
-          )
-        )
+        ValidatorReport("Not a valid UUID", Some(FieldName), Nil, Option(str))
       )
     }
 }
@@ -288,14 +283,7 @@ class ValidateIntegerSpec extends Specification {
   def e2 = {
     val str = "abc"
     ConversionUtils.validateInteger(FieldName, str) must beLeft(
-      FailureDetails.EnrichmentFailure(
-        None,
-        FailureDetails.EnrichmentFailureMessage.InputData(
-          FieldName,
-          Some(str),
-          "not a valid integer"
-        )
-      )
+      ValidatorReport("Not a valid integer", Some(FieldName), Nil, Some(str))
     )
   }
 }
@@ -326,16 +314,8 @@ class StringToDoubleLikeSpec extends Specification with DataTables {
   """
 
   val FieldName = "val"
-  def err: String => FailureDetails.EnrichmentFailure =
-    input =>
-      FailureDetails.EnrichmentFailure(
-        None,
-        FailureDetails.EnrichmentFailureMessage.InputData(
-          FieldName,
-          Option(input),
-          "cannot be converted to Double-like"
-        )
-      )
+  def err: String => ValidatorReport =
+    input => ValidatorReport("Cannot be converted to Double-like", Some(FieldName), Nil, Option(input))
 
   def e1 =
     "SPEC NAME" || "INPUT STR" | "EXPECTED" |
@@ -379,7 +359,7 @@ class StringToJIntegerSpec extends Specification with DataTables {
   stringToJInteger should convert valid Strings to Java Integers                     $e2
   """
 
-  val err: String = "cannot be converted to java.lang.Integer"
+  val err: String = "Cannot be converted to java.lang.Integer"
 
   def e1 =
     "SPEC NAME" || "INPUT STR" | "EXPECTED" |
@@ -410,16 +390,8 @@ class StringToBooleanLikeJByteSpec extends Specification with DataTables {
   """
 
   val FieldName = "val"
-  def err: String => FailureDetails.EnrichmentFailure =
-    input =>
-      FailureDetails.EnrichmentFailure(
-        None,
-        FailureDetails.EnrichmentFailureMessage.InputData(
-          FieldName,
-          Option(input),
-          "cannot be converted to Boolean-like java.lang.Byte"
-        )
-      )
+  def err: String => ValidatorReport =
+    input => ValidatorReport("Cannot be converted to Boolean-like java.lang.Byte", Some(FieldName), Nil, Option(input))
 
   def e1 =
     "SPEC NAME" || "INPUT STR" | "EXPECTED" |


### PR DESCRIPTION
There are 3 places that currently produce an `EnrichmentFailures` bad row whereas the more appropriate type is `SchemaViolations`:

1. When the input fields of the HTTP requests are mapped to the atomic event.
2. When the enrichments contexts get validated.
3. When the atomic fields lengths get validated.

For 1 and 3, the error should be mapped into an Iglu `ValidationError` with the atomic schema referenced.

Before this change, if there was any error in the mapping of the atomic fields, a bad row would get emitted right away and we would not try to validate the entities and unstruct event. Now all these errors are wrapped inside a same `SchemaViolations` bad row.

Likewise, before this change when an enrichment context was invalid, we were emitting a bad row right away and not checking the lengths of the atomic fields. Now all these errors are wrapped inside a same `SchemaViolations` bad row.