### PR TITLE
Add failure entity for incomplete events

### DIFF
--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/AtomicFieldsLengthValidator.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/AtomicFieldsLengthValidator.scala
@@ -19,8 +19,6 @@ import cats.implicits._
 
 import com.snowplowanalytics.iglu.client.validator.ValidatorReport
 
-import com.snowplowanalytics.snowplow.badrows.FailureDetails
-
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.AtomicFields.LimitedAtomicField
 import com.snowplowanalytics.snowplow.enrich.common.outputs.EnrichedEvent
 
@@ -37,7 +35,7 @@ object AtomicFieldsLengthValidator {
     acceptInvalid: Boolean,
     invalidCount: F[Unit],
     atomicFields: AtomicFields
-  ): IorT[F, FailureDetails.SchemaViolation, Unit] =
+  ): IorT[F, Failure.SchemaViolation, Unit] =
     IorT {
       atomicFields.value
         .map(validateField(event, _).toValidatedNel)

--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/Failure.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/Failure.scala
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2024-present Snowplow Analytics Ltd.
+ * All rights reserved.
+ *
+ * This software is made available by Snowplow Analytics, Ltd.,
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
+ * located at https://docs.snowplow.io/limited-use-license-1.0
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
+ * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
+ */
+package com.snowplowanalytics.snowplow.enrich.common.enrichments
+
+import java.time.Instant
+
+import cats.syntax.option._
+
+import io.circe.{Encoder, Json}
+import io.circe.generic.semiauto._
+import io.circe.syntax._
+
+import com.snowplowanalytics.snowplow.badrows._
+
+import com.snowplowanalytics.iglu.client.ClientError
+import com.snowplowanalytics.iglu.client.validator.{ValidatorError, ValidatorReport}
+
+import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer, SelfDescribingData}
+import com.snowplowanalytics.iglu.core.circe.implicits.schemaKeyCirceJsonEncoder
+
+/**
+ * Represents a failure encountered during enrichment of the event.
+ * Failure entities will be attached to incomplete events as derived contexts.
+ */
+sealed trait Failure {
+  def toSDJ(timestamp: Instant, processor: Processor): SelfDescribingData[Json]
+}
+
+object Failure {
+
+  val failureSchemaKey = SchemaKey("com.snowplowanalytics.snowplow", "failure", "jsonschema", SchemaVer.Full(1, 0, 0))
+
+  case class SchemaViolation(
+    schemaViolation: FailureDetails.SchemaViolation,
+    source: String,
+    data: Json
+  ) extends Failure {
+    def toSDJ(timestamp: Instant, processor: Processor): SelfDescribingData[Json] = {
+      val feJson = fromSchemaViolation(this, timestamp, processor)
+      SelfDescribingData(failureSchemaKey, feJson.asJson)
+    }
+
+  }
+
+  case class EnrichmentFailure(
+    enrichmentFailure: FailureDetails.EnrichmentFailure
+  ) extends Failure {
+    def toSDJ(timestamp: Instant, processor: Processor): SelfDescribingData[Json] = {
+      val feJson = fromEnrichmentFailure(this, timestamp, processor)
+      SelfDescribingData(failureSchemaKey, feJson.asJson)
+    }
+  }
+
+  case class FailureContext(
+    failureType: String,
+    errors: List[Json],
+    schema: Option[SchemaKey],
+    data: Option[Json],
+    timestamp: Instant,
+    componentName: String,
+    componentVersion: String
+  )
+
+  object FailureContext {
+    implicit val failureContextEncoder: Encoder[FailureContext] = deriveEncoder[FailureContext]
+  }
+
+  def fromEnrichmentFailure(
+    ef: EnrichmentFailure,
+    timestamp: Instant,
+    processor: Processor
+  ): FailureContext = {
+    val failureType = s"EnrichmentError: ${ef.enrichmentFailure.enrichment.map(_.identifier).getOrElse("")}"
+    val schemaKey = ef.enrichmentFailure.enrichment.map(_.schemaKey)
+    val (errors, data) = ef.enrichmentFailure.message match {
+      case FailureDetails.EnrichmentFailureMessage.InputData(field, value, expectation) =>
+        (
+          List(
+            Json.obj(
+              "message" := s"$field - $expectation",
+              "source" := field
+            )
+          ),
+          Json.obj(field := value).some
+        )
+      case FailureDetails.EnrichmentFailureMessage.Simple(error) =>
+        (
+          List(
+            Json.obj(
+              "message" := error
+            )
+          ),
+          None
+        )
+      case FailureDetails.EnrichmentFailureMessage.IgluError(_, error) =>
+        // EnrichmentFailureMessage.IgluError isn't used anywhere in the project.
+        // We are return this value for completeness.
+        (
+          List(
+            Json.obj(
+              "message" := error
+            )
+          ),
+          None
+        )
+    }
+    FailureContext(
+      failureType = failureType,
+      errors = errors,
+      schema = schemaKey,
+      data = data,
+      timestamp = timestamp,
+      componentName = processor.artifact,
+      componentVersion = processor.version
+    )
+  }
+
+  def fromSchemaViolation(
+    v: SchemaViolation,
+    timestamp: Instant,
+    processor: Processor
+  ): FailureContext = {
+    val (failureType, errors, schema, data) = v.schemaViolation match {
+      case FailureDetails.SchemaViolation.NotJson(_, _, err) =>
+        val error = Json.obj("message" := err, "source" := v.source)
+        ("NotJSON", List(error), None, Json.obj(v.source := v.data).some)
+      case FailureDetails.SchemaViolation.NotIglu(_, err) =>
+        val message = err.message("").split(":").headOption
+        val error = Json.obj("message" := message, "source" := v.source)
+        ("NotIglu", List(error), None, v.data.some)
+      case FailureDetails.SchemaViolation.CriterionMismatch(schemaKey, schemaCriterion) =>
+        val message = s"Unexpected schema: ${schemaKey.toSchemaUri} does not match the criterion"
+        val error = Json.obj(
+          "message" := message,
+          "source" := v.source,
+          "criterion" := schemaCriterion.asString
+        )
+        ("CriterionMismatch", List(error), schemaKey.some, v.data.some)
+      case FailureDetails.SchemaViolation.IgluError(schemaKey, ClientError.ResolutionError(lh)) =>
+        val message = s"Resolution error: schema ${schemaKey.toSchemaUri} not found"
+        val lookupHistory = lh.toList
+          .map {
+            case (repo, lookups) =>
+              lookups.asJson.deepMerge(Json.obj("repository" := repo.asJson))
+          }
+        val error = Json.obj(
+          "message" := message,
+          "source" := v.source,
+          "lookupHistory" := lookupHistory
+        )
+        ("ResolutionError", List(error), schemaKey.some, v.data.some)
+      case FailureDetails.SchemaViolation.IgluError(schemaKey, ClientError.ValidationError(ValidatorError.InvalidData(e), _)) =>
+        val isAtomicField = schemaKey == AtomicFields.atomicSchema
+        // If error is for atomic field, we want to set the source to atomic field name. Since ValidatorReport.path
+        // is set to atomic field name, we are using path as source.
+        def source(r: ValidatorReport) = if (isAtomicField) r.path.getOrElse(v.source) else v.source
+        val errors = e.toList.map { r =>
+          Json.obj(
+            "message" := r.message,
+            "source" := source(r),
+            "path" := r.path,
+            "keyword" := r.keyword,
+            "targets" := r.targets
+          )
+        }
+        ("ValidationError", errors, schemaKey.some, v.data.some)
+      case FailureDetails.SchemaViolation.IgluError(schemaKey, ClientError.ValidationError(ValidatorError.InvalidSchema(e), _)) =>
+        val errors = e.toList.map { r =>
+          Json.obj(
+            "message" := s"Invalid schema: ${schemaKey.toSchemaUri} - ${r.message}",
+            "source" := v.source,
+            "path" := r.path
+          )
+        }
+        ("ValidationError", errors, schemaKey.some, v.data.some)
+    }
+    FailureContext(
+      failureType = failureType,
+      errors = errors,
+      schema = schema,
+      data = data,
+      timestamp = timestamp,
+      componentName = processor.artifact,
+      componentVersion = processor.version
+    )
+  }
+}

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/SpecHelpers.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/SpecHelpers.scala
@@ -66,6 +66,16 @@ object SpecHelpers extends CatsEffect {
           }
         },
         {
+          "name": "Temp Iglu Central",
+          "priority": 0,
+          "vendorPrefixes": [],
+          "connection": {
+            "http": {
+              "uri": "https://raw.githubusercontent.com/snowplow/iglu-central/incomplete-events-schema/"
+            }
+          }
+        },
+        {
           "name": "Embedded src/test/resources",
           "priority": 100,
           "vendorPrefixes": [ "com.snowplowanalytics" ],

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/SpecHelpers.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/SpecHelpers.scala
@@ -139,14 +139,16 @@ object SpecHelpers extends CatsEffect {
       .flatMap(SelfDescribingData.parse[Json])
       .leftMap(err => s"Can't parse Json [$rawJson] as as SelfDescribingData, error: [$err]")
 
-  def listContextsSchemas(rawContexts: String): List[SchemaKey] =
+  def listContexts(rawContexts: String): List[SelfDescribingData[Json]] =
     jsonStringToSDJ(rawContexts)
       .map(_.data.asArray.get.toList)
-      .flatMap(contexts => contexts.traverse(c => SelfDescribingData.parse[Json](c).map(_.schema))) match {
+      .flatMap(contexts => contexts.traverse(c => SelfDescribingData.parse[Json](c))) match {
       case Left(err) =>
         throw new IllegalArgumentException(s"Couldn't list contexts schemas. Error: [$err]")
-      case Right(schemas) => schemas
+      case Right(sdjs) => sdjs
     }
+
+  def listContextsSchemas(rawContexts: String): List[SchemaKey] = listContexts(rawContexts).map(_.schema)
 
   def getUnstructSchema(rawUnstruct: String): SchemaKey =
     jsonStringToSDJ(rawUnstruct)

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/AtomicFieldsSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/AtomicFieldsSpec.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2022-present Snowplow Analytics Ltd.
+ * All rights reserved.
+ *
+ * This software is made available by Snowplow Analytics, Ltd.,
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
+ * located at https://docs.snowplow.io/limited-use-license-1.0
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
+ * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
+ */
+package com.snowplowanalytics.snowplow.enrich.common.enrichments
+
+import cats.data.NonEmptyList
+import cats.syntax.option._
+
+import io.circe.Json
+import io.circe.syntax._
+
+import com.snowplowanalytics.iglu.client.ClientError.ValidationError
+import com.snowplowanalytics.iglu.client.validator.{ValidatorError, ValidatorReport}
+import com.snowplowanalytics.snowplow.badrows.FailureDetails
+
+import org.specs2.mutable.Specification
+
+class AtomicFieldsSpec extends Specification {
+
+  "errorsToSchemaViolation" should {
+    "convert ValidatorReports to SchemaViolation correctly" >> {
+      val vrList = NonEmptyList(
+        ValidatorReport(message = "testMessage", path = "testPath1".some, targets = List("t1, t2"), keyword = "testKeyword1".some),
+        List(
+          ValidatorReport(message = "testMessage", path = None, targets = List.empty, keyword = "testKeyword2".some),
+          ValidatorReport(message = "testMessage", path = "testPath3".some, targets = List("t1", "t2"), keyword = None),
+          ValidatorReport(message = "testMessage", path = "testPath4".some, targets = List.empty, keyword = "testKeyword4".some)
+        )
+      )
+      val expected = Failure.SchemaViolation(
+        schemaViolation = FailureDetails.SchemaViolation.IgluError(
+          schemaKey = AtomicFields.atomicSchema,
+          error = ValidationError(ValidatorError.InvalidData(vrList), None)
+        ),
+        source = "atomic_field",
+        data = Json.obj(
+          "testPath1" := "testKeyword1",
+          "testPath3" := Json.Null,
+          "testPath4" := "testKeyword4"
+        )
+      )
+      val result = AtomicFields.errorsToSchemaViolation(vrList)
+      result must beEqualTo(expected)
+    }
+  }
+}

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/FailureSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/FailureSpec.scala
@@ -1,0 +1,392 @@
+/*
+ * Copyright (c) 2014-present Snowplow Analytics Ltd.
+ * All rights reserved.
+ *
+ * This software is made available by Snowplow Analytics, Ltd.,
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
+ * located at https://docs.snowplow.io/limited-use-license-1.0
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
+ * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
+ */
+package com.snowplowanalytics.snowplow.enrich.common.enrichments
+
+import java.time.Instant
+
+import scala.collection.immutable.SortedMap
+
+import cats.effect.testing.specs2.CatsEffect
+import cats.effect.unsafe.implicits.global
+import cats.effect.IO
+
+import cats.data.NonEmptyList
+import cats.syntax.option._
+
+import io.circe.syntax._
+import io.circe.Json
+
+import org.specs2.mutable.Specification
+import org.specs2.matcher.ValidatedMatchers
+import org.specs2.ScalaCheck
+
+import org.scalacheck.{Gen, Prop}
+
+import com.snowplowanalytics.snowplow.enrich.common.SpecHelpers
+import com.snowplowanalytics.snowplow.badrows.{FailureDetails, Processor}
+import com.snowplowanalytics.iglu.core.{ParseError, SchemaCriterion, SchemaKey, SchemaVer, SelfDescribingData}
+import com.snowplowanalytics.iglu.client.ClientError
+import com.snowplowanalytics.iglu.client.validator.{ValidatorError, ValidatorReport}
+import com.snowplowanalytics.iglu.client.resolver.LookupHistory
+import com.snowplowanalytics.iglu.client.resolver.registries.RegistryLookup
+
+class FailureSpec extends Specification with ValidatedMatchers with CatsEffect with ScalaCheck {
+
+  val timestamp = Instant.now()
+  val processor = Processor("unit tests SCE", "v42")
+  val schemaKey = SchemaKey("com.snowplowanalytics", "test", "jsonschema", SchemaVer.Full(1, 0, 0))
+  val schemaCriterion = SchemaCriterion.apply("com.snowplowanalytics", "test", "jsonschema", 1)
+
+  "FailureEntityContext should be valid against its schema" >> {
+    implicit val registryLookup: RegistryLookup[IO] = SpecHelpers.registryLookup
+
+    val genFeContext = for {
+      failureType <- Gen.alphaNumStr
+      jsonGen = Gen.oneOf(
+                  Json.obj(),
+                  Json.obj("test1" := "value1"),
+                  Json.obj("test1" := "value1", "test2" := "value2"),
+                  Json.obj("test1" := "value1", "test2" := "value2", "test3" := "value3")
+                )
+      errors <- Gen.listOf(jsonGen)
+      data <- Gen.option(jsonGen)
+      schema <- Gen.option(Gen.const(schemaKey))
+    } yield Failure.FailureContext(
+      failureType = failureType,
+      errors = errors,
+      schema = schema,
+      data = data,
+      timestamp = timestamp,
+      componentName = processor.artifact,
+      componentVersion = processor.version
+    )
+
+    Prop.forAll(genFeContext) { feContext: Failure.FailureContext =>
+      val sdj = SelfDescribingData(schema = Failure.failureSchemaKey, data = feContext.asJson)
+      SpecHelpers.client
+        .check(sdj)
+        .value
+        .map(_ must beRight)
+        .unsafeRunSync()
+    }
+  }
+
+  "fromEnrichmentFailure" should {
+    "convert InputData correctly" >> {
+      val ef = Failure.EnrichmentFailure(
+        enrichmentFailure = FailureDetails.EnrichmentFailure(
+          enrichment = FailureDetails
+            .EnrichmentInformation(
+              schemaKey = schemaKey,
+              identifier = "enrichmentId"
+            )
+            .some,
+          message = FailureDetails.EnrichmentFailureMessage.InputData(
+            field = "testField",
+            value = "testValue".some,
+            expectation = "testExpectation"
+          )
+        )
+      )
+      val result = Failure.fromEnrichmentFailure(ef, timestamp, processor)
+      val expected = Failure.FailureContext(
+        failureType = "EnrichmentError: enrichmentId",
+        errors = List(
+          Json.obj(
+            "message" := "testField - testExpectation",
+            "source" := "testField"
+          )
+        ),
+        schema = schemaKey.some,
+        data = Json.obj("testField" := "testValue").some,
+        timestamp = timestamp,
+        componentName = processor.artifact,
+        componentVersion = processor.version
+      )
+      result must beEqualTo(expected)
+    }
+
+    "convert Simple correctly" >> {
+      val ef = Failure.EnrichmentFailure(
+        enrichmentFailure = FailureDetails.EnrichmentFailure(
+          enrichment = FailureDetails
+            .EnrichmentInformation(
+              schemaKey = schemaKey,
+              identifier = "enrichmentId"
+            )
+            .some,
+          message = FailureDetails.EnrichmentFailureMessage.Simple(error = "testError")
+        )
+      )
+      val result = Failure.fromEnrichmentFailure(ef, timestamp, processor)
+      val expected = Failure.FailureContext(
+        failureType = "EnrichmentError: enrichmentId",
+        errors = List(Json.obj("message" := "testError")),
+        schema = schemaKey.some,
+        data = None,
+        timestamp = timestamp,
+        componentName = processor.artifact,
+        componentVersion = processor.version
+      )
+      result must beEqualTo(expected)
+    }
+  }
+
+  "fromSchemaViolation" should {
+    "convert NotJson correctly" >> {
+      val sv = Failure.SchemaViolation(
+        schemaViolation = FailureDetails.SchemaViolation.NotJson(
+          field = "testField",
+          value = "testValue".some,
+          error = "testError"
+        ),
+        source = "testSource",
+        data = "testData".asJson
+      )
+      val fe = Failure.fromSchemaViolation(sv, timestamp, processor)
+      val expected = Failure.FailureContext(
+        failureType = "NotJSON",
+        errors = List(
+          Json.obj(
+            "message" := "testError",
+            "source" := "testSource"
+          )
+        ),
+        schema = None,
+        data = Json.obj("testSource" := "testData").some,
+        timestamp = timestamp,
+        componentName = processor.artifact,
+        componentVersion = processor.version
+      )
+      fe must beEqualTo(expected)
+    }
+
+    "convert NotIglu correctly" >> {
+      val sv = Failure.SchemaViolation(
+        schemaViolation = FailureDetails.SchemaViolation.NotIglu(
+          json = Json.Null,
+          error = ParseError.InvalidSchema
+        ),
+        source = "testSource",
+        data = "testData".asJson
+      )
+      val fe = Failure.fromSchemaViolation(sv, timestamp, processor)
+      val expected = Failure.FailureContext(
+        failureType = "NotIglu",
+        errors = List(
+          Json.obj(
+            "message" := "Invalid schema",
+            "source" := "testSource"
+          )
+        ),
+        schema = None,
+        data = "testData".asJson.some,
+        timestamp = timestamp,
+        componentName = processor.artifact,
+        componentVersion = processor.version
+      )
+      fe must beEqualTo(expected)
+    }
+
+    "convert CriterionMismatch correctly" >> {
+      val sv = Failure.SchemaViolation(
+        schemaViolation = FailureDetails.SchemaViolation.CriterionMismatch(
+          schemaKey = schemaKey,
+          schemaCriterion = schemaCriterion
+        ),
+        source = "testSource",
+        data = "testData".asJson
+      )
+      val fe = Failure.fromSchemaViolation(sv, timestamp, processor)
+      val expected = Failure.FailureContext(
+        failureType = "CriterionMismatch",
+        errors = List(
+          Json.obj(
+            "message" := "Unexpected schema: iglu:com.snowplowanalytics/test/jsonschema/1-0-0 does not match the criterion",
+            "source" := "testSource",
+            "criterion" := "iglu:com.snowplowanalytics/test/jsonschema/1-*-*"
+          )
+        ),
+        schema = schemaKey.some,
+        data = "testData".asJson.some,
+        timestamp = timestamp,
+        componentName = processor.artifact,
+        componentVersion = processor.version
+      )
+      fe must beEqualTo(expected)
+    }
+
+    "convert ResolutionError correctly" >> {
+      val sv = Failure.SchemaViolation(
+        schemaViolation = FailureDetails.SchemaViolation.IgluError(
+          schemaKey = schemaKey,
+          error = ClientError.ResolutionError(
+            value = SortedMap(
+              "repo1" -> LookupHistory(
+                errors = Set.empty,
+                attempts = 1,
+                lastAttempt = timestamp
+              ),
+              "repo2" -> LookupHistory(
+                errors = Set.empty,
+                attempts = 2,
+                lastAttempt = timestamp
+              )
+            )
+          )
+        ),
+        source = "testSource",
+        data = "testData".asJson
+      )
+      val fe = Failure.fromSchemaViolation(sv, timestamp, processor)
+      val expected = Failure.FailureContext(
+        failureType = "ResolutionError",
+        errors = List(
+          Json.obj(
+            "message" := "Resolution error: schema iglu:com.snowplowanalytics/test/jsonschema/1-0-0 not found",
+            "source" := "testSource",
+            "lookupHistory" := Json.arr(
+              Json.obj("repository" := "repo1", "errors" := List.empty[String], "attempts" := 1, "lastAttempt" := timestamp),
+              Json.obj("repository" := "repo2", "errors" := List.empty[String], "attempts" := 2, "lastAttempt" := timestamp)
+            )
+          )
+        ),
+        schema = schemaKey.some,
+        data = "testData".asJson.some,
+        timestamp = timestamp,
+        componentName = processor.artifact,
+        componentVersion = processor.version
+      )
+      fe must beEqualTo(expected)
+    }
+
+    "convert InvalidData correctly" >> {
+      def createSv(schemaKey: SchemaKey) =
+        Failure.SchemaViolation(
+          schemaViolation = FailureDetails.SchemaViolation.IgluError(
+            schemaKey = schemaKey,
+            error = ClientError.ValidationError(
+              error = ValidatorError.InvalidData(
+                messages = NonEmptyList.of(
+                  ValidatorReport(message = "testMessage1",
+                                  path = "testPath1".some,
+                                  targets = List("testTarget1"),
+                                  keyword = "testKeyword1".some
+                  ),
+                  ValidatorReport(message = "testMessage2",
+                                  path = "testPath2".some,
+                                  targets = List("testTarget2"),
+                                  keyword = "testKeyword2".some
+                  )
+                )
+              ),
+              supersededBy = None
+            )
+          ),
+          source = "testSource",
+          data = "testData".asJson
+        )
+
+      val svWithAtomicSchema = createSv(AtomicFields.atomicSchema)
+      val svWithOrdinarySchema = createSv(schemaKey)
+      val feWithAtomicSchema = Failure.fromSchemaViolation(svWithAtomicSchema, timestamp, processor)
+      val feWithOrdinarySchema = Failure.fromSchemaViolation(svWithOrdinarySchema, timestamp, processor)
+      val expectedWithAtomicSchema = Failure.FailureContext(
+        failureType = "ValidationError",
+        errors = List(
+          Json.obj("message" := "testMessage1",
+                   "source" := "testPath1",
+                   "path" := "testPath1",
+                   "keyword" := "testKeyword1",
+                   "targets" := List("testTarget1")
+          ),
+          Json.obj("message" := "testMessage2",
+                   "source" := "testPath2",
+                   "path" := "testPath2",
+                   "keyword" := "testKeyword2",
+                   "targets" := List("testTarget2")
+          )
+        ),
+        schema = AtomicFields.atomicSchema.some,
+        data = "testData".asJson.some,
+        timestamp = timestamp,
+        componentName = processor.artifact,
+        componentVersion = processor.version
+      )
+      val expectedWithOrdinarySchema = Failure.FailureContext(
+        failureType = "ValidationError",
+        errors = List(
+          Json.obj("message" := "testMessage1",
+                   "source" := "testSource",
+                   "path" := "testPath1",
+                   "keyword" := "testKeyword1",
+                   "targets" := List("testTarget1")
+          ),
+          Json.obj("message" := "testMessage2",
+                   "source" := "testSource",
+                   "path" := "testPath2",
+                   "keyword" := "testKeyword2",
+                   "targets" := List("testTarget2")
+          )
+        ),
+        schema = schemaKey.some,
+        data = "testData".asJson.some,
+        timestamp = timestamp,
+        componentName = processor.artifact,
+        componentVersion = processor.version
+      )
+
+      feWithAtomicSchema must beEqualTo(expectedWithAtomicSchema)
+      feWithOrdinarySchema must beEqualTo(expectedWithOrdinarySchema)
+    }
+
+    "convert InvalidSchema correctly" >> {
+      val sv = Failure.SchemaViolation(
+        schemaViolation = FailureDetails.SchemaViolation.IgluError(
+          schemaKey = schemaKey,
+          error = ClientError.ValidationError(
+            error = ValidatorError.InvalidSchema(
+              issues = NonEmptyList.of(
+                ValidatorError.SchemaIssue(path = "testPath1", message = "testMessage1"),
+                ValidatorError.SchemaIssue(path = "testPath2", message = "testMessage2")
+              )
+            ),
+            supersededBy = None
+          )
+        ),
+        source = "testSource",
+        data = "testData".asJson
+      )
+      val fe = Failure.fromSchemaViolation(sv, timestamp, processor)
+      val expected = Failure.FailureContext(
+        failureType = "ValidationError",
+        errors = List(
+          Json.obj(
+            "message" := "Invalid schema: iglu:com.snowplowanalytics/test/jsonschema/1-0-0 - testMessage1",
+            "source" := "testSource",
+            "path" := "testPath1"
+          ),
+          Json.obj(
+            "message" := "Invalid schema: iglu:com.snowplowanalytics/test/jsonschema/1-0-0 - testMessage2",
+            "source" := "testSource",
+            "path" := "testPath2"
+          )
+        ),
+        schema = schemaKey.some,
+        data = "testData".asJson.some,
+        timestamp = timestamp,
+        componentName = processor.artifact,
+        componentVersion = processor.version
+      )
+      fe must beEqualTo(expected)
+    }
+  }
+}


### PR DESCRIPTION
Failure entities are started to be attached to incomplete events as derived contexts.

There are some cases that we need more information than in the bad rows to create failure entities therefore it isn't possible to create failure entities from bad rows directly. For this purpose, we created wrapper classes to attach extra information about failure entities.

