### PR TITLE
Migrate docker-compose command to v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,9 +60,9 @@ jobs:
     - name: Run integration tests for enrich-kafka
       run: |
         sbt "project kafka" "docker:publishLocal"
-        docker-compose -f integration-tests/enrich-kafka/docker-compose.yml up -d
+        docker compose -f integration-tests/enrich-kafka/docker-compose.yml up -d
         sbt "project kafka" IntegrationTest/test
-        docker-compose -f integration-tests/enrich-kafka/docker-compose.yml down
+        docker compose -f integration-tests/enrich-kafka/docker-compose.yml down
     - name: Run integration tests for enrich-nsq
       run: sbt "project nsqDistroless" IntegrationTest/test
     - name: Generate coverage report


### PR DESCRIPTION
A recent build had the following [error](https://github.com/snowplow/enrich/actions/runs/13453980079/job/37593815375#step:15:130):

```
docker-compose: command not found
```

Migrating to v2 command should solve the problem.