### PR TITLE
Set data field of incomplete event failure entity to SDJ's data field only

### DIFF
--- a/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/utils/IgluUtils.scala
+++ b/modules/common/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/utils/IgluUtils.scala
@@ -156,7 +156,7 @@ object IgluUtils {
             Failure.SchemaViolation(
               schemaViolation = FailureDetails.SchemaViolation.IgluError(sdj.schema, clientError),
               source = "derived_contexts",
-              data = sdj.asJson
+              data = sdj.data
             )
         }
       )
@@ -201,7 +201,7 @@ object IgluUtils {
                  Failure.SchemaViolation(
                    schemaViolation = FailureDetails.SchemaViolation.CriterionMismatch(sdj.schema, expectedCriterion),
                    source = field,
-                   data = sdj.asJson
+                   data = sdj.data
                  )
                )
       // Check that the SDJ holding the .data is valid
@@ -211,7 +211,7 @@ object IgluUtils {
                  Failure.SchemaViolation(
                    schemaViolation = FailureDetails.SchemaViolation.IgluError(schemaKey, clientError),
                    source = field,
-                   data = sdj.asJson
+                   data = sdj.data
                  )
              }
       // Extract .data of SelfDescribingData[Json]
@@ -276,7 +276,7 @@ object IgluUtils {
                                    schemaViolation = FailureDetails.SchemaViolation
                                      .IgluError(schemaKey, clientError): FailureDetails.SchemaViolation,
                                    source = field,
-                                   data = json.asJson
+                                   data = sdj.data
                                  )
                              }
                              .leftMap(NonEmptyList.one)

--- a/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/EnrichmentManagerSpec.scala
+++ b/modules/common/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/EnrichmentManagerSpec.scala
@@ -1241,14 +1241,16 @@ class EnrichmentManagerSpec extends Specification with EitherMatchers with CatsE
           JavascriptScriptEnrichment(schemaKey, script)
         )
       )
-      val invalidUe =
+      val invalidUeData =
         """{
+             "emailAddress": "hello@world.com",
+             "emailAddress2": "foo@bar.org",
+             "unallowedAdditionalField": "foo@bar.org"
+           }"""
+      val invalidUe =
+        s"""{
              "schema":"iglu:com.acme/email_sent/jsonschema/1-0-0",
-             "data": {
-               "emailAddress": "hello@world.com",
-               "emailAddress2": "foo@bar.org",
-               "unallowedAdditionalField": "foo@bar.org"
-             }
+             "data": $invalidUeData
            }"""
 
       val parameters = Map(
@@ -1287,7 +1289,7 @@ class EnrichmentManagerSpec extends Specification with EitherMatchers with CatsE
                   )
                 ) &&
                 feJson.field("schema") == emailSentSchema.asJson &&
-                feJson.field("data") == jparse(invalidUe).toOption.get =>
+                feJson.field("data") == jparse(invalidUeData).toOption.get =>
             true
           case _ => false
         }
@@ -1333,13 +1335,15 @@ class EnrichmentManagerSpec extends Specification with EitherMatchers with CatsE
           JavascriptScriptEnrichment(schemaKey, script)
         )
       )
-      val invalidContext =
+      val invalidContextData =
         """{
+            "foo": "hello@world.com",
+            "emailAddress2": "foo@bar.org"
+          }"""
+      val invalidContext =
+        s"""{
             "schema":"iglu:com.acme/email_sent/jsonschema/1-0-0",
-            "data": {
-              "foo": "hello@world.com",
-              "emailAddress2": "foo@bar.org"
-            }
+            "data": $invalidContextData
           }"""
 
       val parameters = Map(
@@ -1383,7 +1387,7 @@ class EnrichmentManagerSpec extends Specification with EitherMatchers with CatsE
                   )
                 ) &&
                 feJson.field("schema") == emailSentSchema.asJson &&
-                feJson.field("data") == jparse(invalidContext).toOption.get =>
+                feJson.field("data") == jparse(invalidContextData).toOption.get =>
             true
           case _ => false
         }
@@ -1428,14 +1432,17 @@ class EnrichmentManagerSpec extends Specification with EitherMatchers with CatsE
           JavascriptScriptEnrichment(schemaKey, script)
         )
       )
-      val invalidContext =
+      val invalidContextData =
         """
           {
+            "foo": "hello@world.com",
+            "emailAddress2": "foo@bar.org"
+          }"""
+      val invalidContext =
+        s"""
+          {
             "schema":"iglu:com.acme/email_sent/jsonschema/1-0-0",
-            "data": {
-              "foo": "hello@world.com",
-              "emailAddress2": "foo@bar.org"
-            }
+            "data": $invalidContextData
           }"""
 
       val parameters = Map(
@@ -1482,7 +1489,7 @@ class EnrichmentManagerSpec extends Specification with EitherMatchers with CatsE
                   )
                 ) &&
                 feJson.field("schema") == emailSentSchema.asJson &&
-                feJson.field("data") == jparse(invalidContext).toOption.get =>
+                feJson.field("data") == jparse(invalidContextData).toOption.get =>
             true
           case _ => false
         }
@@ -1662,14 +1669,17 @@ class EnrichmentManagerSpec extends Specification with EitherMatchers with CatsE
     }
 
     "remove an invalid enrichment context and return the enriched event if emitIncomplete is set to true" >> {
-      val invalidContext =
+      val invalidContextData =
         """
           {
+            "foo": "hello@world.com",
+            "emailAddress2": "foo@bar.org"
+          }"""
+      val invalidContext =
+        s"""
+          {
             "schema":"iglu:com.acme/email_sent/jsonschema/1-0-0",
-            "data": {
-              "foo": "hello@world.com",
-              "emailAddress2": "foo@bar.org"
-            }
+            "data": $invalidContextData
           }"""
       val script =
         s"""
@@ -1727,7 +1737,7 @@ class EnrichmentManagerSpec extends Specification with EitherMatchers with CatsE
                   )
                 ) &&
                 feJson.field("schema") == emailSentSchema.asJson &&
-                feJson.field("data") == jparse(invalidContext).toOption.get =>
+                feJson.field("data") == jparse(invalidContextData).toOption.get =>
             true
           case _ => false
         }


### PR DESCRIPTION
At the moment, we set all self describing json to data field of incomplete event failure entity. However, failure entity has separate schema field and therefore we don't need to set all SDJ to data field. It is enough to use only data field of SDJ.


