### PR TITLE
Upgrade amazon-kinesis-client to 2.6.1

### DIFF
--- a/modules/kinesis/src/main/scala/com/snowplowanalytics/snowplow/enrich/kinesis/Source.scala
+++ b/modules/kinesis/src/main/scala/com/snowplowanalytics/snowplow/enrich/kinesis/Source.scala
@@ -30,7 +30,7 @@ import software.amazon.awssdk.regions.Region
 import software.amazon.kinesis.common.{ConfigsBuilder, InitialPositionInStream, InitialPositionInStreamExtended}
 import software.amazon.kinesis.coordinator.Scheduler
 import software.amazon.kinesis.metrics.MetricsLevel
-import software.amazon.kinesis.processor.ShardRecordProcessorFactory
+import software.amazon.kinesis.processor.{ShardRecordProcessorFactory, SingleStreamTracker}
 import software.amazon.kinesis.retrieval.polling.PollingConfig
 import software.amazon.kinesis.retrieval.fanout.FanOutConfig
 import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient
@@ -125,9 +125,11 @@ object Source {
           InitialPositionInStreamExtended.newInitialPositionAtTimestamp(Date.from(timestamp))
       }
 
+      val stt: SingleStreamTracker = new SingleStreamTracker(kinesisConfig.streamName, initPositionExtended)
+
       val retrievalConfig =
         configsBuilder.retrievalConfig
-          .initialPositionInStreamExtended(initPositionExtended)
+          .streamTracker(stt)
           .retrievalSpecificConfig {
             kinesisConfig.retrievalMode match {
               case Input.Kinesis.Retrieval.FanOut =>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -70,7 +70,7 @@ object Dependencies {
     val awsSdk           = "1.12.694"
     val gcpSdk           = "2.36.1"
     val awsSdk2          = "2.25.24"
-    val kinesisClient2   = "2.4.3"
+    val kinesisClient2   = "2.6.1"
     val kafka            = "3.7.0"
     val mskAuth          = "2.0.3"
     val nsqClient        = "1.3.0"


### PR DESCRIPTION
This PR upgrades amazon-kinesis-client to 2.6.1 to avoid known bugs and issues as mentioned [here](https://docs.aws.amazon.com/streams/latest/dev/kcl.html)